### PR TITLE
Nephe testbed garbage collection

### DIFF
--- a/ci/jenkins/checkin.sh
+++ b/ci/jenkins/checkin.sh
@@ -31,17 +31,17 @@ if [ ! -e "terraform.tfstate.d/${tesbted_name}" ]; then
   exit 1
 fi
 
-if [ -e "../terraform.tfstate.d/current/${tesbted_name}" ]; then
+if [ -e "${HOME}/terraform.tfstate.d/current/${tesbted_name}" ]; then
   if [ "${force}" != "-f" ]; then
     echo "Shared workspace already exists, use $0 <testbed_name> [-f] to force overwrite."
     exit 1
   fi
 fi
 
-if [ ! -e "../terraform.tfstate.d/current/" ]; then
-  mkdir -p ../terraform.tfstate.d/current/
+if [ ! -e "${HOME}/terraform.tfstate.d/current/" ]; then
+  mkdir -p ~/terraform.tfstate.d/current/
 fi
 
 echo ====== Checking in ${tesbted_name} to Shared Workspace ======
-cp -rf "terraform.tfstate.d/${tesbted_name}" "../terraform.tfstate.d/current/"
+cp -rf "terraform.tfstate.d/${tesbted_name}" "${HOME}/terraform.tfstate.d/current/"
 echo ====== Done ======

--- a/ci/jenkins/checkout.sh
+++ b/ci/jenkins/checkout.sh
@@ -27,7 +27,7 @@ if [ -z "${tesbted_name}" ]; then
   exit 1
 fi
 
-if [ ! -e "../terraform.tfstate.d/current/${tesbted_name}" ]; then
+if [ ! -e "${HOME}/terraform.tfstate.d/current/${tesbted_name}" ]; then
   echo "${tesbted_name} does not exist in remote workspace"
   exit 1
 fi
@@ -40,5 +40,5 @@ if [ -e "terraform.tfstate.d/${tesbted_name}" ]; then
 fi
 
 echo ====== Checking out ${tesbted_name} to Local Workspace ======
-cp -rf "../terraform.tfstate.d/current/${tesbted_name}" terraform.tfstate.d/
+cp -rf "${HOME}/terraform.tfstate.d/current/${tesbted_name}" terraform.tfstate.d/
 echo ====== Done ======

--- a/ci/jenkins/destroy.sh
+++ b/ci/jenkins/destroy.sh
@@ -20,7 +20,10 @@ set -e
 
 tesbted_name="$1"
 vc_passwd="$2"
-var_file="terraform.tfstate.d/${tesbted_name}/vars.tfvars"
+var_file="$3"
+if [ -z ${var_file} ]; then
+  var_file="terraform.tfstate.d/${tesbted_name}/vars.tfvars"
+fi
 
 if [ -z "${tesbted_name}" ]; then
   echo "Usage: $0 <testbed_name>"
@@ -44,5 +47,5 @@ terraform workspace "select" default
 terraform workspace delete "${tesbted_name}"
 echo ====== Deleted ${tesbted_name} from Local Workspace ======
 echo ====== Deleting ${tesbted_name} from Shared Workspace ======
-rm -rf "../terraform.tfstate.d/current/${tesbted_name}"
+rm -rf "${HOME}/terraform.tfstate.d/current/${tesbted_name}"
 echo ====== Deleted ${tesbted_name} from Shared Workspace ======

--- a/ci/jenkins/diff.sh
+++ b/ci/jenkins/diff.sh
@@ -27,10 +27,10 @@ if [ ! -e "terraform.tfstate.d/${tesbted_name}" ]; then
   exit 1
 fi
 
-if [ ! -e "../terraform.tfstate.d/current/${tesbted_name}" ]; then
+if [ ! -e "${HOME}/terraform.tfstate.d/current/${tesbted_name}" ]; then
   echo "${tesbted_name} does not exist in remote workspace"
   exit 1
 fi
 
 echo ====== Showing Differences for ${tesbted_name} between Local and Shared Workspaces======
-diff -sur "terraform.tfstate.d/${tesbted_name}" "../terraform.tfstate.d/current/${tesbted_name}"
+diff -sur "terraform.tfstate.d/${tesbted_name}" "${HOME}/terraform.tfstate.d/current/${tesbted_name}"

--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -66,7 +66,26 @@
         url: 'https://github.com/{org_repo}'
     scm:
     - git:
-        branches: master
+        branches:
+          - master
         credentials-id: ANTREA_GIT_CREDENTIAL
         url: 'https://github.com/{org_repo}'
     wrappers: '{wrappers}'
+
+- job-template:
+    name: '{test_name}-testbed-gc-on-all-nodes'
+    node: "{node}"
+    block-downstream: false
+    block-upstream: false
+    builders: '{builders}'
+    concurrent: false
+    description: '{description}'
+    project-type: matrix
+    axes: '{axes}'
+    triggers: "{triggers}"
+    properties:
+    - build-discarder:
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+        days-to-keep: 7
+        num-to-keep: 30

--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -46,3 +46,27 @@
         triggered-status: '{triggered_status}'
         started-status: '{started_status}'
     wrappers: '{wrappers}'
+
+- job-template:
+    name: '{test_name}-testbed-gc'
+    node: '{node}'
+    block-downstream: false
+    block-upstream: false
+    builders: '{builders}'
+    concurrent: '{concurrent}'
+    description: '{description}'
+    project-type: freestyle
+    properties:
+    - build-discarder:
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+        days-to-keep: 7
+        num-to-keep: 30
+    - github:
+        url: 'https://github.com/{org_repo}'
+    scm:
+    - git:
+        branches: master
+        credentials-id: ANTREA_GIT_CREDENTIAL
+        url: 'https://github.com/{org_repo}'
+    wrappers: '{wrappers}'

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -40,4 +40,12 @@
     builders:
       - shell: |-
           #!/bin/bash
-          ./ci/jenkins/nephe-gc.sh --goVcPassword "${{GOVC_PASSWORD}}"
+          chmod +x ./ci/jenkins/nephe-gc.sh
+          ./ci/jenkins/nephe-gc.sh --goVcPassword "${GOVC_PASSWORD}"
+
+- builder:
+    name: nephe-testbed-gc-on-all-nodes
+    builders:
+        - trigger-builds:
+              - project: "nephe-testbed-gc"
+                block: true

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -34,3 +34,10 @@
                   --vcuser "${{VC_USER}}" --datacenter "${{DATACENTERNAME}}" --datastore "${{DATA_STORE}}" \
                   --vcCluster "${{VC_CLUSTER}}" --resourcePool "${{RESOURCEPOOLPATH}}" --vcNetwork "${{VMC_NETWORK_1}}" \
                   --virtualMachine "${{VIRTUAL_MACHINE}}" --goVcPassword "${{GOVC_PASSWORD}}" --testType aks
+
+- builder:
+    name: nephe-gc-cronjob
+    builders:
+      - shell: |-
+          #!/bin/bash
+          ./ci/jenkins/nephe-gc.sh --goVcPassword "${{GOVC_PASSWORD}}"

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -403,7 +403,7 @@
           test_name: nephe
           node: nephe-gc
           triggers:
-            - timed: "H 15 * * *"
+            - timed: "H 7 * * *"
           axes:
             - axis:
                 type: slave

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -399,3 +399,18 @@
                 - text:
                     credential-id: GOVC_PASSWORD
                     variable: GOVC_PASSWORD
+      - '{test_name}-testbed-gc-on-all-nodes':
+          test_name: nephe
+          node: nephe-gc
+          triggers:
+            - timed: "H 15 * * *"
+          axes:
+            - axis:
+                type: slave
+                name: nodes
+                values:
+                  - nephe-test-1
+                  - nephe-test-2
+                  - nephe-test-3
+          builders:
+            - nephe-testbed-gc-on-all-nodes

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -377,3 +377,25 @@
                       default-excludes: true
                       fingerprint: false
                       only-if-success: false
+      - '{test_name}-testbed-gc':
+          test_name: nephe
+          node: 'nephe'
+          description: 'This is the {test_name}-testbed-gc.'
+          builders:
+            - nephe-gc-cronjob
+          white_list_target_branches: [ ]
+          allow_whitelist_orgs_as_admins: true
+          admin_list: '{nephe_admin_list}'
+          org_list: '{nephe_org_list}'
+          white_list: '{nephe_white_list}'
+          success_status: Build finished.
+          failure_status: Failed.
+          error_status: Failed.
+          triggered_status: null
+          started_status: null
+          concurrent: true
+          wrappers:
+            - credentials-binding:
+                - text:
+                    credential-id: GOVC_PASSWORD
+                    variable: GOVC_PASSWORD

--- a/ci/jenkins/list.sh
+++ b/ci/jenkins/list.sh
@@ -19,4 +19,4 @@ echo ====== Local Workspaces ======
 terraform workspace list | grep -xv '^[* ]*default$'
 
 echo ====== Shared Workspaces ======
-ls -1 ../terraform.tfstate.d/current/ | awk '{print "  "$0}'
+ls -1 ${HOME}/terraform.tfstate.d/current/ | awk '{print "  "$0}'

--- a/ci/jenkins/nephe-gc.sh
+++ b/ci/jenkins/nephe-gc.sh
@@ -1,7 +1,29 @@
 #!/bin/bash
+
+# Copyright 2022 Antrea Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script helps to cleanup stale dynamic vm for nephe. It accepts two parameters,
+# `goVcPassword` is password for vc the dynamic vm is deployed on, `terraform-dir` is
+# the path to store vm information.
+
 _usage="Usage: $0 [--goVcPassword <Password for VC>]
   --goVcPassword          Password to the user name for VC.
   --terraform-dir         directory for terraform."
+
+# This is the max timeout we think the dynamic vm is stale.
+timeout=14400
 function echoerr() {
   >&2 echo "$@"
 }
@@ -13,7 +35,6 @@ function print_usage() {
 function print_help() {
   echoerr "Try '$0 --help' for more information."
 }
-
 
 while [[ $# -gt 0 ]]
 do
@@ -28,6 +49,15 @@ case $key in
     terraformDir="$2"
     shift 2
     ;;
+  -h|--help)
+    print_usage
+    exit 0
+    ;;
+  *)
+    echoerr "unknow option $1"
+    print_help
+    exit 1
+    ;;
 esac
 done
 
@@ -41,7 +71,6 @@ for testbed_name in $(ls ${terraformDir}); do
     start_time=$(date "+%s" --date `cat "${terraformDir}/${testbed_name}"/terraform.tfstate|jq -r .resources[6].instances[0].attributes.change_version`)
     curr_time=$(date "+%s")
     delta=$((${curr_time}-${start_time}))
-    timeout=10800
     if [ ${delta} > ${timeout} ]; then
       echo "testbed ${testbed_name} is stale, and it will be destroyed"
       ./ci/jenkins/destroy.sh "${testbed_name}" "${goVcPassword}" "${terraformDir}"

--- a/ci/jenkins/nephe-gc.sh
+++ b/ci/jenkins/nephe-gc.sh
@@ -35,6 +35,7 @@ if [ -z ${terraformDir} ]; then
   terraformDir="${HOME}/terraform.tfstate.d/current/"
 fi
 echo ${terraformDir}
+chmod +x ./ci/jenkins/destroy.sh
 for testbed_name in $(ls ${terraformDir}); do
   if [ -d ${terraformDir}/${testbed_name} ]; then
     start_time=$(date "+%s" --date `cat "${terraformDir}/${testbed_name}"/terraform.tfstate|jq -r .resources[6].instances[0].attributes.change_version`)
@@ -43,7 +44,7 @@ for testbed_name in $(ls ${terraformDir}); do
     timeout=10800
     if [ ${delta} > ${timeout} ]; then
       echo "testbed ${testbed_name} is stale, and it will be destroyed"
-      #./destroy.sh "${testbed_name}" "${goVcPassword}" "${terraformDir}"
+      ./ci/jenkins/destroy.sh "${testbed_name}" "${goVcPassword}" "${terraformDir}"
     else
       echo "testbed ${testbed_name} is in use"
     fi

--- a/ci/jenkins/nephe-gc.sh
+++ b/ci/jenkins/nephe-gc.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+_usage="Usage: $0 [--goVcPassword <Password for VC>]
+  --goVcPassword          Password to the user name for VC.
+  --terraform-dir         directory for terraform."
+function echoerr() {
+  >&2 echo "$@"
+}
+
+function print_usage() {
+  echoerr "$_usage"
+}
+
+function print_help() {
+  echoerr "Try '$0 --help' for more information."
+}
+
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+  --goVcPassword)
+    goVcPassword="$2"
+    shift 2
+    ;;
+  --terraform-dir)
+    terraformDir="$2"
+    shift 2
+    ;;
+esac
+done
+
+if [ -z ${terraformDir} ]; then
+  terraformDir="${HOME}/terraform.tfstate.d/current/"
+fi
+echo ${terraformDir}
+for testbed_name in $(ls ${terraformDir}); do
+  if [ -d ${terraformDir}/${testbed_name} ]; then
+    start_time=$(date "+%s" --date `cat "${terraformDir}/${testbed_name}"/terraform.tfstate|jq -r .resources[6].instances[0].attributes.change_version`)
+    curr_time=$(date "+%s")
+    delta=$((${curr_time}-${start_time}))
+    timeout=10800
+    if [ ${delta} > ${timeout} ]; then
+      echo "testbed ${testbed_name} is stale, and it will be destroyed"
+      #./destroy.sh "${testbed_name}" "${goVcPassword}" "${terraformDir}"
+    else
+      echo "testbed ${testbed_name} is in use"
+    fi
+  fi
+done


### PR DESCRIPTION
As we deploy dynamic VM for each jenkins task, there might be some stale dynamic VMs left when there are some unexpected failures. This patch helps to clean up stale dynamic VMs to release the resources they occupy.