### PR TITLE
Add webhook validations secret object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCKER_SRC=/usr/src/antrea.io/nephe
 DOCKER_GOPATH=/tmp/gopath
 DOCKER_GOCACHE=/tmp/gocache
 GENERATE_CODE_LIST={$$(go list ./... | grep -e apis/crd -e apis/runtime | paste -s -d, -)}
-GENERATE_MANIFEST_LIST={$$(go list ./... | grep apis/crd | paste -s -d, -)}
+GENERATE_MANIFEST_LIST={$$(go list ./... | grep -E 'apis/crd|pkg/apiserver/webhook' | paste -s -d, -)}
 
 DOCKERIZE := \
 	 docker run --rm -u $$(id -u):$$(id -g) \

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -901,3 +901,25 @@ webhooks:
     resources:
     - cloudprovideraccounts
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: nephe-controller-webhook-service
+      namespace: nephe-system
+      path: /validate-v1-secret
+  failurePolicy: Fail
+  name: vsecret.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - secrets
+  sideEffects: None

--- a/config/webhook/manifests-new.yaml
+++ b/config/webhook/manifests-new.yaml
@@ -131,3 +131,23 @@ webhooks:
           - cloudprovideraccounts
     sideEffects: None
     admissionReviewVersions: ["v1", "v1beta1"]
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: nephe-controller-webhook-service
+        namespace: system
+        path: /validate-v1-secret
+    failurePolicy: Fail
+    name: vsecret.kb.io
+    rules:
+      - apiGroups:
+            - ""
+        apiVersions:
+            - v1
+        operations:
+            - UPDATE
+            - DELETE
+        resources:
+            - secrets
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -137,3 +137,24 @@ webhooks:
     resources:
     - virtualmachines
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v1-secret
+  failurePolicy: Fail
+  name: vsecret.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - secrets
+  sideEffects: None

--- a/pkg/apiserver/webhook/secret_webhook.go
+++ b/pkg/apiserver/webhook/secret_webhook.go
@@ -1,0 +1,162 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	crdv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
+)
+
+// nolint:lll
+// +kubebuilder:webhook:verbs=update;delete,path=/validate-v1-secret,mutating=false,failurePolicy=fail,groups="",resources=secrets,versions=v1,name=vsecret.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// SecretValidator is used to validate Secret.
+type SecretValidator struct {
+	Client  controllerclient.Client
+	Log     logr.Logger
+	decoder *admission.Decoder
+}
+
+// Handle handles admission requests for Secret.
+func (v *SecretValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	v.Log.V(1).Info("Received admission webhook", "req", req, "operation", req.Operation)
+	switch req.Operation {
+	case admissionv1.Create:
+		return v.validateCreate(req)
+	case admissionv1.Update:
+		return v.validateUpdate(req)
+	case admissionv1.Delete:
+		return v.validateDelete(req)
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid admission webhook request"))
+	}
+}
+
+// InjectDecoder injects the decoder.
+func (v *SecretValidator) InjectDecoder(d *admission.Decoder) error { //nolint:unparam
+	v.decoder = d
+	return nil
+}
+
+// allowSecretUpdate returns true only when Secret data key is unchanged.
+func (v *SecretValidator) allowSecretUpdate(new *corev1.Secret, old *corev1.Secret, key string) bool {
+	if changed := string(new.Data[key]) != string(old.Data[key]); changed {
+		return false
+	}
+	return true
+}
+
+// getCPABySecret returns nil only when the Secret is not used by any CloudProvideAccount CR,
+// otherwise the dependent CloudProvideAccount CR will be returned.
+func (v *SecretValidator) getCPABySecret(s *corev1.Secret) (error, *crdv1alpha1.CloudProviderAccount) {
+	cpaList := &crdv1alpha1.CloudProviderAccountList{}
+	err := v.Client.List(context.TODO(), cpaList, &controllerclient.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get CloudProviderAccount list, err:%v", err), nil
+	}
+
+	for _, cpa := range cpaList.Items {
+		v.Log.V(1).Info("Checking CloudProvideAccount", "Name", cpa.Name,
+			"Namespace", cpa.Namespace)
+		if cpa.Spec.AWSConfig != nil {
+			if cpa.Spec.AWSConfig.SecretRef.Name == s.Name &&
+				cpa.Spec.AWSConfig.SecretRef.Namespace == s.Namespace {
+				return nil, &cpa
+			}
+		}
+
+		if cpa.Spec.AzureConfig != nil {
+			if cpa.Spec.AzureConfig.SecretRef.Name == s.Name &&
+				cpa.Spec.AzureConfig.SecretRef.Namespace == s.Namespace {
+				return nil, &cpa
+			}
+		}
+	}
+	return nil, nil
+}
+
+// validateCreate does not deny Secret creation.
+func (v *SecretValidator) validateCreate(req admission.Request) admission.Response { // nolint: unparam
+	return admission.Allowed("")
+}
+
+// validateUpdate denies Secret update, if the Secret key is referred in a CloudProviderAccount.
+func (v *SecretValidator) validateUpdate(req admission.Request) admission.Response {
+	newSecret := &corev1.Secret{}
+	err := v.decoder.Decode(req, newSecret)
+	if err != nil {
+		v.Log.Error(err, "Failed to decode Secret", "SecretValidator", req.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	oldSecret := &corev1.Secret{}
+	if req.OldObject.Raw != nil {
+		if err := json.Unmarshal(req.OldObject.Raw, &oldSecret); err != nil {
+			v.Log.Error(err, "Failed to decode old Secret", "SecretValidator", req.Name)
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+	}
+
+	err, cpa := v.getCPABySecret(oldSecret)
+	if err != nil {
+		return admission.Denied(err.Error())
+	}
+	if cpa != nil {
+		var key string
+		if cpa.Spec.AWSConfig != nil {
+			key = cpa.Spec.AWSConfig.SecretRef.Key
+		} else if cpa.Spec.AzureConfig != nil {
+			key = cpa.Spec.AzureConfig.SecretRef.Key
+		}
+		if ok := v.allowSecretUpdate(newSecret, oldSecret, key); !ok {
+			v.Log.Error(nil, "The Secret is referred by a CloudProviderAccount. Cannot modify it,",
+				"Secret", oldSecret.Name, "CloudProviderAccount", cpa.Name)
+			return admission.Denied(fmt.Sprintf("the Secret %v is referred by a "+
+				"CloudProviderAccount %s. The %s field 'value' cannot be changed", oldSecret.Name, cpa.Name, key))
+		}
+	}
+	return admission.Allowed("")
+}
+
+// validateDelete denies Secret deletion if the Secret is referred in a CloudProviderAccount.
+func (v *SecretValidator) validateDelete(req admission.Request) admission.Response {
+	oldSecret := &corev1.Secret{}
+	if req.OldObject.Raw != nil {
+		if err := json.Unmarshal(req.OldObject.Raw, &oldSecret); err != nil {
+			v.Log.Error(err, "Failed to decode old Secret", "SecretValidator", req.Name)
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+	}
+	err, cpa := v.getCPABySecret(oldSecret)
+	if err != nil {
+		return admission.Denied(err.Error())
+	}
+	if cpa != nil {
+		v.Log.Error(nil, "The Secret is referred by a CloudProviderAccount. Cannot delete it,",
+			"Secret", oldSecret.Name, "CloudProviderAccount", cpa.Name)
+		return admission.Denied(fmt.Sprintf("the Secret %s is referred by a CloudProviderAccount %s. "+
+			"Please delete the CloudProviderAccount first", oldSecret.Name, cpa.Name))
+	}
+	return admission.Allowed("")
+}

--- a/pkg/apiserver/webhook/secret_webhook_test.go
+++ b/pkg/apiserver/webhook/secret_webhook_test.go
@@ -1,0 +1,1090 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"antrea.io/nephe/apis/crd/v1alpha1"
+	"antrea.io/nephe/pkg/logging"
+)
+
+var _ = Describe("Webhook", func() {
+	Context("Running Webhook tests for Secret", func() {
+		var (
+			testSecretNamespacedName1 = types.NamespacedName{Namespace: "namespace01", Name: "secret01"}
+			testSecretNamespacedName2 = types.NamespacedName{Namespace: "namespace02", Name: "secret02"}
+			testAccountNamespacedName = types.NamespacedName{Namespace: "namespace01", Name: "account01"}
+			credential                = `{"accessKeyId": "keyId","accessKeySecret": "keySecret"}`
+			credentials               = "credentials"
+			invalidReqErrorMsg        = "invalid admission webhook request"
+			decoderErrorMsg           = "there is no content to decode"
+			account                   *v1alpha1.CloudProviderAccount
+			s1                        *corev1.Secret
+			encodedS1                 []byte
+			decoder                   *admission.Decoder
+			s1Req                     admission.Request
+			fakeClient                client.WithWatch
+			err                       error
+		)
+
+		BeforeEach(func() {
+			credential = `{"accessKeyId": "keyId","accessKeySecret": "keySecret"}`
+			s1 = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+			encodedS1, _ = json.Marshal(s1)
+			s1Req = admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Create,
+					Object: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+
+			newScheme := runtime.NewScheme()
+			utilruntime.Must(clientgoscheme.AddToScheme(newScheme))
+			utilruntime.Must(v1alpha1.AddToScheme(newScheme))
+			decoder, err = admission.NewDecoder(newScheme)
+			Expect(err).Should(BeNil())
+			fakeClient = fake.NewClientBuilder().WithScheme(newScheme).Build()
+		})
+
+		It("Validate Secret create", func() {
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), s1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeTrue())
+		})
+
+		// The below set of tests validate Secret update/delete for AWS config.
+		It("Validate Secret delete with dependent AWS CPA", func() {
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			temp := &corev1.Secret{}
+			err = fakeClient.Get(context.TODO(), testSecretNamespacedName1, temp)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &v1alpha1.CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeFalse())
+		})
+		It("Validate Secret credentials update with dependent AWS CPA", func() {
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &v1alpha1.CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newCredential := `{"accessKeyId": "keyId","accessKeySecret": "keySecret1"}`
+			newS1 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(newCredential),
+				},
+			}
+			encodedNewS1, _ := json.Marshal(newS1)
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Update,
+					Object: runtime.RawExtension{
+						Raw: encodedNewS1,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeFalse())
+		})
+		It("Validate Secret labels update with dependent AWS CPA", func() {
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &v1alpha1.CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newLabel := make(map[string]string)
+			newLabel["test"] = "testLabel"
+			newS1 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Labels:    newLabel,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+			encodedNewS1, _ := json.Marshal(newS1)
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Update,
+					Object: runtime.RawExtension{
+						Raw: encodedNewS1,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeTrue())
+		})
+		It("Validate Secret delete without dependent AWS CPA", func() {
+			credential := `{"accessKeyId": "keyId","accessKeySecret": "keySecret"}`
+			s1 = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName2.Name,
+					Namespace: testSecretNamespacedName2.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+			encodedS1, _ := json.Marshal(s1)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account := &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &v1alpha1.CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName2.Name,
+					Namespace: testSecretNamespacedName2.Namespace,
+					Operation: v1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeTrue())
+		})
+		It("Validate Secret credentials update without dependent AWS CPA", func() {
+			credential := `{"accessKeyId": "keyId","accessKeySecret": "keySecret"}`
+			s1 = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName2.Name,
+					Namespace: testSecretNamespacedName2.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+
+			encodedS1, _ := json.Marshal(s1)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account := &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &v1alpha1.CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newCredential := `{"accessKeyId": "keyId","accessKeySecret": "keySecret1"}`
+			newS1 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName2.Name,
+					Namespace: testSecretNamespacedName2.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(newCredential),
+				},
+			}
+			encodedNewS1, _ := json.Marshal(newS1)
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Update,
+					Object: runtime.RawExtension{
+						Raw: encodedNewS1,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeTrue())
+		})
+
+		// The below set of tests validate Secret update/delete for Azure config.
+		It("Validate Azure Secret delete with dependent Azure CPA", func() {
+			credential = `{"subscriptionId": "SubID",
+				"clientId": "ClientID",
+				"tenantId": "TenantID,
+				"clientKey": "ClientKey"
+			}`
+			s1 = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+			encodedS1, _ := json.Marshal(s1)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			temp := &corev1.Secret{}
+			err = fakeClient.Get(context.TODO(), testSecretNamespacedName1, temp)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AzureConfig: &v1alpha1.CloudProviderAccountAzureConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeFalse())
+		})
+		It("Validate Secret credentials update with dependent Azure CPA", func() {
+			credential = `{"subscriptionId": "SubID",
+				"clientId": "ClientID",
+				"tenantId": "TenantID,
+				"clientKey": "ClientKey"
+			}`
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AzureConfig: &v1alpha1.CloudProviderAccountAzureConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newCredential := `{"subscriptionId": "SubID",
+				"clientId": "ClientID",
+				"tenantId": "TenantID",
+				"clientKey": "ClientKey"
+			}`
+			newS1 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(newCredential),
+				},
+			}
+			encodedNewS1, _ := json.Marshal(newS1)
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Update,
+					Object: runtime.RawExtension{
+						Raw: encodedNewS1,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeFalse())
+		})
+		It("Validate Secret labels update with dependent Azure CPA", func() {
+			credential = `{"subscriptionId": "SubID",
+				"clientId": "ClientID",
+				"tenantId": "TenantID,
+				"clientKey": "ClientKey"
+			}`
+			s1 = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+			encodedS1, _ := json.Marshal(s1)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AzureConfig: &v1alpha1.CloudProviderAccountAzureConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newLabel := make(map[string]string)
+			newLabel["test"] = "testLabel"
+			newS1 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Labels:    newLabel,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+			encodedNewS1, _ := json.Marshal(newS1)
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Update,
+					Object: runtime.RawExtension{
+						Raw: encodedNewS1,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeTrue())
+		})
+		It("Validate Secret delete without dependent Azure CPA", func() {
+			credential = `{"subscriptionId": "SubID",
+				"clientId": "ClientID",
+				"tenantId": "TenantID,
+				"clientKey": "ClientKey"
+			}`
+			s1 = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName2.Name,
+					Namespace: testSecretNamespacedName2.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+			encodedS1, _ := json.Marshal(s1)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account := &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AzureConfig: &v1alpha1.CloudProviderAccountAzureConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName2.Name,
+					Namespace: testSecretNamespacedName2.Namespace,
+					Operation: v1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeTrue())
+		})
+		It("Validate Secret credentials update without Azure dependent CPA", func() {
+			credential = `{"subscriptionId": "SubID",
+				"clientId": "ClientID",
+				"tenantId": "TenantID,
+				"clientKey": "ClientKey"
+			}`
+			s1 = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName2.Name,
+					Namespace: testSecretNamespacedName2.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(credential),
+				},
+			}
+
+			encodedS1, _ := json.Marshal(s1)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account := &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AzureConfig: &v1alpha1.CloudProviderAccountAzureConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newCredential := `{"accessKeyId": "keyId","accessKeySecret": "keySecret1"}`
+			newS1 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName2.Name,
+					Namespace: testSecretNamespacedName2.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(newCredential),
+				},
+			}
+			encodedNewS1, _ := json.Marshal(newS1)
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Update,
+					Object: runtime.RawExtension{
+						Raw: encodedNewS1,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeTrue())
+		})
+
+		// Other tests.
+		It("Validate Secret delete with json marshal error", func() {
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			temp := &corev1.Secret{}
+			err = fakeClient.Get(context.TODO(), testSecretNamespacedName1, temp)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &v1alpha1.CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			// To simulate error during json marshall, do not encode.
+			dummyEncodeS1 := []byte("dummy")
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: dummyEncodeS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeFalse())
+			Expect(response.Result.Code).Should(BeEquivalentTo(400))
+		})
+		It("Validate Secret update with json marshal error", func() {
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &v1alpha1.CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			newCredential := `{"accessKeyId": "keyId","accessKeySecret": "keySecret1"}`
+			newS1 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+				},
+				Data: map[string][]byte{
+					credentials: []byte(newCredential),
+				},
+			}
+			encodedNewS1, _ := json.Marshal(newS1)
+			dummyEncodeS1 := []byte("dummy")
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Update,
+					Object: runtime.RawExtension{
+						Raw: encodedNewS1,
+					},
+					OldObject: runtime.RawExtension{
+						Raw: dummyEncodeS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeFalse())
+			Expect(response.Result.Code).Should(BeEquivalentTo(400))
+		})
+		It("Validate Secret update with decoder error", func() {
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating Secret [%s, %s]\n", s1.Name, s1.Namespace)))
+			err = fakeClient.Create(context.Background(), s1)
+			Expect(err).Should(BeNil())
+			var pollIntv uint = 1
+			account = &v1alpha1.CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: v1alpha1.CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &v1alpha1.CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &v1alpha1.SecretReference{
+							Name:      testSecretNamespacedName1.Name,
+							Namespace: testSecretNamespacedName1.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Creating CloudProviderAccount [%s, %s] with SecretRef [%s, %s]\n",
+				account.Name, account.Namespace, testSecretNamespacedName1.Name,
+				testSecretNamespacedName1.Namespace)))
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+			dummyEncodeS1 := []byte("dummy")
+			// Do not add Object field to simulate error while decoding.
+			newS1Req := admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: dummyEncodeS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), newS1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response)))
+			Expect(response.Allowed).To(BeFalse())
+			Expect(response.Result.Code).Should(BeEquivalentTo(400))
+			Expect(response.Result.Message).Should(BeEquivalentTo(decoderErrorMsg))
+		})
+		It("Validate Secret invalid admission request", func() {
+			// Set admission.Request type to connect to simulate invalid request.
+			s1Req = admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "corev1",
+						Kind:    "Secret",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "",
+						Version:  "corev1",
+						Resource: "Secrets",
+					},
+					Name:      testSecretNamespacedName1.Name,
+					Namespace: testSecretNamespacedName1.Namespace,
+					Operation: v1.Connect,
+					Object: runtime.RawExtension{
+						Raw: encodedS1,
+					},
+				},
+			}
+			SecretValidatorTest1 := &SecretValidator{
+				Client: fakeClient,
+				Log:    logging.GetLogger("webhook").WithName("Secret")}
+			err = SecretValidatorTest1.InjectDecoder(decoder)
+			Expect(err).Should(BeNil())
+			response := SecretValidatorTest1.Handle(context.Background(), s1Req)
+			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Got admission response %+v\n", response.Result)))
+			Expect(response.Allowed).To(BeFalse())
+			Expect(response.Result.Code).Should(BeEquivalentTo(400))
+			Expect(response.Result.Message).Should(BeEquivalentTo(invalidReqErrorMsg))
+		})
+	})
+})

--- a/pkg/apiserver/webhook/webhook_suite_test.go
+++ b/pkg/apiserver/webhook/webhook_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
+}


### PR DESCRIPTION
- Update of secrets are allowed only when the secret key
  (which is reffered by CPA) is not changed.
- Delete of secrets are allowed only when it is not being
  referred by CPA.
- Add unit tests for validating webhook for Secret
- Coverage at 95.1%

Signed-off-by: Anand Kumar <kumaranand@vmware.com>