### PR TITLE
fix aws dependency violation error

### DIFF
--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -1061,7 +1061,7 @@ func (a *appliedToSecurityGroup) notify(op securityGroupOperation, status error,
 		a.hasMembers = true
 	case securityGroupOperationUpdateRules:
 		// AppliedToSecurityGroup added rules, now update rule realization state, addrGroup references and add members.
-    a.updateRuleRealizationState(r)
+		a.updateRuleRealizationState(r)
 		if err := a.updateAddrGroupReference(r); err != nil {
 			return err
 		}

--- a/pkg/controllers/cloud/networkpolicy_controller.go
+++ b/pkg/controllers/cloud/networkpolicy_controller.go
@@ -515,7 +515,7 @@ func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			appliedToIndexerByAddrGroupRef: func(obj interface{}) ([]string, error) {
 				appliedToGrp := obj.(*appliedToSecurityGroup)
 				addrGrps := make([]string, 0)
-				for sg := range appliedToGrp.references {
+				for sg := range appliedToGrp.addrGroupRef {
 					addrGrps = append(addrGrps, sg)
 				}
 				return addrGrps, nil

--- a/pkg/controllers/cloud/networkpolicy_controller.go
+++ b/pkg/controllers/cloud/networkpolicy_controller.go
@@ -515,7 +515,7 @@ func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			appliedToIndexerByAddrGroupRef: func(obj interface{}) ([]string, error) {
 				appliedToGrp := obj.(*appliedToSecurityGroup)
 				addrGrps := make([]string, 0)
-				for sg := range appliedToGrp.addrGroupRef {
+				for sg := range appliedToGrp.addrGroupRefs {
 					addrGrps = append(addrGrps, sg)
 				}
 				return addrGrps, nil

--- a/pkg/controllers/cloud/networkpolicy_pendingitem.go
+++ b/pkg/controllers/cloud/networkpolicy_pendingitem.go
@@ -17,10 +17,11 @@ package cloud
 import (
 	"fmt"
 
-	antreanetworking "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	"github.com/mohae/deepcopy"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+
+	antreanetworking "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 )
 
 type PendingItem interface {

--- a/pkg/controllers/cloud/networkpolicy_test.go
+++ b/pkg/controllers/cloud/networkpolicy_test.go
@@ -700,14 +700,19 @@ var _ = Describe("NetworkPolicy", func() {
 			err = reconciler.processNetworkPolicy(event)
 			Expect(err).ToNot(HaveOccurred())
 		}
+		nAddr := 0
+		if outOrder {
+			nAddr = len(anp.Rules)
+		}
 
+		Expect(len(reconciler.addrSGIndexer.ListKeys())).To(Equal(nAddr))
 		Expect(len(reconciler.networkPolicyIndexer.ListKeys())).To(Equal(0))
-		Expect(len(reconciler.addrSGIndexer.ListKeys())).To(Equal(0))
 		Expect(len(reconciler.appliedToSGIndexer.ListKeys())).To(Equal(0))
 
 		if !sgConfig.sgDeletePending {
 			wait()
 		}
+		Expect(len(reconciler.addrSGIndexer.ListKeys())).To(Equal(0))
 	}
 
 	verifyDeleteNP := func(outOrder bool) []chan error {


### PR DESCRIPTION
## Description

This PR fixes the dependency violation error for AWS. When ANP rule and addressGroup changes, cloud controller attempts to delete previous addressGroup before checking if the associated security rule in appliedToGroup is deleted. This result in a dependency violation error returned by AWS. The deletion eventually succeed on retry after the security rule is removed. This PR adds such security rule association and checks before deleting addressGroup, putting it into a pending state. No user behavior is changed

## Changes

1. Add a map in appliedToSG to track its rule referenced addressGroups. Add an index for the reference.
2. Block addressGroup delete if any reference exist.
3. Fix some import and comment format.

Signed-off-by: Alexander Liu <alliu@vmware.com>