### PR TITLE
reduce terraform dependencies and env vars

### DIFF
--- a/ci/jenkins/scripts/test-aks.sh
+++ b/ci/jenkins/scripts/test-aks.sh
@@ -101,12 +101,6 @@ echo "Installing Azure CLI"
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 az login --service-principal -u $TF_VAR_azure_client_id -p $TF_VAR_azure_client_secret --tenant $TF_VAR_azure_client_tenant_id
 
-# Set AKS exports too
-export TF_VAR_aks_client_subscription_id=${TF_VAR_azure_client_subscription_id}
-export TF_VAR_aks_client_id=${TF_VAR_azure_client_id}
-export TF_VAR_aks_client_tenant_id=${TF_VAR_azure_client_tenant_id}
-export TF_VAR_aks_client_secret=${TF_VAR_azure_client_secret}
-
 function cleanup() {
     echo "Destroying AKS Cluster"
     $HOME/terraform/aks destroy

--- a/ci/jenkins/scripts/test-aws.sh
+++ b/ci/jenkins/scripts/test-aws.sh
@@ -39,7 +39,7 @@ function print_help {
 
 # Defaults
 export TF_VAR_owner="ci"
-export TF_VAR_region="us-west-2"
+export AWS_DEFAULT_REGION="us-west-2"
 
 while [[ $# -gt 0 ]]
 do
@@ -55,7 +55,7 @@ case $key in
     shift 2
     ;;
     --aws-region)
-    export TF_VAR_region="$2"
+    export AWS_DEFAULT_REGION="$2"
     shift 2
     ;;
     --owner)
@@ -101,17 +101,15 @@ echo "Creating Kind cluster"
 hack/install-cloud-tools.sh
 ci/kind/kind-setup.sh create kind
 
-export AWS_DEFAULT_REGION=${TF_VAR_region}
-
 # Create a key pair
 KEY_PAIR="nephe-$$"
-aws ec2 import-key-pair --key-name ${KEY_PAIR} --public-key-material fileb://~/.ssh/id_rsa.pub --region ${TF_VAR_region}
+aws ec2 import-key-pair --key-name ${KEY_PAIR} --public-key-material fileb://~/.ssh/id_rsa.pub --region ${AWS_DEFAULT_REGION}
 
 export TF_VAR_aws_key_pair_name=${KEY_PAIR}
 
 function cleanup() {
     # Delete key pair
-    aws ec2 delete-key-pair  --key-name ${KEY_PAIR}  --region ${TF_VAR_region}
+    aws ec2 delete-key-pair  --key-name ${KEY_PAIR}  --region ${AWS_DEFAULT_REGION}
 }
 trap cleanup EXIT
 

--- a/ci/jenkins/scripts/test-aws.sh
+++ b/ci/jenkins/scripts/test-aws.sh
@@ -101,6 +101,8 @@ echo "Creating Kind cluster"
 hack/install-cloud-tools.sh
 ci/kind/kind-setup.sh create kind
 
+export AWS_DEFAULT_REGION=${TF_VAR_region}
+
 # Create a key pair
 KEY_PAIR="nephe-$$"
 aws ec2 import-key-pair --key-name ${KEY_PAIR} --public-key-material fileb://~/.ssh/id_rsa.pub --region ${TF_VAR_region}

--- a/ci/jenkins/scripts/test-aws.sh
+++ b/ci/jenkins/scripts/test-aws.sh
@@ -47,11 +47,11 @@ key="$1"
 
 case $key in
     --aws-access-key-id)
-    export TF_VAR_aws_access_key_id="$2"
+    export AWS_ACCESS_KEY_ID="$2"
     shift 2
     ;;
     --aws-secret-key)
-    export TF_VAR_aws_access_key_secret="$2"
+    export AWS_SECRET_ACCESS_KEY="$2"
     shift 2
     ;;
     --aws-region)
@@ -74,7 +74,7 @@ case $key in
 esac
 done
 
-if [ -z "$TF_VAR_aws_access_key_id" ] || [ -z "$TF_VAR_aws_access_key_id" ]; then
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     echoerr "AWS credentials must be set."
     print_usage
     exit 1
@@ -100,11 +100,6 @@ docker tag antrea/nephe:latest projects.registry.vmware.com/antrea/nephe:latest
 echo "Creating Kind cluster"
 hack/install-cloud-tools.sh
 ci/kind/kind-setup.sh create kind
-
-# Export AWS Credentials for AWS CLI
-export AWS_ACCESS_KEY_ID=${TF_VAR_aws_access_key_id}
-export AWS_SECRET_ACCESS_KEY=${TF_VAR_aws_access_key_secret}
-export AWS_DEFAULT_REGION=${TF_VAR_region}
 
 # Create a key pair
 KEY_PAIR="nephe-$$"

--- a/ci/jenkins/scripts/test-eks.sh
+++ b/ci/jenkins/scripts/test-eks.sh
@@ -111,6 +111,8 @@ install_common_packages
 echo "Building Nephe Docker image"
 make build
 
+export AWS_DEFAULT_REGION=${TF_VAR_region}
+
 # Create SSH Key Pair
 KEY_PAIR="nephe-$$"
 aws ec2 import-key-pair --key-name ${KEY_PAIR} --public-key-material fileb://~/.ssh/id_rsa.pub --region ${TF_VAR_region}

--- a/ci/jenkins/scripts/test-eks.sh
+++ b/ci/jenkins/scripts/test-eks.sh
@@ -49,11 +49,11 @@ key="$1"
 
 case $key in
     --aws-access-key-id)
-    export TF_VAR_aws_access_key_id="$2"
+    export AWS_ACCESS_KEY_ID="$2"
     shift 2
     ;;
     --aws-secret-key)
-    export TF_VAR_aws_access_key_secret="$2"
+    export AWS_SECRET_ACCESS_KEY="$2"
     shift 2
     ;;
     --aws-region)
@@ -84,7 +84,7 @@ case $key in
 esac
 done
 
-if [ -z "$TF_VAR_aws_access_key_id" ] || [ -z "$TF_VAR_aws_access_key_id" ]; then
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     echoerr "AWS credentials must be set."
     print_usage
     exit 1
@@ -111,16 +111,10 @@ install_common_packages
 echo "Building Nephe Docker image"
 make build
 
-# Set Export for AWS CLI
-export AWS_ACCESS_KEY_ID=${TF_VAR_aws_access_key_id}
-export AWS_SECRET_ACCESS_KEY=${TF_VAR_aws_access_key_secret}
-export AWS_DEFAULT_REGION=${TF_VAR_region}
-
 # Create SSH Key Pair
 KEY_PAIR="nephe-$$"
 aws ec2 import-key-pair --key-name ${KEY_PAIR} --public-key-material fileb://~/.ssh/id_rsa.pub --region ${TF_VAR_region}
 export TF_VAR_aws_key_pair_name=${KEY_PAIR}
-export TF_VAR_eks_key_pair_name=${KEY_PAIR}
 
 function wait_for_cert_manager() {
     i=1

--- a/ci/jenkins/scripts/test-eks.sh
+++ b/ci/jenkins/scripts/test-eks.sh
@@ -41,7 +41,7 @@ function print_help {
 
 # Defaults
 export TF_VAR_owner="ci"
-export TF_VAR_region="us-west-2"
+export AWS_DEFAULT_REGION="us-west-2"
 
 while [[ $# -gt 0 ]]
 do
@@ -57,7 +57,7 @@ case $key in
     shift 2
     ;;
     --aws-region)
-    export TF_VAR_region="$2"
+    export AWS_DEFAULT_REGION="$2"
     shift 2
     ;;
     --eks-cluster-role)
@@ -111,11 +111,9 @@ install_common_packages
 echo "Building Nephe Docker image"
 make build
 
-export AWS_DEFAULT_REGION=${TF_VAR_region}
-
 # Create SSH Key Pair
 KEY_PAIR="nephe-$$"
-aws ec2 import-key-pair --key-name ${KEY_PAIR} --public-key-material fileb://~/.ssh/id_rsa.pub --region ${TF_VAR_region}
+aws ec2 import-key-pair --key-name ${KEY_PAIR} --public-key-material fileb://~/.ssh/id_rsa.pub --region ${AWS_DEFAULT_REGION}
 export TF_VAR_aws_key_pair_name=${KEY_PAIR}
 
 function wait_for_cert_manager() {
@@ -133,7 +131,7 @@ function wait_for_cert_manager() {
 
 function cleanup() {
     $HOME/terraform/eks destroy
-    aws ec2 delete-key-pair  --key-name ${KEY_PAIR}  --region ${TF_VAR_region}
+    aws ec2 delete-key-pair  --key-name ${KEY_PAIR}  --region ${AWS_DEFAULT_REGION}
 }
 trap cleanup EXIT
 

--- a/docs/aks-installation.md
+++ b/docs/aks-installation.md
@@ -20,7 +20,7 @@
 
 ## Prerequisites
 
-1. Install and configure [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest).
+1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.24+.
 2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html). Recommend v1.2.2.
 3. Install `jq`, `pv`, and `bzip2`.
 4. Create or obtain an azure service principal and set the below environment
@@ -28,10 +28,10 @@
    for more information.
 
    ```bash
-   export TF_VAR_aks_client_id=YOUR_SERVICE_PRINCIPAL_ID
-   export TF_VAR_aks_client_secret=YOUR_SERVICE_PRINCIPAL_SECRET
-   export TF_VAR_aks_client_subscription_id=YOUR_SUBCRIPTION_ID
-   export TF_VAR_aks_client_tenant_id=YOUR_TENANT_ID
+   export TF_VAR_azure_client_id=YOUR_SERVICE_PRINCIPAL_ID
+   export TF_VAR_azure_client_secret=YOUR_SERVICE_PRINCIPAL_SECRET
+   export TF_VAR_azure_client_subscription_id=YOUR_SUBCRIPTION_ID
+   export TF_VAR_azure_client_tenant_id=YOUR_TENANT_ID
    export TF_VAR_owner=YOUR_NAME
    ```
 
@@ -108,11 +108,12 @@ Additionally, you can also create compute VNET with 3 VMs using terraform
 scripts for testing purpose. Each VM will have a public IP and an Apache Tomcat
 server deployed on port 80. Use curl `<PUBLIC_IP>:80` to access a sample web
 page. Create or obtain Azure Service Principal credential and configure the
-below environment variables.
+below environment variables, see [Prerequisites](#Prerequisites) section for
+more details.
 
 ```bash
-export TF_VAR_azure_client_id=YOUR_CLIENT_ID
-export TF_VAR_azure_client_secret=YOUR_CLIENT_SECRET
+export TF_VAR_azure_client_id=YOUR_SERVICE_PRINCIPAL_ID
+export TF_VAR_azure_client_secret=YOUR_SERVICE_PRINCIPAL_SECRET
 export TF_VAR_azure_client_subscription_id=YOUR_SUBCRIPTION_ID
 export TF_VAR_azure_client_tenant_id=YOUR_TENANT_ID
 export TF_VAR_owner=YOUR_NAME
@@ -131,7 +132,7 @@ export TF_VAR_owner=YOUR_NAME
 ```
 
 Terraform state files and other runtime info will be stored under
-`~/tmp/terraform-azure/`
+`~/tmp/terraform-azure/`.
 
 ### Display VNET attributes
 

--- a/docs/aks-installation.md
+++ b/docs/aks-installation.md
@@ -20,9 +20,9 @@
 
 ## Prerequisites
 
-1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.24+.
+1. Install [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.24+.
 2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html). Recommend v1.2.2.
-3. Install `jq`, `pv`, and `bzip2`.
+3. Install `jq` and `pv`.
 4. Create or obtain an azure service principal and set the below environment
    variables. Please refer to [Azure documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#create-an-azure-active-directory-application)
    for more information.
@@ -35,8 +35,8 @@
    export TF_VAR_owner=YOUR_NAME
    ```
 
-   Note: `TF_VAR_owner` may be set so that you can identify your own cloud resources.
-   It should be one word, with no spaces and in lower case.
+   Note: `TF_VAR_owner` may be set so that you can identify your own cloud
+   resources. It should be one word, with no spaces and in lower case.
 
 ## Create an AKS cluster via terraform
 
@@ -67,8 +67,7 @@ This also deploys `cert-manager v1.8.2` and `antrea v1.8`.
 ### Deploy Nephe Controller
 
 To deploy the latest version of nephe (built from the main branch), use the
-checked-in [deployment yaml](../config/nephe.yml) after `cert-manager` Pods are
-running:
+checked-in [deployment yaml](../config/nephe.yml).
 
 ```bash
 ~/terraform/aks kubectl apply -f https://raw.githubusercontent.com/antrea-io/nephe/main/config/nephe.yml

--- a/docs/aks-installation.md
+++ b/docs/aks-installation.md
@@ -67,7 +67,8 @@ This also deploys `cert-manager v1.8.2` and `antrea v1.8`.
 ### Deploy Nephe Controller
 
 To deploy the latest version of nephe (built from the main branch), use the
-checked-in [deployment yaml](../config/nephe.yml):
+checked-in [deployment yaml](../config/nephe.yml) after `cert-manager` Pods are
+running:
 
 ```bash
 ~/terraform/aks kubectl apply -f https://raw.githubusercontent.com/antrea-io/nephe/main/config/nephe.yml

--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -21,7 +21,7 @@
 ## Prerequisites
 
 1. Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v2.3.6+.
-2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.24+.
+2. Install [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.24+.
 3. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html). Recommend v1.2.2.
 4. Install `jq`, `pv`, and `bzip2`.
 5. Set the below environment variables.
@@ -74,8 +74,7 @@ This also deploys `cert-manager v1.8.2` and `Antrea v1.8`.
 ### Deploy Nephe Controller
 
 To deploy the latest version of nephe (built from the main branch), use the
-checked-in [deployment yaml](../config/nephe.yml) after `cert-manager` Pods are
-running:
+checked-in [deployment yaml](../config/nephe.yml).
 
 ```bash
 ~/terraform/eks kubectl apply -f https://raw.githubusercontent.com/antrea-io/nephe/main/config/nephe.yml

--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -33,6 +33,7 @@
    export TF_VAR_aws_key_pair_name=YOUR_KEY_PAIR_TO_ACCESS_WORKER_NODE
    export AWS_ACCESS_KEY_ID=YOUR_AWS_KEY
    export AWS_SECRET_ACCESS_KEY=YOUR_AWS_KEY_SECRET
+   export AWS_DEFAULT_REGION=YOUR_REGION
    ```
 
    - `TF_VAR_owner` may be set so that you can identify your own cloud resources.
@@ -128,7 +129,7 @@ variables, see [Prerequisites](#Prerequisites) section for more details.
 ```bash
 export AWS_ACCESS_KEY_ID=YOUR_AWS_KEY
 export AWS_SECRET_ACCESS_KEY=YOUR_AWS_KEY_SECRET
-export TF_VAR_region=YOUR_REGION
+export AWS_DEFAULT_REGION=YOUR_REGION
 export TF_VAR_aws_key_pair_name=YOU_AWS_KEY_PAIR
 ```
 

--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -74,7 +74,8 @@ This also deploys `cert-manager v1.8.2` and `Antrea v1.8`.
 ### Deploy Nephe Controller
 
 To deploy the latest version of nephe (built from the main branch), use the
-checked-in [deployment yaml](../config/nephe.yml):
+checked-in [deployment yaml](../config/nephe.yml) after `cert-manager` Pods are
+running:
 
 ```bash
 ~/terraform/eks kubectl apply -f https://raw.githubusercontent.com/antrea-io/nephe/main/config/nephe.yml

--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -20,23 +20,26 @@
 
 ## Prerequisites
 
-1. Install and configure [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
-2. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html). Recommend v1.2.2.
-3. Install `jq`, `pv`, and `bzip2`.
-4. Set the below environment variables.
+1. Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v2.3.6+.
+2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.24+.
+3. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html). Recommend v1.2.2.
+4. Install `jq`, `pv`, and `bzip2`.
+5. Set the below environment variables.
 
    ```bash
    export TF_VAR_owner=YOUR_NAME
    export TF_VAR_eks_cluster_iam_role_name=YOUR_EKS_ROLE
    export TF_VAR_eks_iam_instance_profile_name=YOUR_EKS_WORKER_NODE_PROFILE
-   export TF_VAR_eks_key_pair_name=YOUR_KEY_PAIR_TO_ACCESS_WORKER_NODE
+   export TF_VAR_aws_key_pair_name=YOUR_KEY_PAIR_TO_ACCESS_WORKER_NODE
+   export AWS_ACCESS_KEY_ID=YOUR_AWS_KEY
+   export AWS_SECRET_ACCESS_KEY=YOUR_AWS_KEY_SECRET
    ```
 
    - `TF_VAR_owner` may be set so that you can identify your own cloud resources.
       It should be one word, with no spaces and in lower case.
    - `TF_VAR_eks_cluster_iam_role_name` may be created following this [AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html#create-service-role).
    - `TF_VAR_eks_iam_instance_profile_name` may be created following this [AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html).
-   - `TF_VAR_eks_key_pair_name` must be configured following this
+   - `TF_VAR_aws_key_pair_name` must be configured following this
       [AWS cli documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/import-key-pair.html).
       The public key imported to AWS should be `~/.ssh/id_rsa.pub`. Follow the
       documentation to create a new key then import if this key doesn't exist.
@@ -112,12 +115,12 @@ Additionally, you can also create compute VPC with 3 VMs using terraform
 scripts for testing purpose. Each VM will have a public IP and an Apache Tomcat
 server deployed on port 80. Use curl `<PUBLIC_IP>:80` to access a sample web
 page. Create or obtain AWS key and secret and configure the below environment
-variables.
+variables, see [Prerequisites](#Prerequisites) section for more details.
 
 ```bash
+export AWS_ACCESS_KEY_ID=YOUR_AWS_KEY
+export AWS_SECRET_ACCESS_KEY=YOUR_AWS_KEY_SECRET
 export TF_VAR_region=YOUR_REGION
-export TF_VAR_aws_access_key_id=YOUR_AWS_KEY
-export TF_VAR_aws_access_key_secret=YOUR_AWS_KEY_SECRET
 export TF_VAR_aws_key_pair_name=YOU_AWS_KEY_PAIR
 ```
 
@@ -134,7 +137,7 @@ export TF_VAR_aws_key_pair_name=YOU_AWS_KEY_PAIR
 ```
 
 Terraform state files and other runtime info will be stored under
-`~/tmp/terraform-aws/`
+`~/tmp/terraform-aws/`.
 
 ### Display VPC attributes
 

--- a/hack/aks
+++ b/hack/aks
@@ -18,7 +18,7 @@ TERRAFORM="terraform"
 KUBECTL="kubectl"
 RUN_PATH="$HOME/tmp/terraform-aks"
 CONFIG_PATH=$(dirname $(readlink -f "$0"))/terraform/aks
-CMD_ARRAY=($TERRAFORM $KUBECTL pv bzip2 jq)
+CMD_ARRAY=($TERRAFORM $KUBECTL pv jq)
 ENV_ARRAY=(TF_VAR_azure_client_id TF_VAR_azure_client_secret TF_VAR_azure_client_subscription_id TF_VAR_azure_client_tenant_id)
 CREATE_ONLY=
 

--- a/hack/aks
+++ b/hack/aks
@@ -14,13 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-AZURE_CLI="az"
 TERRAFORM="terraform"
 KUBECTL="kubectl"
 RUN_PATH="$HOME/tmp/terraform-aks"
 CONFIG_PATH=$(dirname $(readlink -f "$0"))/terraform/aks
-CMD_ARRAY=($AZURE_CLI $TERRAFORM $KUBECTL pv bzip2 jq)
-ENV_ARRAY=(TF_VAR_aks_client_id TF_VAR_aks_client_secret)
+CMD_ARRAY=($TERRAFORM $KUBECTL pv bzip2 jq)
+ENV_ARRAY=(ARM_SUBSCRIPTION_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_CLIENT_ID)
 CREATE_ONLY=
 
 _usage="Usage: $0 :
@@ -101,7 +100,7 @@ function load {
   nodes=$(KUBECONFIG=$RUN_PATH/kubeconfig kubectl get nodes -o json | jq -r '.items[] | .status | .addresses[] | select(.type == "ExternalIP") |.address')
   for node in $(echo $nodes); do
     echo load $image to $node
-    docker save $image | pv| ssh  -oStrictHostKeyChecking=no azureuser@$node 'sudo ctr -n=k8s.io images import -'
+    docker save $image | pv | ssh -oStrictHostKeyChecking=no azureuser@$node 'sudo ctr -n=k8s.io images import -'
   done
 }
 

--- a/hack/aks
+++ b/hack/aks
@@ -19,7 +19,7 @@ KUBECTL="kubectl"
 RUN_PATH="$HOME/tmp/terraform-aks"
 CONFIG_PATH=$(dirname $(readlink -f "$0"))/terraform/aks
 CMD_ARRAY=($TERRAFORM $KUBECTL pv bzip2 jq)
-ENV_ARRAY=(ARM_SUBSCRIPTION_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_CLIENT_ID)
+ENV_ARRAY=(TF_VAR_azure_client_id TF_VAR_azure_client_secret TF_VAR_azure_client_subscription_id TF_VAR_azure_client_tenant_id)
 CREATE_ONLY=
 
 _usage="Usage: $0 :

--- a/hack/eks
+++ b/hack/eks
@@ -21,7 +21,7 @@ KUBECTL="kubectl"
 RUN_PATH="$HOME/tmp/terraform-eks"
 CONFIG_PATH=$(dirname $(readlink -f "$0"))/terraform/eks
 CMD_ARRAY=($AWS_CLI $TERRAFORM $KUBECTL pv bzip2 jq)
-ENV_ARRAY=(TF_VAR_eks_cluster_iam_role_name TF_VAR_eks_iam_instance_profile_name TF_VAR_eks_key_pair_name)
+ENV_ARRAY=(TF_VAR_eks_cluster_iam_role_name TF_VAR_eks_iam_instance_profile_name TF_VAR_aws_key_pair_name)
 CREATE_ONLY=
 
 _usage="Usage: $0 :
@@ -56,19 +56,6 @@ function validate {
        exit 1
      fi
   done
-
-  # check for aws permissions
-  $AWS_CLI eks list-clusters > /dev/null 2>&1
-   if [ $? -ne 0 ]; then
-     echo aws user has no permission to eks
-     exit 1
-   fi
-
-  $AWS_CLI iam list-roles > /dev/null 2>&1
-   if [ $? -ne 0 ]; then
-     echo aws user has no permission to iam
-     exit 1
-   fi
 }
 
 function apply {
@@ -116,7 +103,7 @@ function load {
   nodes=$(KUBECONFIG=$RUN_PATH/kubeconfig kubectl get nodes -o json | jq -r '.items[] | .status | .addresses[] | select(.type == "ExternalIP") |.address')
   for node in $(echo $nodes); do
     echo load $image to $node
-    docker save $image | bzip2 |pv| ssh  -oStrictHostKeyChecking=no ec2-user@$node 'docker load'
+    docker save $image | bzip2 | pv | ssh -oStrictHostKeyChecking=no ec2-user@$node 'docker load'
   done
 }
 

--- a/hack/terraform/aks/aks_nsg_id
+++ b/hack/terraform/aks/aks_nsg_id
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-rg_name=$(az group list --query [].name -o tsv | grep MC_$1)
-OUTPUT=$(az network nsg list | jq -r ".[] | select(.resourceGroup == \"$rg_name\") | .name")
-jq -n --arg output "$OUTPUT" '{"output":$output}'

--- a/hack/terraform/aks/aks_rg_name
+++ b/hack/terraform/aks/aks_rg_name
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-OUTPUT=$(az group list --query [].name -o tsv | grep MC_$1 | head -n 1)
-jq -n --arg output "$OUTPUT" '{"output":$output}'

--- a/hack/terraform/aks/main.tf
+++ b/hack/terraform/aks/main.tf
@@ -31,7 +31,7 @@ locals {
 
 data "azurerm_resources" "node_nsg" {
   resource_group_name = azurerm_kubernetes_cluster.k8s.node_resource_group
-  type = "Microsoft.Network/networkSecurityGroups"
+  type                = "Microsoft.Network/networkSecurityGroups"
 }
 
 resource "random_string" "suffix" {
@@ -91,7 +91,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     type = "SystemAssigned"
   }
   kubernetes_version = "1.24.3"
-  tags = {
+  tags               = {
     Environment = "nephe"
   }
 }

--- a/hack/terraform/aks/main.tf
+++ b/hack/terraform/aks/main.tf
@@ -90,7 +90,6 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   identity {
     type = "SystemAssigned"
   }
-  kubernetes_version = "1.24.3"
   tags               = {
     Environment = "nephe"
   }

--- a/hack/terraform/aks/main.tf
+++ b/hack/terraform/aks/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   identity {
     type = "SystemAssigned"
   }
-  tags               = {
+  tags = {
     Environment = "nephe"
   }
 }

--- a/hack/terraform/aks/main.tf
+++ b/hack/terraform/aks/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   identity {
     type = "SystemAssigned"
   }
-
+  kubernetes_version = "1.24.3"
   tags = {
     Environment = "nephe"
   }

--- a/hack/terraform/aks/variables.tf
+++ b/hack/terraform/aks/variables.tf
@@ -1,10 +1,7 @@
-variable aks_client_id {}
-variable aks_client_secret {}
-variable aks_client_subscription_id{}
-variable aks_client_tenant_id{}
-variable cloud_controller_identity_id{
-  default = ""
-}
+variable azure_client_id {}
+variable azure_client_secret {}
+variable azure_client_subscription_id{}
+variable azure_client_tenant_id{}
 
 variable owner {
   type = string

--- a/hack/terraform/aws/main.tf
+++ b/hack/terraform/aws/main.tf
@@ -11,8 +11,6 @@ terraform {
 
 provider "aws" {
   region     = var.region
-  access_key = var.aws_access_key_id
-  secret_key = var.aws_access_key_secret
 }
 
 ##################################################################

--- a/hack/terraform/aws/main.tf
+++ b/hack/terraform/aws/main.tf
@@ -9,9 +9,7 @@ terraform {
   }
 }
 
-provider "aws" {
-  region     = var.region
-}
+provider "aws" {}
 
 ##################################################################
 # Data sources to get VPC, subnet, security group and AMI details
@@ -44,6 +42,8 @@ data "template_file" user_data {
   template = file(var.aws_vm_os_types[count.index].init)
 }
 
+data "aws_region" "current" {}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "2.77.0"
@@ -51,7 +51,7 @@ module "vpc" {
   name = local.vpc_name
   cidr = var.vpc_cidr
 
-  azs            = ["${var.region}b"]
+  azs            = ["${data.aws_region.current.name}b"]
   public_subnets = [var.vpc_public_subnet]
 
   #enable_nat_gateway = true

--- a/hack/terraform/aws/outputs.tf
+++ b/hack/terraform/aws/outputs.tf
@@ -40,5 +40,5 @@ output "private_ips" {
 
 output "region" {
   description = "VPC region"
-  value       = var.region
+  value       = data.aws_region.current.name
 }

--- a/hack/terraform/aws/variables.tf
+++ b/hack/terraform/aws/variables.tf
@@ -1,5 +1,3 @@
-variable aws_access_key_id {}
-variable aws_access_key_secret {}
 variable aws_key_pair_name {}
 
 variable owner {

--- a/hack/terraform/aws/variables.tf
+++ b/hack/terraform/aws/variables.tf
@@ -5,10 +5,6 @@ variable owner {
   default = null
 }
 
-variable "region" {
-  default = "us-west-1"
-}
-
 variable aws_vm_type {
   default = "t2.micro"
 }

--- a/hack/terraform/eks/main.tf
+++ b/hack/terraform/eks/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 0.13.5"
   required_providers {
     aws = {
       version = "~> 4.4"
@@ -116,7 +116,7 @@ module "eks" {
       asg_desired_capacity      = var.eks_worker_count
       public_ip                 = true
       iam_instance_profile_name = var.eks_iam_instance_profile_name
-      key_name                  = var.eks_key_pair_name
+      key_name                  = var.aws_key_pair_name
     },
   ]
 

--- a/hack/terraform/eks/main.tf
+++ b/hack/terraform/eks/main.tf
@@ -22,9 +22,7 @@ terraform {
   }
 }
 
-provider "aws" {
-  region = var.region
-}
+provider "aws" {}
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
@@ -39,6 +37,8 @@ data "aws_eks_cluster" "cluster" {
 data "aws_eks_cluster_auth" "cluster" {
   name = module.eks.cluster_id
 }
+
+data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 

--- a/hack/terraform/eks/outputs.tf
+++ b/hack/terraform/eks/outputs.tf
@@ -22,7 +22,7 @@ output "config_map_aws_auth" {
 
 output "region" {
   description = "AWS region."
-  value       = var.region
+  value       = data.aws_region.current.name
 }
 
 output "vpc" {

--- a/hack/terraform/eks/variables.tf
+++ b/hack/terraform/eks/variables.tf
@@ -1,14 +1,6 @@
+variable aws_key_pair_name {}
 variable eks_iam_instance_profile_name {}
 variable eks_cluster_iam_role_name {}
-variable eks_key_pair_name {}
-variable jfrog_usr {
-  default = ""
-}
-
-variable jfrog_api_key {
-  default = ""
-}
-
 variable owner {
   type    = string
   default = null

--- a/hack/terraform/eks/variables.tf
+++ b/hack/terraform/eks/variables.tf
@@ -21,7 +21,3 @@ variable eks_worker_count {
 variable eks_worker_type {
   default = "t2.medium"
 }
-
-variable "region" {
-  default = "us-west-1"
-}

--- a/test/utils/cloud_provider_aws.go
+++ b/test/utils/cloud_provider_aws.go
@@ -35,8 +35,7 @@ type awsVPC struct {
 
 // createAWSVPC creates AWS VPC that contains some VMs. It returns VPC id if successful.
 func createAWSVPC(timeout time.Duration) (map[string]interface{}, error) {
-	envs := []string{"TF_VAR_aws_access_key_secret",
-		"TF_VAR_aws_access_key_id"}
+	envs := []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}
 	for _, key := range envs {
 		if _, ok := os.LookupEnv(key); !ok {
 			return nil, fmt.Errorf("environment variable %v not set", key)
@@ -207,8 +206,8 @@ func (p *awsVPC) GetCloudAccountParameters(name, namespace string, cloudCluster 
 		cred.RoleArn = roleArn
 		logf.Log.Info("Using AWS role based access")
 	} else {
-		cred.AccessKeyID = os.Getenv("TF_VAR_aws_access_key_id")
-		cred.AccessKeySecret = os.Getenv("TF_VAR_aws_access_key_secret")
+		cred.AccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
+		cred.AccessKeySecret = os.Getenv("AWS_SECRET_ACCESS_KEY")
 	}
 	secretString, _ := json.Marshal(cred)
 	out.SecretRef.Credential = string(secretString)


### PR DESCRIPTION
## What does this PR do?

This PR reduces the dependencies terraform needs and unify the environment variables used. It also aims to resolve potential credential leaks.

## Changes
1. eks and aws all take same key pair env var `aws_key_pair_name`.
1. eks, aws, aws cli will now take credentials from `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
1. aks shell script and az cli dependency removed.
1. aks and azure will now both take credentials from
```
TF_VAR_azure_client_secret
TF_VAR_azure_client_subscription_id
TF_VAR_azure_client_tenant_id
TF_VAR_azure_client_id
```
1. update corresponding docs to reflect env var change.