### PR TITLE
Add support to import Agented VMs

### DIFF
--- a/apis/crd/v1alpha1/cloudentityselector_types.go
+++ b/apis/crd/v1alpha1/cloudentityselector_types.go
@@ -39,7 +39,7 @@ type VirtualMachineSelector struct {
 	// If it is not specified, all VirtualMachines matching VpcMatch are selected.
 	VMMatch []EntityMatch `json:"vmMatch,omitempty"`
 	// Agented specifies if VM runs in agented mode, default is false.
-	Agented bool `json:"agented"`
+	Agented bool `json:"agented,omitempty"`
 }
 
 // CloudEntitySelectorSpec defines the desired state of CloudEntitySelector.

--- a/apis/crd/v1alpha1/cloudentityselector_types.go
+++ b/apis/crd/v1alpha1/cloudentityselector_types.go
@@ -38,6 +38,8 @@ type VirtualMachineSelector struct {
 	// It is an array, match satisfying any item on VMMatch is selected(ORed).
 	// If it is not specified, all VirtualMachines matching VpcMatch are selected.
 	VMMatch []EntityMatch `json:"vmMatch,omitempty"`
+	// Agented specifies if VM runs in agented mode, default is false.
+	Agented bool `json:"agented"`
 }
 
 // CloudEntitySelectorSpec defines the desired state of CloudEntitySelector.

--- a/apis/crd/v1alpha1/virtualmachine_types.go
+++ b/apis/crd/v1alpha1/virtualmachine_types.go
@@ -86,6 +86,8 @@ type VirtualMachineStatus struct {
 	NetworkInterfaces []NetworkInterface `json:"networkInterfaces,omitempty"`
 	// State indicates current state of the VirtualMachine.
 	State VMState `json:"state,omitempty"`
+	// Agented specifies if VM runs in agented mode, default is false.
+	Agented bool `json:"agented"`
 }
 
 // +genclient
@@ -96,6 +98,7 @@ type VirtualMachineStatus struct {
 // +kubebuilder:printcolumn:name="Cloud-Provider",type=string,JSONPath=`.status.provider`
 // +kubebuilder:printcolumn:name="Virtual-Private-Cloud",type=string,JSONPath=`.status.virtualPrivateCloud`
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
+// +kubebuilder:printcolumn:name="Agented",type=string,JSONPath=`.status.agented`
 // VirtualMachine is the Schema for the virtualmachines API
 // A virtualMachine object is created automatically based on
 // matching criteria specification of CloudEntitySelector.

--- a/ci/aks/antrea-aks.yml
+++ b/ci/aks/antrea-aks.yml
@@ -3052,7 +3052,7 @@ data:
     #  IPsecCertAuth: false
 
     # Enable managing ExternalNode for unmanaged VM/BM.
-    #  ExternalNode: false
+      ExternalNode: true
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -3969,6 +3969,7 @@ spec:
   selector:
     app: antrea
     component: antrea-controller
+  type: LoadBalancer
 ---
 # Source: antrea/templates/agent/daemonset.yaml
 apiVersion: apps/v1

--- a/ci/eks/antrea-eks.yml
+++ b/ci/eks/antrea-eks.yml
@@ -3052,7 +3052,7 @@ data:
     #  IPsecCertAuth: false
 
     # Enable managing ExternalNode for unmanaged VM/BM.
-    #  ExternalNode: false
+      ExternalNode: true
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -3962,6 +3962,7 @@ metadata:
   labels:
     app: antrea
 spec:
+  type: LoadBalancer
   ports:
     - port: 443
       protocol: TCP

--- a/ci/kind/antrea-kind.yml
+++ b/ci/kind/antrea-kind.yml
@@ -3052,7 +3052,7 @@ data:
     #  IPsecCertAuth: false
 
     # Enable managing ExternalNode for unmanaged VM/BM.
-    #  ExternalNode: false
+      ExternalNode: true
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the

--- a/cmd/nephe-controller/main.go
+++ b/cmd/nephe-controller/main.go
@@ -24,7 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	antreanetworking "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
-	antreatypes "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	antreav1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	antreav1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	crdv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
 	"antrea.io/nephe/pkg/apiserver"
@@ -42,7 +43,8 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = antreanetworking.AddToScheme(scheme)
-	_ = antreatypes.AddToScheme(scheme)
+	_ = antreav1alpha1.AddToScheme(scheme)
+	_ = antreav1alpha2.AddToScheme(scheme)
 	_ = crdv1alpha1.AddToScheme(scheme)
 	_ = runtimev1alpha1.AddToScheme(scheme)
 

--- a/config/crd/bases/crd.cloud.antrea.io_cloudentityselectors.yaml
+++ b/config/crd/bases/crd.cloud.antrea.io_cloudentityselectors.yaml
@@ -51,6 +51,10 @@ spec:
                     criteria. VirtualMachines must satisfy all fields(ANDed) in a
                     VirtualMachineSelector in order to satisfy match.
                   properties:
+                    agented:
+                      description: Agented specifies if VM runs in agented mode, default
+                        is false.
+                      type: boolean
                     vmMatch:
                       description: VMMatch specifies VirtualMachines to match. It
                         is an array, match satisfying any item on VMMatch is selected(ORed).
@@ -86,6 +90,8 @@ spec:
                             not specified, it matches any cloud entities.
                           type: string
                       type: object
+                  required:
+                  - agented
                   type: object
                 type: array
             required:

--- a/config/crd/bases/crd.cloud.antrea.io_cloudentityselectors.yaml
+++ b/config/crd/bases/crd.cloud.antrea.io_cloudentityselectors.yaml
@@ -90,8 +90,6 @@ spec:
                             not specified, it matches any cloud entities.
                           type: string
                       type: object
-                  required:
-                  - agented
                   type: object
                 type: array
             required:

--- a/config/crd/bases/crd.cloud.antrea.io_virtualmachines.yaml
+++ b/config/crd/bases/crd.cloud.antrea.io_virtualmachines.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .status.state
       name: State
       type: string
+    - jsonPath: .status.agented
+      name: Agented
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -50,6 +53,10 @@ spec:
             description: VirtualMachineStatus defines the observed state of VirtualMachine
               It contains observable parameters.
             properties:
+              agented:
+                description: Agented specifies if VM runs in agented mode, default
+                  is false.
+                type: boolean
               networkInterfaces:
                 description: NetworkInterfaces is array of NetworkInterfaces attached
                   to this VirtualMachine.
@@ -96,6 +103,8 @@ spec:
                 description: VirtualPrivateCloud is the virtual private cloud this
                   VirtualMachine belongs to.
                 type: string
+            required:
+            - agented
             type: object
         type: object
     served: true

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -107,8 +107,6 @@ spec:
                             not specified, it matches any cloud entities.
                           type: string
                       type: object
-                  required:
-                  - agented
                   type: object
                 type: array
             required:
@@ -505,6 +503,7 @@ rules:
   - get
   - list
   - patch
+  - watch
 - apiGroups:
   - crd.antrea.io
   resources:

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -68,6 +68,10 @@ spec:
                     criteria. VirtualMachines must satisfy all fields(ANDed) in a
                     VirtualMachineSelector in order to satisfy match.
                   properties:
+                    agented:
+                      description: Agented specifies if VM runs in agented mode, default
+                        is false.
+                      type: boolean
                     vmMatch:
                       description: VMMatch specifies VirtualMachines to match. It
                         is an array, match satisfying any item on VMMatch is selected(ORed).
@@ -103,6 +107,8 @@ spec:
                             not specified, it matches any cloud entities.
                           type: string
                       type: object
+                  required:
+                  - agented
                   type: object
                 type: array
             required:
@@ -287,6 +293,9 @@ spec:
     - jsonPath: .status.state
       name: State
       type: string
+    - jsonPath: .status.agented
+      name: Agented
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -310,6 +319,10 @@ spec:
             description: VirtualMachineStatus defines the observed state of VirtualMachine
               It contains observable parameters.
             properties:
+              agented:
+                description: Agented specifies if VM runs in agented mode, default
+                  is false.
+                type: boolean
               networkInterfaces:
                 description: NetworkInterfaces is array of NetworkInterfaces attached
                   to this VirtualMachine.
@@ -356,6 +369,8 @@ spec:
                 description: VirtualPrivateCloud is the virtual private cloud this
                   VirtualMachine belongs to.
                 type: string
+            required:
+            - agented
             type: object
         type: object
     served: true
@@ -476,6 +491,24 @@ rules:
   - crd.antrea.io
   resources:
   - externalentities/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - externalnodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - externalnodes/status
   verbs:
   - get
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,6 +66,7 @@ rules:
     - get
     - list
     - patch
+    - watch
 - apiGroups:
     - crd.antrea.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -57,6 +57,25 @@ rules:
   - patch
   - update
 - apiGroups:
+    - crd.antrea.io
+  resources:
+    - externalnodes
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+- apiGroups:
+    - crd.antrea.io
+  resources:
+    - externalnodes/status
+  verbs:
+    - get
+    - patch
+    - update
+
+- apiGroups:
   - crd.cloud.antrea.io
   resources:
   - cloudentityselectors

--- a/config/samples/cloud_v1alpha1_cloudentityselector.yaml
+++ b/config/samples/cloud_v1alpha1_cloudentityselector.yaml
@@ -9,6 +9,7 @@ spec:
   vmSelector:
       - vpcMatch:
           matchID: "<VPC_ID>"
+        agented: false
 ---
 # Match based on vmMatch in the vpc configured : A vm with id <VM_ID> in vpc <VPC_ID> is matched
 apiVersion: crd.cloud.antrea.io/v1alpha1

--- a/docs/agented-vm-guide.md
+++ b/docs/agented-vm-guide.md
@@ -1,0 +1,263 @@
+# Agented VM User Guide
+
+## Table of Contents
+
+<!-- toc -->
+- [Import Agented And Agentless VMs](#import-agented-and-agentless-vms)
+- [VirtualMachine CR Creation](#virtualmachine-cr-creation)
+- [ExternalNode CR Creation](#externalnode-cr-creation)
+- [ExternalEntities CR Creation](#externalentities-cr-creation)
+- [Install Antrea-Agent On Public Cloud VM](#install-antrea-agent-on-public-cloud-vm)
+  - [Installation On Linux VMs](#installation-on-linux-vms)
+  - [Installation On Windows VMs](#installation-on-windows-vms)
+- [Troubleshoot VM Agent](#troubleshoot-vm-agent)
+  - [Linux VM](#linux-vm)
+  - [Windows VM](#windows-vm)
+<!-- /toc -->
+
+Nephe supports auto-onboarding of public cloud VMs, that can run
+`antrea-agent` on VMs. When a CloudEntitySelector selector is configured to
+import agented VMs, `nephe-controller` will auto-create an ExternalNode CR
+corresponding to each VirtualMachine CR. `Antrea-Controller` watches on the
+ExternalNode CR and then creates a corresponding ExternalEntity CR. Upon
+onboarding the agented VMs, user can define Antrea NetworkPolicies using
+ExternalEntity selector.
+
+For more information about the `ExternalNode` feature, please refer to antrea
+[ExternalNode](https://github.com/antrea-io/antrea/blob/main/docs/external-node.md)
+documentation.
+
+Note: While applying antrea manifests, make sure to enable `externalnode`
+feature in the `antrea-controller` configuration. Also, make sure that VM
+can connect to the Kubernetes API server and Antrea API server.
+
+## Import Agented And Agentless VMs
+
+To import public cloud VMs that can run in agented or agentless configuration,
+the user needs to specify the `agented` flag in CloudEntitySelector CR.
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: crd.cloud.antrea.io/v1alpha1
+kind: CloudEntitySelector
+metadata:
+  name: cloudentityselector-aws-sample
+  namespace: vm-ns
+spec:
+  accountName: cloudprovideraccount-aws-sample
+  vmSelector:
+    - vmMatch:
+        - matchID: "i-0a20bae92ddcdb60b"
+        - matchID: "i-05e3fb66922d56e0a"
+        - matchID: "i-0033eb4a6c846451d"
+      agented: false
+    - vmMatch:
+        - matchID: "i-019459b33d951b62e"
+      agented: true
+EOF
+```
+
+## VirtualMachine CR Creation
+
+The `nephe-controller` will poll the cloud inventory and create VirtualMachine
+CR. Based on the `agented` flag specified in the CES, VirtualMachines will
+either be imported as agented or as agentless. In the example above
+`i-019459b33d951b62e` is imported as an agented VM, while the remaining three
+VMs are imported as agentless VMs.
+
+```bash
+kubectl get vm -A
+```
+
+```text
+# Output
+NAMESPACE   NAME                  CLOUD-PROVIDER   VIRTUAL-PRIVATE-CLOUD   STATE     AGENTED
+vm-ns       i-0033eb4a6c846451d   AWS              vpc-0d6bb6a4a880bd9ad   running   false
+vm-ns       i-019459b33d951b62e   AWS              vpc-0d6bb6a4a880bd9ad   running   true
+vm-ns       i-05e3fb66922d56e0a   AWS              vpc-0d6bb6a4a880bd9ad   running   false
+vm-ns       i-0a20bae92ddcdb60b   AWS              vpc-0d6bb6a4a880bd9ad   running   false
+```
+
+```bash
+kubectl describe vm i-019459b33d951b62e -n vm-ns
+```
+
+```text
+# Output
+Name:         i-019459b33d951b62e
+Namespace:    vm-ns
+Labels:       <none>
+Annotations:  cloud-assigned-id: i-019459b33d951b62e
+              cloud-assigned-name: ubuntu2004
+              cloud-assigned-vpc-id: vpc-0d6bb6a4a880bd9ad
+API Version:  crd.cloud.antrea.io/v1alpha1
+Kind:         VirtualMachine
+Metadata:
+  Creation Timestamp:  2022-09-27T12:18:23Z
+  Generation:          1
+  Managed Fields:
+    API Version:  crd.cloud.antrea.io/v1alpha1
+    Fields Type:  FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .:
+          f:cloud-assigned-id:
+          f:cloud-assigned-name:
+          f:cloud-assigned-vpc-id:
+        f:ownerReferences:
+          .:
+          k:{"uid":"42467d8c-9ae7-433b-879c-fdd7b2b843e1"}:
+    Manager:      nephe-controller
+    Operation:    Update
+    Time:         2022-09-27T12:18:23Z
+    API Version:  crd.cloud.antrea.io/v1alpha1
+    Fields Type:  FieldsV1
+    fieldsV1:
+      f:status:
+        .:
+        f:agented:
+        f:networkInterfaces:
+        f:provider:
+        f:state:
+        f:tags:
+          .:
+          f:Name:
+        f:virtualPrivateCloud:
+    Manager:      nephe-controller
+    Operation:    Update
+    Subresource:  status
+    Time:         2022-09-27T12:18:23Z
+  Owner References:
+    API Version:           crd.cloud.antrea.io/v1alpha1
+    Block Owner Deletion:  true
+    Controller:            true
+    Kind:                  CloudEntitySelector
+    Name:                  cloudentityselector-aws-sample
+    UID:                   42467d8c-9ae7-433b-879c-fdd7b2b843e1
+  Resource Version:        7908985
+  UID:                     da9c4826-e9d6-43d7-87e0-44743f881fb1
+Status:
+  Agented:  true
+  Network Interfaces:
+    Ips:
+      Address:       10.0.1.45
+      Address Type:  InternalIP
+      Address:       54.193.202.222
+      Address Type:  ExternalIP
+    Mac:             02:96:fc:89:17:ed
+    Name:            eni-056b0d6da3f592943
+  Provider:          AWS
+  State:             running
+  Tags:
+    Name:                 ubuntu2004
+  Virtual Private Cloud:  vpc-0d6bb6a4a880bd9ad
+Events:                   <none>
+```
+
+## ExternalNode CR Creation
+
+The `Nephe Controller` will create an ExternalNode CR corresponding to each
+VirtualMachine CR, which has the `agented` flag enabled. In the below example,
+since VM `i-019459b33d951b62e` is configured with agented flag set to true,
+a corresponding ExternalNode `virtualmachine-i-019459b33d951b62e` is created.
+
+```bash
+kubectl get en -A
+```
+
+```text
+# Output
+NAMESPACE   NAME                                 AGE
+vm-ns       virtualmachine-i-019459b33d951b62e   6s
+```
+
+## ExternalEntities CR Creation
+
+For each ExternalNode CR, `antrea-controller` will create a corresponding
+ExternalEntity CR. In this example, the ExternalEntity
+`virtualmachine-i-019459b33d951b62e-5df40` corresponds to the ExternalNode
+`virtualmachine-i-019459b33d951b62e`.
+
+```bash
+kubectl get ee -A
+```
+
+```text
+# Output
+NAMESPACE   NAME                                       AGE
+vm-ns       virtualmachine-i-0033eb4a6c846451d         9s
+vm-ns       virtualmachine-i-019459b33d951b62e-5df40   9s
+vm-ns       virtualmachine-i-05e3fb66922d56e0a         9s
+vm-ns       virtualmachine-i-0a20bae92ddcdb60b         9s
+```
+
+## Install Antrea-Agent On Public Cloud VM
+
+Nephe provides a wrapper install script, to facilitate easier installation on
+the public cloud VMs. The wrapper install script sets the Environment variable
+`NODE_NAME` to be same as ExternalNode name. It downloads the `antrea-agent`
+install script from antrea repository and triggers installation.
+
+The wrapper install script requires 4 arguments:
+Namespace            - Specifies the Namespace to be used by the `antrea-agent`.
+It should match with the ExternalNode Namespace.
+Antrea version       - Specifies the Antrea version to be used.
+Kubeconfig           - Provides access to the Kubernetes API server.
+Antrea Kubeconfig    - Provides access to the Antrea API server.
+
+For more information on how to generate the kubeconfig files, please refer to
+antrea [ExternalNode](https://github.com/antrea-io/antrea/blob/main/docs/external-node.md#install-antrea-agent-on-vm)
+documentation.
+
+### Installation On Linux VMs
+
+Download the [wrapper install script](../hack/install-wrapper.sh) and run
+installation.
+
+```bash
+./install-wrapper.sh --ns vm-ns --antrea-version v1.8.0 --kubeconfig ./antrea-agent.kubeconfig \
+  --antrea-kubeconfig ./antrea-agent.antrea.kubeconfig --bin ./antrea-agent
+```
+
+Note: For Ubuntu, `antrea-agent` binaries are not published as part of release
+assets in the antrea 1.8 release. So the user has to manually generate an
+`antrea-agent` binary and copy onto the VM.
+
+### Installation On Windows VMs
+
+Download the [wrapper install script](../hack/install-wrapper.ps1) and run
+installation.
+
+```powershell
+.\install-wrapper.ps1 -Namespace vm-ns -AntreaVersion v1.8.0 -KubeConfigPath .\antrea-agent.kubeconfig `
+  -AntreaKubeConfigPath .\antrea-agent.antrea.kubeconfig
+```
+
+## Troubleshoot VM Agent
+
+Run the `ovs-vsctl show` command on the VM, to validate the interface is moved
+into OVS.
+
+```text
+root@ip-10-0-1-45:~# ovs-vsctl show
+2d2efb51-3f63-4413-8a6e-ee27a7707da9
+    Bridge br-int
+        datapath_type: system
+        Port "eth0~"
+            Interface "eth0~"
+        Port eth0
+            Interface eth0
+                type: internal
+    ovs_version: "2.13.8"
+```
+
+### Linux VM
+
+- The `antrea-agent` logs are located in `/var/log/antrea/antrea-agent.log`.
+- The `antrea-agent` configuration files are located in `/etc/antrea`.
+
+### Windows VM
+
+- The `antrea-agent` logs are located in `C:\antrea-agent\logs`.
+- The `antrea-agent` configuration files are located in `C:\antrea-agent\conf`.

--- a/hack/install-wrapper.ps1
+++ b/hack/install-wrapper.ps1
@@ -1,0 +1,196 @@
+<#
+  .SYNOPSIS
+  Installs Antrea-Agent on Public Cloud VMs.
+
+  .PARAMETER Namespace
+  ExternalNode Namespace to be used.
+
+  .PARAMETER AntreaVersion
+  Antrea version to be used.
+
+  .PARAMETER KubeConfigPath
+  Specifies the path of the kubeconfig to access K8s API Server.
+
+  .PARAMETER AntreaKubeConfigPath
+  Specifies the path of the kubeconfig to access Antrea API Server.
+#>
+Param(
+    [parameter(Mandatory = $true)] [string] $Namespace,
+    [parameter(Mandatory = $true)] [string] $AntreaVersion,
+    [parameter(Mandatory = $true)] [string] $KubeConfigPath,
+    [parameter(Mandatory = $true)] [string] $AntreaKubeConfigPath
+)
+
+$ErrorActionPreference = "Stop"
+
+# System related.
+$SystemDrive = [environment]::GetEnvironmentVariable("SystemDrive")
+$AntreaTemp =  $SystemDrive + "\antrea-tmp"
+$WorkDir = [System.IO.Path]::GetDirectoryName($myInvocation.MyCommand.Definition)
+$InstallLog = "$WorkDir\nephe-install.Log"
+$OSVersion = ""
+
+# Antrea constants.
+$AntreaAgentBin = "antrea-agent.exe"
+$AntreaAgentConf = "antrea-agent.conf"
+$InstallScript = "install-vm.ps1"
+
+# Cloud specific constants
+$AWS = "AWS"
+$AZURE = "Azure"
+$AWSMetaRoot = "http://169.254.169.254/latest/meta-data"
+$AzureMetaRoot = "http://169.254.169.254/metadata"
+$Cloud = ""
+
+# Antrea
+$AntreaBranch = ""
+$AntreaInstallScript = ""
+$AntreaConfig = ""
+$AgentBin = ""
+$Nodename = ""
+
+function ExitOnError() {
+    exit 1
+}
+
+trap {
+    Write-Output "Operation failed. Please look at $InstallLog for more information."
+    Write-Output $_
+    Log $_
+    ExitOnError
+}
+
+function Log($Info) {
+    $time = $(get-date -Format g)
+    "$time $Info " | Tee-Object $InstallLog -Append | Write-Host
+}
+
+function RemoveIfExists($path, $force=$true, $recurse=$false) {
+    $cmd = "Remove-Item `"$path`""
+    if ($force) {
+        $cmd = $cmd + " -Force"
+    }
+    if ($recurse) {
+        $cmd = $cmd + " -Recurse"
+    }
+    if (Test-Path -Path $path) {
+        iex $cmd
+    }
+}
+
+function SetOSVersion() {
+    $version = [System.Environment]::OSVersion.Version
+    $Script:OSVersion = $version.Major.ToString() + "." + $version.Minor.ToString() + "." +
+                            $version.Build.ToString()
+}
+
+function InitCloud() {
+    $version = (Get-WmiObject -class Win32_ComputerSystemProduct -namespace root\CIMV2).Version
+    $vendor = (Get-WmiObject -class Win32_ComputerSystemProduct -namespace root\CIMV2).Vendor
+    if ($version.ToLower().Contains("amazon")) {
+        $script:Cloud = $AWS
+    } elseif ($vendor -like "*Microsoft*Corporation") {
+        $script:Cloud = $AZURE
+    } else {
+        Log "Error unknown cloud platform. Only $AWS and $AZURE clouds are supported"
+        ExitOnError
+    }
+}
+
+function UpdateAntreaURL() {
+    $branchTag = $AntreaVersion.Substring(1,3)
+    $Script:AntreaBranch = "release-${branchTag}"
+    $Script:AntreaInstallScript = "https://raw.githubusercontent.com/antrea-io/antrea/${AntreaBranch}/hack/externalnode/install-vm.ps1"
+    $Script:AntreaConfig = "https://raw.githubusercontent.com/antrea-io/antrea/${AntreaBranch}/build/yamls/externalnode/conf/antrea-agent.conf"
+    $Script:AgentBin = "https://github.com/antrea-io/antrea/releases/download/${AntreaVersion}/antrea-agent-windows-x86_64.exe"
+}
+
+function GenerateNodename() {
+    $name = $null
+    $retries = 5
+    if ($Cloud -eq $AWS) {
+        for ($i = 0; $i -lt $retries; $i++) {
+            try {
+                $endPoint = "$AWSMetaRoot/instance-id"
+                # NodeName is represented as virtualmachine-<instance-id>
+                $name = "virtualmachine-" + (Invoke-WebRequest -uri $endPoint).Content
+                break
+            } catch {
+                Log "Retrying query for $endPoint, attempt=$i"
+                Start-Sleep -Seconds 5
+                continue
+            }
+        }
+    } elseif ($Cloud -eq $AZURE) {
+        $vmId = ""
+        $vmName = ""
+        for ($i=0; $i -lt $retries; $i++) {
+            try {
+                $endPoint = "$AzureMetaRoot/instance/compute/resourceId?api-version=2021-01-01&format=text"
+                $vmId = (Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -Uri $endPoint).ToLower()
+                $endPoint = "$AzureMetaRoot/instance/compute/name?api-version=2021-01-01&format=text"
+                $vmName = (Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -Uri $endPoint).ToLower()
+                break
+            } catch {
+                Log "Retrying query for $endPoint, attempt=$i"
+                Start-Sleep -Seconds 5
+                continue
+            }
+        }
+        # Convert to ASCII
+        $vmIdAscii = [int[]][char[]]$vmId
+        # Compute sum of ASCII values of vmId
+        $sum=0
+        foreach ($i in $vmIdAscii) {
+            $sum = $sum + $i
+        }
+        # NodeName is represented as virtualmachine-<vm-name>-<hash of the VM resource ID>
+        $name = "virtualmachine-" + $vmName + "-" + $sum
+    }
+    $Script:Nodename = $name
+    if ($null -eq $Nodename) {
+        Log "Error Nodename cannot be empty for cloud $Cloud"
+        ExitOnError
+    }
+}
+
+function DownloadFile($src, $dst) {
+    Log "Downloading file $src to $dst"
+    $retries = 3
+    for ($i = 1; $i -le $retries; $i++) {
+        try {
+            # Redirection option is required to download large files.
+            $options = @("-s", "-L")
+            curl.exe $options "$src" -o "$dst"
+        } catch {
+            Log "Failed to download file $src to $dst, retry $i"
+            if ($i -ge $retries) {
+                Log "Error failed to download file $src after $retries attempts"
+                ExitOnError
+            }
+        }
+    }
+}
+
+function DownloadAntreaFiles() {
+    RemoveIfExists $AntreaTemp -recurse $true
+    New-Item $AntreaTemp -type directory -Force | Out-Null
+    DownloadFile $AntreaInstallScript $AntreaTemp\$InstallScript
+    DownloadFile $AntreaConfig $AntreaTemp\$AntreaAgentConf
+    DownloadFile $AgentBin $AntreaTemp\$AntreaAgentBin
+}
+
+function Install() {
+    SetOSVersion
+    Log "Installing antrea-agent on Windows $OSVersion, cloud $Cloud"
+    UpdateAntreaURL
+    DownloadAntreaFiles
+    GenerateNodename
+    Log "Set Environment variable NODE_NAME=$NodeName"
+    $InstallArgs = "-NameSpace $NameSpace -BinaryPath $AntreaTemp\$AntreaAgentBin -ConfigPath $AntreaTemp\$AntreaAgentConf -KubeConfigPath $KubeConfigPath -AntreaKubeConfigPath $AntreaKubeConfigPath -NodeName $NodeName"
+    Invoke-Expression "& `"$AntreaTemp\$InstallScript`" $InstallArgs"
+    RemoveIfExists $AntreaTemp -recurse $true
+}
+
+InitCloud
+Install

--- a/hack/install-wrapper.sh
+++ b/hack/install-wrapper.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+# Constants.
+ANTREA_AGENT_BIN="antrea-agent"
+ANTREA_AGENT_CONF="antrea-agent.conf"
+INSTALL_SCRIPT="install-vm.sh"
+
+# Cloud specific constants.
+AWS="AWS"
+AZURE="AZURE"
+AWS_METADATA_QUERY_ID="http://169.254.169.254/latest/meta-data/instance-id"
+AZURE_METADATA_QUERY_ID="http://169.254.169.254/metadata/instance/compute/resourceId?api-version=2021-02-01&format=text"
+AZURE_METADATA_QUERY_NAME="http://169.254.169.254/metadata/instance/compute/name?api-version=2021-02-01&format=text"
+
+# Platform specific
+OS=""
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information"
+}
+
+_usage="Usage: $0 [arguments]
+
+Downloads install script from Antrea and setup antrea-agent on AWS or Azure VM.
+
+[arguments]
+        --ns <Namespace>                                Namespace to be used by the antrea-agent.
+        --kubeconfig <KubeconfigSavePath>               Path of the kubeconfig to access K8s API Server.
+        --antrea-kubeconfig <AntreaKubeconfigSavePath>  Path of the kubeconfig to access Antrea API Server.
+        --antrea-version <Version>                      Antrea version to be used.
+        --bin <AntreaAgentSavePath>                     Path of the antrea-agent binary(Temporary).
+        --help, -h                                      Print this message and exit."
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --ns)
+    NAMESPACE="$2"
+    shift 2
+    ;;
+    --kubeconfig)
+    KUBECONFIG="$2"
+    shift 2
+    ;;
+    --antrea-kubeconfig)
+    ANTREA_KUBECONFIG="$2"
+    shift 2
+    ;;
+    --antrea-version)
+    ANTREA_VERSION="$2"
+    shift 2
+    ;;
+    --bin)
+    AGENT_BIN="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    print_help
+    exit 1
+    ;;
+esac
+done
+
+if [ -z "$ANTREA_VERSION" ] || [ -z "$NAMESPACE" ] || [ -z "$KUBECONFIG" ] || [ -z "$ANTREA_KUBECONFIG" ]; then
+  echoerr "Required fields are not set"
+  print_usage
+  exit 1
+fi
+
+function get_cloud_platform() {
+    cat /sys/class/dmi/id/bios_version | grep -iq "amazon"
+    if [ $? -eq 0 ]; then
+        echo -n "$AWS"
+        return
+    fi
+    cat /sys/class/dmi/id/bios_vendor | grep -iq "amazon"
+    if [ $? -eq 0 ]; then
+        echo -n "$AWS"
+        return
+    fi
+    cat /sys/class/dmi/id/sys_vendor | grep -iq "microsoft"
+    if [ $? -eq 0 ]; then
+        echo -n "$AZURE"
+        return
+    fi
+}
+
+function check_os_prerequisites() {
+    CLOUD=$(get_cloud_platform)
+    if [ -z "$CLOUD" ]; then
+        echoerr "Unknown cloud platform. Only AWS and Azure Clouds are supported"
+        exit 2
+    fi
+    OS=$(grep -Po '^ID=\K.*' /etc/os-release | sed -e 's/^"//' -e 's/"$//')
+    echo "Installing antrea-agent on $OS, cloud $CLOUD"
+    case "$OS" in
+        ubuntu)
+          return
+        ;;
+    esac
+    echoerr "Unsupported $OS platform"
+    exit 2
+}
+
+function install_curl() {
+    echo "Installing curl in $OS"
+    case "$OS" in
+        ubuntu)
+            cmd="apt-get install curl -y"
+            timeout --preserve-status --foreground 1m $cmd
+            if [ $? -ne 0 ]; then
+                echoerr "$cmd failed with status $ret at $(date)"
+                echoerr "Exiting!! please check internet connectivity and re-run install script"
+                exit 2
+            fi
+        ;;
+    esac
+}
+
+function install_required_packages() {
+    if ! command -v curl &> /dev/null; then
+        install_curl
+    fi
+}
+
+function update_antrea_url() {
+    ANTREA_BRANCH="release-$(echo $ANTREA_VERSION | cut -b 2-4)"
+    ANTREA_INSTALL_SCRIPT="https://raw.githubusercontent.com/antrea-io/antrea/${ANTREA_BRANCH}/hack/externalnode/install-vm.sh"
+    ANTREA_CONFIG="https://raw.githubusercontent.com/antrea-io/antrea/${ANTREA_BRANCH}/build/yamls/externalnode/conf/antrea-agent.conf"
+    if [ -z "$AGENT_BIN" ]; then
+        echo "Uncomment and update the url post antrea 1.9 release"
+        #AGENT_BIN="https://github.com/antrea-io/antrea/releases/download/${ANTREA_VERSION}/antrea-agent-x86_64"
+    fi
+}
+
+function download_file() {
+    from=$1
+    to=$2
+    echo "Downloading file $from to $to"
+    curl --connect-timeout 30 -# --retry 3 "$from" --output "$to"
+    if [ $? -ne 0 ]; then
+        echoerr "Failed to download file $from"
+        exit 2
+    fi
+}
+
+function download_antrea_files() {
+    # Create a temp directory.
+    tmp_dir=$( mktemp -d )
+    if [ $? -ne 0 ]; then
+        echoerr "Failed to create a temporary directory, rc $?"
+        exit 2
+    fi
+    download_file "${ANTREA_INSTALL_SCRIPT}" "${tmp_dir}"/${INSTALL_SCRIPT}
+    download_file "${ANTREA_CONFIG}" "${tmp_dir}"/${ANTREA_AGENT_CONF}
+    # TODO: Cleanup post antrea 1.9 release.
+    if [ -f "$AGENT_BIN" ]; then
+        # Temporary solution to use antrea-agent binary from local.
+        cp "$AGENT_BIN" "${tmp_dir}"/${ANTREA_AGENT_BIN}
+    else
+        download_file "${AGENT_BIN}" "${tmp_dir}"/${ANTREA_AGENT_BIN}
+    fi
+}
+
+function generate_nodename() {
+    if [ "$CLOUD" == $AWS ]; then
+        # NodeName is represented as virtualmachine-<instance-id>
+        NODENAME="virtualmachine-$(curl ${AWS_METADATA_QUERY_ID})"
+    elif [ "$CLOUD" == $AZURE ]; then
+        vm_name=$(curl -s -H Metadata:true "${AZURE_METADATA_QUERY_NAME}")
+        vm_id=$(curl -sS -H Metadata:true "${AZURE_METADATA_QUERY_ID}")
+        # Convert to lowercase
+        vm_name=$(echo -n "$vm_name" | tr '[:upper:]' '[:lower:]')
+        vm_id=$(echo -n "$vm_id" | tr '[:upper:]' '[:lower:]')
+        # Convert to ASCII
+        vm_id_ascci=$(echo -n "$vm_id" | od  -An -tu1)
+        # Remove leading/trailing spaces
+        vm_id_ascci=$(echo "$vm_id_ascci" | sed 's/ *$//g')
+        # Compute sum of ASCII values of vm_id
+        sum=0
+        IFS=" "
+        for i in $vm_id_ascci
+        do
+            sum=$(($sum + $i))
+        done
+        # NodeName is represented as virtualmachine-<vm-name>-<hash of the VM resource ID>
+        NODENAME="virtualmachine-${vm_name}-${sum}"
+    fi
+
+    if [ -z "$NODENAME" ]; then
+        echoerr "NODENAME cannot be empty for cloud $CLOUD"
+        exit 2
+    fi
+}
+
+function install() {
+    echo "Running antrea $INSTALL_SCRIPT script"
+    chmod +x "${tmp_dir}"/$INSTALL_SCRIPT
+    "${tmp_dir}"/$INSTALL_SCRIPT --ns "$NAMESPACE" --bin "${tmp_dir}"/${ANTREA_AGENT_BIN} \
+    --config "${tmp_dir}"/${ANTREA_AGENT_CONF} --kubeconfig "$KUBECONFIG" \
+    --antrea-kubeconfig "$ANTREA_KUBECONFIG" --nodename "$NODENAME"
+    echo "Set antrea-agent Service Environment variable NODE_NAME=$NODENAME"
+    # Delete the temporary directory.
+    rm -rf "${tmp_dir}"
+}
+
+check_os_prerequisites
+install_required_packages
+update_antrea_url
+download_antrea_files
+generate_nodename
+install

--- a/pkg/cloud-provider/cloudapi/aws/aws_crd_helpers.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_crd_helpers.go
@@ -15,6 +15,8 @@
 package aws
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"antrea.io/nephe/apis/crd/v1alpha1"
@@ -70,6 +72,7 @@ func ec2InstanceToVirtualMachineCRD(instance *ec2.Instance, namespace string, ac
 	cloudID := *instance.InstanceId
 	cloudNetwork := *instance.VpcId
 
-	return utils.GenerateVirtualMachineCRD(cloudID, cloudName, cloudID, namespace, cloudNetwork, cloudNetwork,
-		v1alpha1.VMState(*instance.State.Name), tags, networkInterfaces, providerType, accountId)
+	return utils.GenerateVirtualMachineCRD(cloudID, strings.ToLower(cloudName), strings.ToLower(cloudID), namespace,
+		strings.ToLower(cloudNetwork), cloudNetwork, v1alpha1.VMState(*instance.State.Name), tags, networkInterfaces,
+		providerType, accountId)
 }

--- a/pkg/cloud-provider/utils/crd_generator.go
+++ b/pkg/cloud-provider/utils/crd_generator.go
@@ -34,6 +34,7 @@ func GenerateVirtualMachineCRD(crdName string, cloudName string, cloudID string,
 		Tags:                tags,
 		State:               state,
 		NetworkInterfaces:   networkInterfaces,
+		Agented:             false,
 	}
 	annotationsMap := map[string]string{
 		cloudcommon.AnnotationCloudAssignedIDKey:    cloudID,

--- a/pkg/controllers/cloud/virtualmachine_controller.go
+++ b/pkg/controllers/cloud/virtualmachine_controller.go
@@ -15,16 +15,18 @@
 package cloud
 
 import (
-	cloudv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
-	converter "antrea.io/nephe/pkg/converter/source"
-	"antrea.io/nephe/pkg/logging"
 	"context"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cloudv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
+	converter "antrea.io/nephe/pkg/converter/source"
+	"antrea.io/nephe/pkg/logging"
 )
 
 // VirtualMachineReconciler reconciles a VirtualMachine object.
@@ -48,7 +50,7 @@ func (r *VirtualMachineReconciler) Reconcile(_ context.Context, req ctrl.Request
 			return ctrl.Result{}, err
 		}
 		// Fall through if owner is deleted.
-		r.Log.V(1).Info("Is delete")
+		r.Log.V(1).Info("Is delete", "vm", req.NamespacedName)
 		accessor, _ := meta.Accessor(&virtualMachine)
 		accessor.SetName(req.Name)
 		accessor.SetNamespace(req.Namespace)

--- a/pkg/converter/source/converter_source_suite_test.go
+++ b/pkg/converter/source/converter_source_suite_test.go
@@ -38,12 +38,18 @@ var (
 	mockClient                  *controllerruntimeclient.MockClient
 	scheme                      = runtime.NewScheme()
 	networkInterfaceIPAddresses = []string{"1.1.1.1", "2.2.2.2"}
-	testNamespace               = "test-namespace"
-	emptyExternalEntitySources  = map[string]target.ExternalEntitySource{
+	// Used by ExternalNode.
+	networkInterfaceNames      = []string{"nic0"}
+	testNamespace              = "test-namespace"
+	emptyExternalEntitySources = map[string]target.ExternalEntitySource{
+		"VirtualMachine": &source.VirtualMachineSource{},
+	}
+	emptyExternalNodeSources = map[string]target.ExternalNodeSource{
 		"VirtualMachine": &source.VirtualMachineSource{},
 	}
 
 	externalEntitySources map[string]target.ExternalEntitySource
+	externalNodeSources   map[string]target.ExternalNodeSource
 )
 
 var _ = BeforeSuite(func() {
@@ -58,6 +64,7 @@ func commonInitTest() {
 	mockCtrl = mock.NewController(GinkgoT())
 	mockClient = controllerruntimeclient.NewMockClient(mockCtrl)
 	externalEntitySources = testing2.SetupExternalEntitySources(networkInterfaceIPAddresses, testNamespace)
+	externalNodeSources = testing2.SetupExternalNodeSources(networkInterfaceIPAddresses, testNamespace)
 }
 
 // Testing converting source crd to target crd

--- a/pkg/converter/source/export_test.go
+++ b/pkg/converter/source/export_test.go
@@ -24,8 +24,8 @@ var (
 
 type RetryRecord = retryRecord
 
-func ProcessEvent(v VMConverter, vm *VirtualMachineSource, failedUpdates map[string]retryRecord, isRetry bool) {
-	v.processEvent(vm, failedUpdates, isRetry)
+func ProcessEvent(v VMConverter, vm *VirtualMachineSource, failedUpdates map[string]retryRecord, isRetry bool, isAgented bool) {
+	v.processEvent(vm, failedUpdates, isRetry, isAgented)
 }
 
 func (v VMConverter) GetRetryCh() chan cloudv1alpha1.VirtualMachine {

--- a/pkg/converter/source/virtualmachine.go
+++ b/pkg/converter/source/virtualmachine.go
@@ -39,6 +39,11 @@ func (v *VirtualMachineSource) GetEndPointAddresses() ([]string, error) {
 	return ip, nil
 }
 
+// GetNetworkInterfaces returns VirtualMachine's IP addresses.
+func (v *VirtualMachineSource) GetNetworkInterfaces() ([]v1alpha1.NetworkInterface, error) {
+	return v.Status.NetworkInterfaces, nil
+}
+
 // GetEndPointPort returns nil as VirtualMachine has no associated port.
 func (v *VirtualMachineSource) GetEndPointPort(_ client.Client) []antreatypes.NamedPort {
 	return nil
@@ -54,13 +59,13 @@ func (v *VirtualMachineSource) GetLabelsFromClient(_ client.Client) map[string]s
 	return map[string]string{config.ExternalEntityLabelCloudVPCKey: v.Status.VirtualPrivateCloud}
 }
 
-// GetExternalNode returns external node/controller associated with VirtualMachine.
-func (v *VirtualMachineSource) GetExternalNode(_ client.Client) string {
+// GetExternalNodeName returns controller associated with VirtualMachine.
+func (v *VirtualMachineSource) GetExternalNodeName(_ client.Client) string {
 	return config.ANPNepheController
 }
 
 // Copy returns a duplicate of VirtualMachineSource.
-func (v *VirtualMachineSource) Copy() target.ExternalEntitySource {
+func (v *VirtualMachineSource) Copy() (duplicate interface{}) {
 	newVM := &VirtualMachineSource{}
 	v.VirtualMachine.DeepCopyInto(&newVM.VirtualMachine)
 	return newVM
@@ -77,5 +82,6 @@ func (v *VirtualMachineSource) IsFedResource() bool {
 
 var (
 	_ target.ExternalEntitySource = &VirtualMachineSource{}
+	_ target.ExternalNodeSource   = &VirtualMachineSource{}
 	_ client.Object               = &VirtualMachineSource{}
 )

--- a/pkg/converter/source/virtualmachine_converter.go
+++ b/pkg/converter/source/virtualmachine_converter.go
@@ -50,7 +50,7 @@ func (v VMConverter) Start() {
 		select {
 		case recv, ok := <-v.Ch:
 			if !ok {
-				v.Log.Info("vm converter channel closed")
+				v.Log.Info("VM converter channel closed")
 				return
 			}
 			vm := &VirtualMachineSource{recv}
@@ -72,12 +72,12 @@ func (v VMConverter) processEvent(vm *VirtualMachineSource, failedUpdates map[st
 	} else {
 		fetchKey = target.GetExternalEntityKeyFromSource(vm)
 	}
-	log.Info("received event", "Key", fetchKey, "Agented", isAgent)
+	log.Info("Received event", "Key", fetchKey, "Agented", isAgent)
 	if isRetry {
 		retry, ok := failedUpdates[fetchKey.String()]
 		// ignore event if newer event succeeds or newer event retrying
 		if !ok || v.isNewEvent(retry.item.(*VirtualMachineSource), vm) {
-			log.Info("ignore retry", "Key", fetchKey, "retryCount", retry.retryCount)
+			log.Info("Ignore retry", "Key", fetchKey, "retryCount", retry.retryCount)
 			return
 		}
 	}
@@ -95,7 +95,7 @@ func (v VMConverter) processEvent(vm *VirtualMachineSource, failedUpdates map[st
 		}
 		record.retryCount += 1
 		if record.retryCount >= maxRetry {
-			log.Info("max retry reached, ignoring", "Key", fetchKey, "maxRetry", maxRetry)
+			log.Info("Max retry reached, ignoring", "Key", fetchKey, "maxRetry", maxRetry)
 			delete(failedUpdates, fetchKey.String())
 			return
 		}
@@ -108,7 +108,7 @@ func (v VMConverter) processEvent(vm *VirtualMachineSource, failedUpdates map[st
 	ctx := context.Background()
 	ips, err := vm.GetEndPointAddresses()
 	if err != nil {
-		log.Info("failed to get IP address for", "Name", fetchKey, "err", err)
+		log.Info("Failed to get IP address for", "Name", fetchKey, "err", err)
 		return
 	}
 
@@ -146,7 +146,7 @@ func (v VMConverter) processEvent(vm *VirtualMachineSource, failedUpdates map[st
 		if err != nil {
 			log.Error(err, "unable to delete ", "Key", fetchKey)
 		} else {
-			log.V(1).Info("deleted resource", "Key", fetchKey)
+			log.V(1).Info("Deleted resource", "Key", fetchKey)
 		}
 		return
 	}
@@ -165,7 +165,7 @@ func (v VMConverter) processEvent(vm *VirtualMachineSource, failedUpdates map[st
 		if err != nil {
 			log.Error(err, "unable to patch ", "Key", fetchKey)
 		} else {
-			log.V(1).Info("patched resource", "Key", fetchKey)
+			log.V(1).Info("Patched resource", "Key", fetchKey)
 		}
 		return
 	}
@@ -181,7 +181,7 @@ func (v VMConverter) processEvent(vm *VirtualMachineSource, failedUpdates map[st
 	if err != nil {
 		log.Error(err, "unable to create ", "Key", fetchKey)
 	} else {
-		log.V(1).Info("created resource", "Key", fetchKey)
+		log.V(1).Info("Created resource", "Key", fetchKey)
 	}
 }
 

--- a/pkg/converter/source/virtualmachine_test.go
+++ b/pkg/converter/source/virtualmachine_test.go
@@ -31,21 +31,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	antreatypes "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	antreav1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	antreav1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	cloudv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
 	"antrea.io/nephe/pkg/controllers/config"
 	"antrea.io/nephe/pkg/converter/source"
 	"antrea.io/nephe/pkg/converter/target"
 )
 
-var _ = Describe("VirtualmachineConverter", func() {
+var _ = Describe("VirtualMachineConverter", func() {
 
 	var (
 		// Test framework.
 		converter source.VMConverter
 
 		// Test parameters.
-		expectedExternalEntities = make(map[string]*antreatypes.ExternalEntity)
+		expectedExternalEntities = make(map[string]*antreav1alpha2.ExternalEntity)
+		expectedExternalNodes    = make(map[string]*antreav1alpha1.ExternalNode)
 
 		// Test tunable.
 		useInternalMethod      bool
@@ -54,6 +56,9 @@ var _ = Describe("VirtualmachineConverter", func() {
 		expectExternalEntityOp bool
 		externalEntityOpError  error
 		expectWaiTime          time.Duration
+
+		expectExternalNodeOp bool
+		externalNodeOpError  error
 	)
 
 	BeforeEach(func() {
@@ -67,21 +72,25 @@ var _ = Describe("VirtualmachineConverter", func() {
 		useInternalMethod = true
 		isEmptyEvent = false
 		generateEvent = true
+		// ExternalEntity
 		expectExternalEntityOp = true
 		externalEntityOpError = nil
+		// ExternalNode
+		expectExternalNodeOp = true
+		externalNodeOpError = nil
 		expectWaiTime = source.RetryInterval
 
 		go converter.Start()
 
 		// Setup expected ExternalEntity from source resources.
 		for name, externalEntitySource := range externalEntitySources {
-			ee := &antreatypes.ExternalEntity{}
-			fetchKey := target.GetObjectKeyFromSource(externalEntitySource)
+			ee := &antreav1alpha2.ExternalEntity{}
+			fetchKey := target.GetExternalEntityKeyFromSource(externalEntitySource)
 			ee.Name = fetchKey.Name
 			ee.Namespace = fetchKey.Namespace
-			eps := make([]antreatypes.Endpoint, 0)
+			eps := make([]antreav1alpha2.Endpoint, 0)
 			for _, ip := range networkInterfaceIPAddresses {
-				eps = append(eps, antreatypes.Endpoint{IP: ip})
+				eps = append(eps, antreav1alpha2.Endpoint{IP: ip})
 			}
 			ee.Spec.Endpoints = eps
 			ee.Spec.Ports = externalEntitySource.GetEndPointPort(nil)
@@ -102,13 +111,45 @@ var _ = Describe("VirtualmachineConverter", func() {
 			ee.Spec.ExternalNode = config.ANPNepheController
 			expectedExternalEntities[name] = ee
 		}
+
+		// Setup expected ExternalNode from source resources.
+		for name, externalNodeSource := range externalNodeSources {
+			en := &antreav1alpha1.ExternalNode{}
+			fetchKey := target.GetExternalNodeKeyFromSource(externalNodeSource)
+			en.Name = fetchKey.Name
+			en.Namespace = fetchKey.Namespace
+			labels := make(map[string]string)
+			accessor, _ := meta.Accessor(externalNodeSource)
+			labels[config.ExternalEntityLabelKeyKind] = target.GetExternalEntityLabelKind(externalNodeSource.EmbedType())
+			labels[config.ExternalEntityLabelKeyName] = strings.ToLower(accessor.GetName())
+			labels[config.ExternalEntityLabelKeyNamespace] = strings.ToLower(accessor.GetNamespace())
+			for k, v := range externalNodeSource.GetLabelsFromClient(nil) {
+				labels[k] = v
+			}
+			accessor, _ = meta.Accessor(externalNodeSource.EmbedType())
+			_ = controllerruntime.SetControllerReference(accessor, en, scheme)
+			for k, v := range externalNodeSource.GetTags() {
+				labels[k+config.ExternalEntityLabelKeyTagPostfix] = v
+			}
+			en.Labels = labels
+			// Currently only one NetworkInterface with multiple IPs is supported.
+			networkInterface := make([]antreav1alpha1.NetworkInterface, 0, len(networkInterfaceNames))
+			for _, name := range networkInterfaceNames {
+				networkInterface = append(networkInterface, antreav1alpha1.NetworkInterface{
+					Name: name,
+					IPs:  networkInterfaceIPAddresses,
+				})
+			}
+			en.Spec.Interfaces = networkInterface
+			expectedExternalNodes[name] = en
+		}
 	})
 
 	AfterEach(func() {
 		mockCtrl.Finish()
 	})
 
-	Describe("processEvent", func() {
+	Describe("processEvent for ExternalEntity", func() {
 		var (
 			externalEntityGetErr error
 			failedUpdates        map[string]source.RetryRecord
@@ -123,14 +164,14 @@ var _ = Describe("VirtualmachineConverter", func() {
 				externalEntitySource = emptyExternalEntitySources[name]
 			}
 
-			fetchKey := target.GetObjectKeyFromSource(externalEntitySource)
+			fetchKey := target.GetExternalEntityKeyFromSource(externalEntitySource)
 			orderedCalls := make([]*mock.Call, 0)
 
 			// Determine ExternalEntity source exits.
 			orderedCalls = append(orderedCalls,
 				mockClient.EXPECT().Get(mock.Any(), fetchKey, mock.Any()).
 					Return(externalEntityGetErr).
-					Do(func(_ context.Context, _ client.ObjectKey, ee *antreatypes.ExternalEntity) {
+					Do(func(_ context.Context, _ client.ObjectKey, ee *antreav1alpha2.ExternalEntity) {
 						expectedExternalEntities[name].DeepCopyInto(ee)
 						outstandingExpects--
 						if outstandingExpects == 0 {
@@ -181,7 +222,7 @@ var _ = Describe("VirtualmachineConverter", func() {
 
 			if generateEvent {
 				if useInternalMethod {
-					source.ProcessEvent(converter, externalEntitySource.(*source.VirtualMachineSource), failedUpdates, isRetry)
+					source.ProcessEvent(converter, externalEntitySource.(*source.VirtualMachineSource), failedUpdates, isRetry, false)
 				} else {
 					converter.Ch <- externalEntitySource.(*source.VirtualMachineSource).VirtualMachine
 				}
@@ -274,6 +315,7 @@ var _ = Describe("VirtualmachineConverter", func() {
 					table.Entry("VirtualMachineSource", "VirtualMachine"),
 				)
 			})
+
 			Context("Should patch when ExternalEntity is found", func() {
 				table.DescribeTable("When source is",
 					func(name string) {
@@ -300,6 +342,189 @@ var _ = Describe("VirtualmachineConverter", func() {
 						generateEvent = false
 						expectWaiTime = source.RetryInterval + time.Second*10
 						tester(name, "delete")
+					},
+					table.Entry("VirtualMachineSource", "VirtualMachine"),
+				)
+			})
+		})
+	})
+
+	Describe("processEvent for ExternalNode", func() {
+		var (
+			externalNodeGetErr error
+			failedUpdates      map[string]source.RetryRecord
+			isRetry            bool
+		)
+
+		tester := func(name string, op string) {
+			finished := make(chan struct{}, 1)
+			outstandingExpects := 0
+			externalNodeSource := externalNodeSources[name]
+			if isEmptyEvent {
+				externalNodeSource = emptyExternalNodeSources[name]
+			}
+
+			fetchKey := target.GetExternalNodeKeyFromSource(externalNodeSource)
+			orderedCalls := make([]*mock.Call, 0)
+
+			// Determine ExternalNode source exits.
+			orderedCalls = append(orderedCalls,
+				mockClient.EXPECT().Get(mock.Any(), fetchKey, mock.Any()).
+					Return(externalNodeGetErr).
+					Do(func(_ context.Context, _ client.ObjectKey, en *antreav1alpha1.ExternalNode) {
+						expectedExternalNodes[name].DeepCopyInto(en)
+						outstandingExpects--
+						if outstandingExpects == 0 {
+							finished <- struct{}{}
+						}
+					}))
+
+			if expectExternalNodeOp {
+				if op == "create" {
+					orderedCalls = append(orderedCalls,
+						mockClient.EXPECT().Create(mock.Any(), mock.Any()).
+							Return(externalNodeOpError).
+							Do(func(_ context.Context, obj runtime.Object) {
+								Expect(obj).To(Equal(expectedExternalNodes[name]))
+								outstandingExpects--
+								if outstandingExpects == 0 {
+									finished <- struct{}{}
+								}
+							}))
+				} else if op == "patch" {
+					orderedCalls = append(orderedCalls,
+						mockClient.EXPECT().Patch(mock.Any(), mock.Any(), mock.Any()).
+							Return(externalNodeOpError).
+							Do(func(_ context.Context, patch runtime.Object, _ client.Patch) {
+								Expect(patch).To(Equal(expectedExternalNodes[name]))
+								outstandingExpects--
+								if outstandingExpects == 0 {
+									finished <- struct{}{}
+								}
+							}))
+
+				} else if op == "delete" {
+					orderedCalls = append(orderedCalls,
+						mockClient.EXPECT().Delete(mock.Any(), mock.Any()).
+							Return(externalNodeOpError).
+							Do(func(_ context.Context, obj runtime.Object) {
+								Expect(obj).To(Equal(expectedExternalNodes[name]))
+								outstandingExpects--
+								if outstandingExpects == 0 {
+									finished <- struct{}{}
+								}
+							}))
+
+				}
+			}
+			mock.InOrder(orderedCalls...)
+			outstandingExpects = len(orderedCalls)
+
+			if generateEvent {
+				if useInternalMethod {
+					source.ProcessEvent(converter, externalNodeSource.(*source.VirtualMachineSource), failedUpdates, isRetry, true)
+				} else {
+					converter.Ch <- externalNodeSource.(*source.VirtualMachineSource).VirtualMachine
+				}
+			}
+
+			select {
+			case <-finished:
+				logf.Log.Info("All expectations are met")
+			case <-time.After(expectWaiTime):
+				logf.Log.Info("Test timed out")
+			case <-converter.GetRetryCh():
+				Fail("Received retry event")
+			}
+		}
+
+		BeforeEach(func() {
+			externalNodeGetErr = nil
+			failedUpdates = make(map[string]source.RetryRecord)
+			isRetry = false
+		})
+
+		Context("Should create when ExternalNode is not found", func() {
+			JustBeforeEach(func() {
+				externalNodeGetErr = errors.NewNotFound(schema.GroupResource{}, "")
+			})
+			table.DescribeTable("When source is",
+				func(name string) {
+					tester(name, "create")
+				},
+				table.Entry("VirtualMachineSource", "VirtualMachine"),
+			)
+		})
+
+		Context("Should patch when ExternalNode is found", func() {
+			table.DescribeTable("When source is",
+				func(name string) {
+					tester(name, "patch")
+				},
+				table.Entry("VirtualMachineSource", "VirtualMachine"),
+			)
+		})
+
+		Context("Should delete ExternalNode when source is empty", func() {
+			JustBeforeEach(func() {
+				isEmptyEvent = true
+			})
+			table.DescribeTable("When source is",
+				func(name string) {
+					tester(name, "delete")
+				},
+				table.Entry("VirtualMachineSource", "VirtualMachine"),
+			)
+		})
+
+		Context("Should do nothing if ExternalNode is not found and source is empty", func() {
+			JustBeforeEach(func() {
+				externalNodeGetErr = errors.NewNotFound(schema.GroupResource{}, "")
+				isEmptyEvent = true
+			})
+			table.DescribeTable("When source is",
+				func(name string) {
+					tester(name, "")
+				},
+				table.Entry("VirtualMachineSource", "VirtualMachine"),
+			)
+		})
+
+		Context("Handle error with retry", func() {
+			JustBeforeEach(func() {
+				externalNodeOpError = errors.NewBadRequest("dummy")
+				useInternalMethod = false
+			})
+
+			Context("Should create when ExternalNode is not found", func() {
+				JustBeforeEach(func() {
+					externalNodeGetErr = errors.NewNotFound(schema.GroupResource{}, "")
+				})
+				table.DescribeTable("When source is",
+					func(name string) {
+						tester(name, "create")
+						tester(name, "create")
+						tester(name, "create")
+
+						// a single successful retry cancels all previous failures.
+						externalNodeOpError = nil
+						generateEvent = false
+						expectWaiTime = source.RetryInterval + time.Second*10
+						tester(name, "create")
+					},
+					table.Entry("VirtualMachineSource", "VirtualMachine"),
+				)
+			})
+
+			Context("Should patch when ExternalNode is found", func() {
+				table.DescribeTable("When source is",
+					func(name string) {
+						tester(name, "patch")
+
+						externalNodeOpError = nil
+						generateEvent = false
+						expectWaiTime = source.RetryInterval + time.Second*10
+						tester(name, "patch")
 					},
 					table.Entry("VirtualMachineSource", "VirtualMachine"),
 				)

--- a/pkg/converter/target/common.go
+++ b/pkg/converter/target/common.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package target
+
+import (
+	"antrea.io/nephe/pkg/controllers/config"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetExternalEntityKeyFromSource(source ExternalEntitySource) client.ObjectKey {
+	access, _ := meta.Accessor(source)
+	return client.ObjectKey{Namespace: access.GetNamespace(),
+		Name: getTargetEntityName(source.EmbedType())}
+}
+
+func GetExternalNodeKeyFromSource(source ExternalNodeSource) client.ObjectKey {
+	access, _ := meta.Accessor(source)
+	return client.ObjectKey{Namespace: access.GetNamespace(),
+		Name: getTargetEntityName(source.EmbedType())}
+}
+
+// GetExternalEntityLabelKind returns value of ExternalEntity kind label.
+func GetExternalEntityLabelKind(obj runtime.Object) string {
+	return strings.ToLower(reflect.TypeOf(obj).Elem().Name())
+}
+
+// getTargetEntityName returns the desired name of the target resource.
+func getTargetEntityName(obj runtime.Object) string {
+	access, _ := meta.Accessor(obj)
+	// ExternalNode/ExternalEntity CR name will be vm-<VirtualMachine CR name>.
+	return "vm-" + strings.ToLower(access.GetName())
+}
+
+// genTargetEntityLabels labels for any targets of VirtualMachineSource.
+func genTargetEntityLabels(source interface{}, cl client.Client) map[string]string {
+	// VirtualMachine source implements both ExternalNodeSource and ExternalEntitySource.
+	// Either ExternalEntitySource or ExternalNodeSource can be type cast.
+	vmSource, _ := source.(ExternalEntitySource)
+	labels := make(map[string]string)
+	accessor, _ := meta.Accessor(vmSource)
+	labels[config.ExternalEntityLabelKeyKind] = GetExternalEntityLabelKind(vmSource.EmbedType())
+	labels[config.ExternalEntityLabelKeyName] = strings.ToLower(accessor.GetName())
+	labels[config.ExternalEntityLabelKeyNamespace] = strings.ToLower(accessor.GetNamespace())
+	for key, val := range vmSource.GetLabelsFromClient(cl) {
+		labels[key] = val
+	}
+	for key, val := range vmSource.GetTags() {
+		reg, _ := regexp.Compile(LabelExpression)
+		fkey := reg.ReplaceAllString(key, "") + config.ExternalEntityLabelKeyTagPostfix
+		if len(fkey) > LabelSizeLimit {
+			fkey = fkey[:LabelSizeLimit]
+		}
+		fval := reg.ReplaceAllString(val, "")
+		if len(fval) > LabelSizeLimit {
+			fval = fval[:LabelSizeLimit]
+		}
+		labels[strings.ToLower(fkey)] = strings.ToLower(fval)
+	}
+	return labels
+}

--- a/pkg/converter/target/common.go
+++ b/pkg/converter/target/common.go
@@ -45,8 +45,8 @@ func GetExternalEntityLabelKind(obj runtime.Object) string {
 // getTargetEntityName returns the desired name of the target resource.
 func getTargetEntityName(obj runtime.Object) string {
 	access, _ := meta.Accessor(obj)
-	// ExternalNode/ExternalEntity CR name will be vm-<VirtualMachine CR name>.
-	return "vm-" + strings.ToLower(access.GetName())
+	// ExternalNode/ExternalEntity CR name will be virtualmachine-<VirtualMachine CR name>.
+	return strings.ToLower(reflect.TypeOf(obj).Elem().Name()) + "-" + access.GetName()
 }
 
 // genTargetEntityLabels labels for any targets of VirtualMachineSource.

--- a/pkg/converter/target/externalentity_test.go
+++ b/pkg/converter/target/externalentity_test.go
@@ -15,19 +15,19 @@
 package target_test
 
 import (
-	converter "antrea.io/nephe/pkg/converter/target"
 	"context"
+	"reflect"
+
 	mock "github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	antreatypes "antrea.io/antrea/pkg/apis/crd/v1alpha2"
-
+	antreav1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	cloud "antrea.io/nephe/apis/crd/v1alpha1"
+	target "antrea.io/nephe/pkg/converter/target"
 	"antrea.io/nephe/pkg/testing"
 	"antrea.io/nephe/pkg/testing/controllerruntimeclient"
 )
@@ -44,12 +44,12 @@ var _ = Describe("Externalentity", func() {
 
 		// Test tunable
 		networkInterfaceIPAddresses = []string{"1.1.1.1", "2.2.2.2"}
-		namedports                  = []antreatypes.NamedPort{
+		namedports                  = []antreav1alpha2.NamedPort{
 			{Name: "http", Protocol: v1.ProtocolTCP, Port: 80},
 			{Name: "https", Protocol: v1.ProtocolTCP, Port: 443},
 		}
 
-		externalEntitySources map[string]converter.ExternalEntitySource
+		externalEntitySources map[string]target.ExternalEntitySource
 	)
 
 	BeforeEach(func() {
@@ -83,7 +83,8 @@ var _ = Describe("Externalentity", func() {
 
 	copyTester := func(name string) {
 		externalEntitySource := externalEntitySources[name]
-		dup := externalEntitySource.Copy()
+		temp := externalEntitySource.Copy()
+		dup, _ := temp.(target.ExternalEntitySource)
 		Expect(dup).To(Equal(externalEntitySource))
 	}
 

--- a/pkg/converter/target/externalnode.go
+++ b/pkg/converter/target/externalnode.go
@@ -1,0 +1,81 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package target
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	antreav1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	"antrea.io/nephe/apis/crd/v1alpha1"
+)
+
+type ExternalNodeSource interface {
+	client.Object
+	// GetEndPointAddresses returns IP addresses of ExternalNodeSource.
+	// Passing client in case there are references needs to be retrieved from local cache.
+	GetEndPointAddresses() ([]string, error)
+	// GetNetworkInterfaces returns list of NetworkInterfaces of ExternalNodeSource.
+	GetNetworkInterfaces() ([]v1alpha1.NetworkInterface, error)
+	// GetTags returns tags of ExternalNodeSource.
+	GetTags() map[string]string
+	// GetLabelsFromClient returns labels specific to ExternalNodeSource.
+	GetLabelsFromClient(client client.Client) map[string]string
+	// Copy return a duplicate of current ExternalNodeSource.
+	Copy() (duplicate interface{})
+	// EmbedType returns the underlying ExternalNodeSource source resource.
+	EmbedType() client.Object
+}
+
+// NewExternalNodeFrom generate a new ExternalNode from source.
+func NewExternalNodeFrom(
+	source ExternalNodeSource, name, namespace string, cl client.Client, scheme *runtime.Scheme) *antreav1alpha1.ExternalNode {
+	externalNode := &antreav1alpha1.ExternalNode{}
+	populateExternalNodeFrom(source, externalNode, cl)
+	externalNode.SetName(name)
+	externalNode.SetNamespace(namespace)
+	accessor, _ := meta.Accessor(source.EmbedType())
+	if err := ctrl.SetControllerReference(accessor, externalNode, scheme); err != nil {
+		externalNode.SetName(name)
+		externalNode.SetNamespace(namespace)
+	}
+	return externalNode
+}
+
+// PatchExternalNodeFrom generate a patch for existing ExternalNode from source.
+func PatchExternalNodeFrom(
+	source ExternalNodeSource, patch *antreav1alpha1.ExternalNode, cl client.Client) *antreav1alpha1.ExternalNode {
+	populateExternalNodeFrom(source, patch, cl)
+	return patch
+}
+
+func populateExternalNodeFrom(source ExternalNodeSource, externalNode *antreav1alpha1.ExternalNode, cl client.Client) {
+	externalNode.SetLabels(genTargetEntityLabels(source, cl))
+	interfaces, _ := source.GetNetworkInterfaces()
+	networkInterface := make([]antreav1alpha1.NetworkInterface, 0, len(interfaces))
+	for _, intf := range interfaces {
+		var ips []string
+		for _, ip := range intf.IPs {
+			ips = append(ips, ip.Address)
+		}
+		networkInterface = append(networkInterface, antreav1alpha1.NetworkInterface{
+			Name: intf.Name,
+			IPs:  ips,
+		})
+	}
+	externalNode.Spec.Interfaces = networkInterface
+}

--- a/pkg/converter/target/externalnode_test.go
+++ b/pkg/converter/target/externalnode_test.go
@@ -1,0 +1,111 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package target_test
+
+import (
+	"context"
+	"reflect"
+
+	mock "github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cloud "antrea.io/nephe/apis/crd/v1alpha1"
+	converter "antrea.io/nephe/pkg/converter/target"
+	"antrea.io/nephe/pkg/testing"
+	"antrea.io/nephe/pkg/testing/controllerruntimeclient"
+)
+
+var _ = Describe("ExternalNode", func() {
+	var (
+		// Test framework
+		mockCtrl   *mock.Controller
+		mockclient *controllerruntimeclient.MockClient
+
+		// Test parameters
+		namespace = "test-externalnode-sources-namespace"
+
+		// Test tunable
+		networkInterfaceIPAddresses = []string{"1.1.1.1", "2.2.2.2"}
+		externalNodeSources         map[string]converter.ExternalNodeSource
+	)
+
+	BeforeEach(func() {
+		mockCtrl = mock.NewController(GinkgoT())
+		mockclient = controllerruntimeclient.NewMockClient(mockCtrl)
+		externalNodeSources = testing.SetupExternalNodeSources(networkInterfaceIPAddresses, namespace)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	embedTypeTester := func(name string, expType interface{}) {
+		externalNodeSource := externalNodeSources[name]
+		embed := externalNodeSource.EmbedType()
+		Expect(reflect.TypeOf(embed).Elem()).To(Equal(reflect.TypeOf(expType).Elem()))
+	}
+
+	getTagsTester := func(name string, hasTag bool) {
+		externalNodeSource := externalNodeSources[name]
+		tags := externalNodeSource.GetTags()
+		if hasTag {
+			Expect(tags).ToNot(BeNil())
+		} else {
+			Expect(tags).To(BeNil())
+		}
+	}
+
+	getLabelsTester := func(name string, hasLabels bool) {
+		mockclient.EXPECT().Get(mock.Any(), mock.Any(), mock.Any()).
+			Return(nil).
+			Do(func(_ context.Context, key client.ObjectKey, out *cloud.VirtualMachine) {
+				vm := externalNodeSources["VirtualMachine"].EmbedType().(*cloud.VirtualMachine)
+				Expect(key.Name).To(Equal(vm.Name))
+				Expect(key.Namespace).To(Equal(vm.Namespace))
+				vm.DeepCopyInto(out)
+			}).AnyTimes()
+
+		externalNodeSource := externalNodeSources[name]
+		labels := externalNodeSource.GetLabelsFromClient(mockclient)
+		if hasLabels {
+			Expect(labels).ToNot(BeNil())
+		} else {
+			Expect(labels).To(BeNil())
+		}
+	}
+
+	Context("Source has required information", func() {
+		table.DescribeTable("GetTags",
+			func(name string, hasTags bool) {
+				getTagsTester(name, hasTags)
+			},
+			table.Entry("VirtualMachine", "VirtualMachine", true))
+
+		table.DescribeTable("GetLabels",
+			func(name string, hasLabels bool) {
+				getLabelsTester(name, hasLabels)
+			},
+			table.Entry("VirtualMachine", "VirtualMachine", true))
+
+		table.DescribeTable("EmbedType",
+			func(name string, expType interface{}) {
+				embedTypeTester(name, expType)
+			},
+			table.Entry("VirtualMachine", "VirtualMachine", &cloud.VirtualMachine{}))
+	})
+})

--- a/test/integration/externalentity_test.go
+++ b/test/integration/externalentity_test.go
@@ -112,7 +112,8 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalEntity", focusAws, focusAzure), fun
 	tester := func(kind string, epNum int, hasNic, hasPort bool) {
 		// TODO: remove set resource version and copy status in another way
 		externalEntitySource := externalEntitySources[kind].EmbedType()
-		externalEntitySourceCopy := externalEntitySources[kind].Copy().EmbedType()
+		tempCopy, _ := externalEntitySources[kind].Copy().(target.ExternalEntitySource)
+		externalEntitySourceCopy := tempCopy.EmbedType()
 		ctx := context.Background()
 		By("ExternalEntity can be created")
 		err := k8sClient.Create(ctx, externalEntitySourceCopy)


### PR DESCRIPTION
- Added agented flag in CloudEntitySelector CRD.
- Added agented flag in VirtualMachine CRD.
- Update antrea.yml to enable ExternalNodeController and set antrea service type to LoadBalancer.
- Update converter module to create ExternalNode CR for agented VMs and create create ExternalEntity CR for agentless VMs.
- Implement cache to get vmSelector from VMId/VPCId.

Signed-off-by: Anand Kumar <kumaranand@vmware.com>