### PR TITLE
fix gc job: nephe uses main branch

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -69,7 +69,7 @@
     scm:
     - git:
         branches:
-          - master
+          - main
         credentials-id: ANTREA_GIT_CREDENTIAL
         url: 'https://github.com/{org_repo}'
     wrappers: '{wrappers}'


### PR DESCRIPTION
Signed-off-by: Bin Liu <biliu@vmware.com>

the job is verified here:
https://jenkins.antrea-ci.rocks/job/nephe-testbed-gc-on-all-nodes/2/console