### PR TITLE
Update rule realization for ANP

### DIFF
--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -454,6 +454,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - controlplane.antrea.io
+  resources:
+  - networkpolicies/status
+  verbs:
+  - create
+  - delete
+- apiGroups:
   - crd.antrea.io
   resources:
   - externalentities

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,6 +30,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - controlplane.antrea.io
+  resources:
+  - networkpolicies/status
+  verbs:
+  - create
+  - delete
+- apiGroups:
   - crd.antrea.io
   resources:
   - externalentities

--- a/pkg/controllers/cloud/networkpolicy_controller.go
+++ b/pkg/controllers/cloud/networkpolicy_controller.go
@@ -72,7 +72,7 @@ type NetworkPolicyReconciler struct {
 	client.Client
 	Log          logr.Logger
 	Scheme       *runtime.Scheme
-	antreaClient *antreanetworkingclient.ControlplaneV1beta2Client
+	antreaClient antreanetworkingclient.ControlplaneV1beta2Interface
 
 	// Watcher interfaces
 	addrGroupWatcher      watch.Interface

--- a/pkg/controllers/cloud/networkpolicy_test.go
+++ b/pkg/controllers/cloud/networkpolicy_test.go
@@ -37,6 +37,7 @@ import (
 
 	antreanetworking "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	antreatypes "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	antreafakeclientset "antrea.io/antrea/pkg/client/clientset/versioned/fake"
 	cloud "antrea.io/nephe/apis/crd/v1alpha1"
 	cloudcommon "antrea.io/nephe/pkg/cloud-provider/cloudapi/common"
 	"antrea.io/nephe/pkg/cloud-provider/securitygroup"
@@ -98,7 +99,9 @@ var _ = Describe("NetworkPolicy", func() {
 			Log:             logf.Log,
 			Client:          mockClient,
 			syncedWithCloud: true,
+			antreaClient:    antreafakeclientset.NewSimpleClientset().ControlplaneV1beta2(),
 		}
+
 		err := reconciler.SetupWithManager(nil)
 		Expect(err).ToNot(HaveOccurred())
 		vmMembers = make(map[string]*securitygroup.CloudResource)


### PR DESCRIPTION
Nephe controller combines all the ANP rules and apply them to cloud together. As such, all ANPs having same appliedToGroup will share the same fate. Here, with every ANP change, we walk thru all the ANPs sharing the same appliedTo and report combined rule realization statuses.

Note: As the ANPs are combined together, antrea controller will receive dup realization status for already realized rule if there are more than 1 ANP sharing the same appliedToGroup.

Signed-off-by: Rahul Jain <rahulj@vmware.com>