### PR TITLE
Optimization changes for security group update operation.

### DIFF
--- a/pkg/cloud-provider/cloudapi/aws/aws_cloudinterface_impl.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_cloudinterface_impl.go
@@ -75,14 +75,6 @@ func (c *awsCloud) InstancesGivenProviderAccount(accountNamespacedName *types.Na
 	return vmCRDs, err
 }
 
-// IsVirtualPrivateCloudPresent returns true if given ID is managed by the cloud, else false.
-func (c *awsCloud) IsVirtualPrivateCloudPresent(vpcUniqueIdentifier string) bool {
-	if accCfg := c.getVpcAccount(vpcUniqueIdentifier); accCfg == nil {
-		return false
-	}
-	return true
-}
-
 // ////////////////////////////////////////////////////////
 //
 //	AccountMgmtInterface Implementation

--- a/pkg/cloud-provider/cloudapi/aws/aws_crd_helpers.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_crd_helpers.go
@@ -24,7 +24,7 @@ import (
 const ResourceNameTagKey = "Name"
 
 // ec2InstanceToVirtualMachineCRD converts ec2 instance to VirtualMachine CRD.
-func ec2InstanceToVirtualMachineCRD(instance *ec2.Instance, namespace string) *v1alpha1.VirtualMachine {
+func ec2InstanceToVirtualMachineCRD(instance *ec2.Instance, namespace string, accountId string) *v1alpha1.VirtualMachine {
 	tags := make(map[string]string)
 	vmTags := instance.Tags
 	if len(vmTags) > 0 {
@@ -71,5 +71,5 @@ func ec2InstanceToVirtualMachineCRD(instance *ec2.Instance, namespace string) *v
 	cloudNetwork := *instance.VpcId
 
 	return utils.GenerateVirtualMachineCRD(cloudID, cloudName, cloudID, namespace, cloudNetwork, cloudNetwork,
-		v1alpha1.VMState(*instance.State.Name), tags, networkInterfaces, providerType)
+		v1alpha1.VMState(*instance.State.Name), tags, networkInterfaces, providerType, accountId)
 }

--- a/pkg/cloud-provider/cloudapi/aws/aws_ec2.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_ec2.go
@@ -249,12 +249,12 @@ func (ec2Cfg *ec2ServiceConfig) RemoveResourceFilters(selectorName string) {
 	delete(ec2Cfg.instanceFilters, selectorName)
 }
 
-func (ec2Cfg *ec2ServiceConfig) GetResourceCRDs(namespace string) *internal.CloudServiceResourceCRDs {
+func (ec2Cfg *ec2ServiceConfig) GetResourceCRDs(namespace string, accountId string) *internal.CloudServiceResourceCRDs {
 	instances := ec2Cfg.getCachedInstances()
 	vmCRDs := make([]*v1alpha1.VirtualMachine, 0, len(instances))
 	for _, instance := range instances {
 		// build VirtualMachine CRD
-		vmCRD := ec2InstanceToVirtualMachineCRD(instance, namespace)
+		vmCRD := ec2InstanceToVirtualMachineCRD(instance, namespace, accountId)
 		vmCRDs = append(vmCRDs, vmCRD)
 	}
 

--- a/pkg/cloud-provider/cloudapi/azure/azure_account_mgmt.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_account_mgmt.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"antrea.io/nephe/apis/crd/v1alpha1"
-	"antrea.io/nephe/pkg/cloud-provider/cloudapi/internal"
 )
 
 type azureAccountConfig struct {
@@ -101,27 +100,4 @@ func extractSecret(c client.Client, s *v1alpha1.SecretReference) (*v1alpha1.Azur
 	}
 
 	return cred, nil
-}
-
-// getVnetAccount returns first found account config to which this vnet id belongs.
-func (c *azureCloud) getVnetAccount(vpcID string) internal.CloudAccountInterface {
-	accCfgs := c.cloudCommon.GetCloudAccounts()
-	if len(accCfgs) == 0 {
-		return nil
-	}
-
-	for _, accCfg := range accCfgs {
-		ec2ServiceCfg, err := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
-		if err != nil {
-			continue
-		}
-		accVpcIDs := ec2ServiceCfg.(*computeServiceConfig).getCachedVnetIDs()
-		if len(accVpcIDs) == 0 {
-			continue
-		}
-		if _, found := accVpcIDs[strings.ToLower(vpcID)]; found {
-			return accCfg
-		}
-	}
-	return nil
 }

--- a/pkg/cloud-provider/cloudapi/azure/azure_cloudinterface_impl.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_cloudinterface_impl.go
@@ -75,14 +75,6 @@ func (c *azureCloud) InstancesGivenProviderAccount(accountNamespacedName *types.
 	return vmCRDs, err
 }
 
-// IsVirtualPrivateCloudPresent returns true if given ID is managed by the cloud, else false.
-func (c *azureCloud) IsVirtualPrivateCloudPresent(vpcUniqueIdentifier string) bool {
-	if accCfg := c.getVnetAccount(vpcUniqueIdentifier); accCfg == nil {
-		return false
-	}
-	return true
-}
-
 // ////////////////////////////////////////////////////////
 //
 //	AccountMgmtInterface Implementation

--- a/pkg/cloud-provider/cloudapi/azure/azure_compute.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_compute.go
@@ -237,13 +237,13 @@ func (computeCfg *computeServiceConfig) RemoveResourceFilters(selectorName strin
 	delete(computeCfg.computeFilters, selectorName)
 }
 
-func (computeCfg *computeServiceConfig) GetResourceCRDs(namespace string) *internal.CloudServiceResourceCRDs {
+func (computeCfg *computeServiceConfig) GetResourceCRDs(namespace string, accountId string) *internal.CloudServiceResourceCRDs {
 	virtualMachines := computeCfg.getCachedVirtualMachines()
 	vmCRDs := make([]*v1alpha1.VirtualMachine, 0, len(virtualMachines))
 
 	for _, virtualMachine := range virtualMachines {
 		// build VirtualMachine CRD
-		vmCRD := computeInstanceToVirtualMachineCRD(virtualMachine, namespace)
+		vmCRD := computeInstanceToVirtualMachineCRD(virtualMachine, namespace, accountId)
 		vmCRDs = append(vmCRDs, vmCRD)
 	}
 

--- a/pkg/cloud-provider/cloudapi/azure/azure_crd_helpers.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_crd_helpers.go
@@ -32,7 +32,7 @@ var azureStateMap = map[string]v1alpha1.VMState{
 	"PowerState/unknown":      v1alpha1.Unknown,
 }
 
-func computeInstanceToVirtualMachineCRD(instance *virtualMachineTable, namespace string) *v1alpha1.VirtualMachine {
+func computeInstanceToVirtualMachineCRD(instance *virtualMachineTable, namespace string, accountId string) *v1alpha1.VirtualMachine {
 	tags := make(map[string]string)
 
 	vmTags := instance.Tags
@@ -100,5 +100,5 @@ func computeInstanceToVirtualMachineCRD(instance *virtualMachineTable, namespace
 	}
 	return utils.GenerateVirtualMachineCRD(crdName, strings.ToLower(cloudName), strings.ToLower(cloudID), namespace,
 		strings.ToLower(cloudNetworkID), cloudNetworkShortID,
-		state, tags, networkInterfaces, providerType)
+		state, tags, networkInterfaces, providerType, accountId)
 }

--- a/pkg/cloud-provider/cloudapi/azure/azure_security_test.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_security_test.go
@@ -38,26 +38,27 @@ import (
 
 var _ = Describe("Azure Cloud Security", func() {
 	var (
-		testAccountNamespacedName       = &types.NamespacedName{Namespace: "namespace01", Name: "account01"}
-		testSubID                       = "SubID"
-		credentials                     = "credentials"
-		testClientID                    = "ClientID"
-		testClientKey                   = "ClientKey"
-		testTenantID                    = "TenantID"
-		testRegion                      = "eastus"
-		testRG                          = "testRG"
-		nsgID                           = "nephe-ag-nsgID"
-		atAsgID                         = "nephe-at-atapplicationsgID"
-		atAsgName                       = "atapplicationsgID"
-		agAsgID                         = "nephe-ag-agapplicationsgID"
-		testPriority              int32 = 100
-		testSourcePortRange             = "*"
-		testDestinationPortRange        = "*"
-		testPrivateIP                   = "0.0.0.0"
-		testProtocol                    = 6
-		testFromPort                    = 22
-		testToPort                      = 23
-		testCidrStr                     = "192.168.1.1/24"
+		testAccountNamespacedName               = &types.NamespacedName{Namespace: "namespace01", Name: "account01"}
+		testAccountNamespacedNameNotExist       = &types.NamespacedName{Namespace: "notexist01", Name: "notexist01"}
+		testSubID                               = "SubID"
+		credentials                             = "credentials"
+		testClientID                            = "ClientID"
+		testClientKey                           = "ClientKey"
+		testTenantID                            = "TenantID"
+		testRegion                              = "eastus"
+		testRG                                  = "testRG"
+		nsgID                                   = "nephe-ag-nsgID"
+		atAsgID                                 = "nephe-at-atapplicationsgID"
+		atAsgName                               = "atapplicationsgID"
+		agAsgID                                 = "nephe-ag-agapplicationsgID"
+		testPriority                      int32 = 100
+		testSourcePortRange                     = "*"
+		testDestinationPortRange                = "*"
+		testPrivateIP                           = "0.0.0.0"
+		testProtocol                            = 6
+		testFromPort                            = 22
+		testToPort                              = 23
+		testCidrStr                             = "192.168.1.1/24"
 
 		testVnet01   = "testVnet01"
 		testVnetID01 = fmt.Sprintf("/subscriptions/%v/resourceGroups/%v/providers/Microsoft.Network/virtualNetworks/%v",
@@ -259,18 +260,28 @@ var _ = Describe("Azure Cloud Security", func() {
 
 		Context("CreateSecurityGroup", func() {
 			It("Should create security group(ASG and NSG) successfully and return ID", func() {
-				webAddressGroupIdentifier01 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID01,
+				webAddressGroupIdentifier01 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID01,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				cloudSgID01, err := c.CreateSecurityGroup(webAddressGroupIdentifier01, false)
 				Expect(err).Should(BeNil())
 				Expect(cloudSgID01).Should(Not(BeNil()))
 
-				webAddressGroupIdentifier02 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID02,
+				webAddressGroupIdentifier02 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID02,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				cloudSgID02, err := c.CreateSecurityGroup(webAddressGroupIdentifier02, true)
@@ -280,9 +291,14 @@ var _ = Describe("Azure Cloud Security", func() {
 			})
 
 			It("Should fail to create security group", func() {
-				webAddressGroupIdentifier01 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID03,
+				webAddressGroupIdentifier01 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID03,
+					},
+					AccountID:     testAccountNamespacedNameNotExist.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				_, err := c.CreateSecurityGroup(webAddressGroupIdentifier01, false)
@@ -293,21 +309,28 @@ var _ = Describe("Azure Cloud Security", func() {
 
 		Context("UpdateSecurityGroup", func() {
 			It("Should Update security group members", func() {
-				webAddressGroupIdentifier01 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID01,
+				webAddressGroupIdentifier01 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID01,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
-				webAddressGroupIdentifier02 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID02,
+				webAddressGroupIdentifier02 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID02,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				members := []*securitygroup.CloudResource{
-					{
-						Type: securitygroup.CloudResourceTypeVM,
-						Name: *webAddressGroupIdentifier02,
-					},
+					webAddressGroupIdentifier02,
 				}
 
 				err := c.UpdateSecurityGroupMembers(webAddressGroupIdentifier01, members, false)
@@ -315,21 +338,28 @@ var _ = Describe("Azure Cloud Security", func() {
 			})
 
 			It("Should fail to update security group members", func() {
-				webAddressGroupIdentifier01 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID03,
+				webAddressGroupIdentifier01 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID03,
+					},
+					AccountID:     testAccountNamespacedNameNotExist.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
-				webAddressGroupIdentifier02 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID02,
+				webAddressGroupIdentifier02 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID02,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				members := []*securitygroup.CloudResource{
-					{
-						Type: securitygroup.CloudResourceTypeVM,
-						Name: *webAddressGroupIdentifier02,
-					},
+					webAddressGroupIdentifier02,
 				}
 
 				err := c.UpdateSecurityGroupMembers(webAddressGroupIdentifier01, members, false)
@@ -339,9 +369,14 @@ var _ = Describe("Azure Cloud Security", func() {
 
 		Context("UpdateSecurityRules", func() {
 			It("Should update Security rules successfully", func() {
-				webAddressGroupIdentifier03 := &securitygroup.CloudResourceID{
-					Name: atAsgName,
-					Vpc:  testVnetID01,
+				webAddressGroupIdentifier03 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: atAsgName,
+						Vpc:  testVnetID01,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				fromSrcIP := getFromSrcIP(testCidrStr)
@@ -360,7 +395,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						ToPort:   &testToPort,
 						ToDstIP:  fromSrcIP,
 						ToSecurityGroups: []*securitygroup.CloudResourceID{
-							webAddressGroupIdentifier03,
+							&webAddressGroupIdentifier03.CloudResourceID,
 						},
 					},
 				}
@@ -370,9 +405,14 @@ var _ = Describe("Azure Cloud Security", func() {
 			})
 
 			It("Should fail to update Security rules -- asg not found", func() {
-				webAddressGroupIdentifier03 := &securitygroup.CloudResourceID{
-					Name: nsgID,
-					Vpc:  testVnetID01,
+				webAddressGroupIdentifier03 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: nsgID,
+						Vpc:  testVnetID01,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				fromSrcIP := getFromSrcIP(testCidrStr)
@@ -391,7 +431,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						ToPort:   &testToPort,
 						ToDstIP:  fromSrcIP,
 						ToSecurityGroups: []*securitygroup.CloudResourceID{
-							webAddressGroupIdentifier03,
+							&webAddressGroupIdentifier03.CloudResourceID,
 						},
 					},
 				}
@@ -401,9 +441,14 @@ var _ = Describe("Azure Cloud Security", func() {
 			})
 
 			It("Should update Security rules for Peerings", func() {
-				webAddressGroupIdentifier03 := &securitygroup.CloudResourceID{
-					Name: atAsgName,
-					Vpc:  testVnetPeerID01,
+				webAddressGroupIdentifier03 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: atAsgName,
+						Vpc:  testVnetPeerID01,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				cidr := ipaddr.NewIPAddressString(testCidrStr)
@@ -430,7 +475,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						ToPort:   &testToPort,
 						ToDstIP:  fromSrcIP,
 						ToSecurityGroups: []*securitygroup.CloudResourceID{
-							webAddressGroupIdentifier03,
+							&webAddressGroupIdentifier03.CloudResourceID,
 						},
 					},
 				}
@@ -465,20 +510,30 @@ var _ = Describe("Azure Cloud Security", func() {
 				serviceConfig, _ := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
 				serviceConfig.(*computeServiceConfig).resourcesCache.UpdateSnapshot(&computeResourcesCacheSnapshot{vmToUpdateMap, nil, nil})
 
-				serviceConfig.(*computeServiceConfig).GetResourceCRDs(testAccountNamespacedName.Namespace)
+				serviceConfig.(*computeServiceConfig).GetResourceCRDs(testAccountNamespacedName.Namespace, testAccountNamespacedName.String())
 			})
 		})
 
 		Context("DeleteSecurityGroup", func() {
 			It("Should delete security group(ASG and NSG) successfully", func() {
-				webAddressGroupIdentifier01 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID01,
+				webAddressGroupIdentifier01 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID01,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
-				webAddressGroupIdentifier02 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID02,
+				webAddressGroupIdentifier02 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID02,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				err := c.DeleteSecurityGroup(webAddressGroupIdentifier01, false)
@@ -489,9 +544,14 @@ var _ = Describe("Azure Cloud Security", func() {
 			})
 
 			It("Should fail to delete security group)", func() {
-				webAddressGroupIdentifier01 := &securitygroup.CloudResourceID{
-					Name: "Web",
-					Vpc:  testVnetID03,
+				webAddressGroupIdentifier01 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: "Web",
+						Vpc:  testVnetID03,
+					},
+					AccountID:     testAccountNamespacedNameNotExist.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
 				}
 
 				err := c.DeleteSecurityGroup(webAddressGroupIdentifier01, false)

--- a/pkg/cloud-provider/cloudapi/azure/azure_test.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_test.go
@@ -188,9 +188,6 @@ var _ = Describe("Azure", func() {
 				_, err = c.Instances()
 				Expect(err).Should(BeNil())
 
-				res := c.IsVirtualPrivateCloudPresent("vpc")
-				Expect(res).Should(Equal(false))
-
 				_ = c.GetEnforcedSecurity()
 			})
 		})

--- a/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
@@ -81,7 +81,7 @@ func (mr *MockCloudInterfaceMockRecorder) AddProviderAccount(client, account int
 }
 
 // CreateSecurityGroup mocks base method.
-func (m *MockCloudInterface) CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResourceID, membershipOnly bool) (*string, error) {
+func (m *MockCloudInterface) CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecurityGroup", addressGroupIdentifier, membershipOnly)
 	ret0, _ := ret[0].(*string)
@@ -96,7 +96,7 @@ func (mr *MockCloudInterfaceMockRecorder) CreateSecurityGroup(addressGroupIdenti
 }
 
 // DeleteSecurityGroup mocks base method.
-func (m *MockCloudInterface) DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResourceID, membershipOnly bool) error {
+func (m *MockCloudInterface) DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecurityGroup", addressGroupIdentifier, membershipOnly)
 	ret0, _ := ret[0].(error)
@@ -168,20 +168,6 @@ func (mr *MockCloudInterfaceMockRecorder) InstancesGivenProviderAccount(namespac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstancesGivenProviderAccount", reflect.TypeOf((*MockCloudInterface)(nil).InstancesGivenProviderAccount), namespacedName)
 }
 
-// IsVirtualPrivateCloudPresent mocks base method.
-func (m *MockCloudInterface) IsVirtualPrivateCloudPresent(uniqueIdentifier string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsVirtualPrivateCloudPresent", uniqueIdentifier)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsVirtualPrivateCloudPresent indicates an expected call of IsVirtualPrivateCloudPresent.
-func (mr *MockCloudInterfaceMockRecorder) IsVirtualPrivateCloudPresent(uniqueIdentifier interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVirtualPrivateCloudPresent", reflect.TypeOf((*MockCloudInterface)(nil).IsVirtualPrivateCloudPresent), uniqueIdentifier)
-}
-
 // ProviderType mocks base method.
 func (m *MockCloudInterface) ProviderType() ProviderType {
 	m.ctrl.T.Helper()
@@ -221,7 +207,7 @@ func (mr *MockCloudInterfaceMockRecorder) RemoveProviderAccount(namespacedName i
 }
 
 // UpdateSecurityGroupMembers mocks base method.
-func (m *MockCloudInterface) UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResourceID, computeResourceIdentifier []*securitygroup.CloudResource, membershipOnly bool) error {
+func (m *MockCloudInterface) UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource, membershipOnly bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupMembers", addressGroupIdentifier, computeResourceIdentifier, membershipOnly)
 	ret0, _ := ret[0].(error)
@@ -235,7 +221,7 @@ func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupMembers(addressGrou
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockCloudInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResourceID, ingressRules []*securitygroup.IngressRule, egressRules []*securitygroup.EgressRule) error {
+func (m *MockCloudInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, ingressRules []*securitygroup.IngressRule, egressRules []*securitygroup.EgressRule) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", addressGroupIdentifier, ingressRules, egressRules)
 	ret0, _ := ret[0].(error)
@@ -391,20 +377,6 @@ func (mr *MockComputeInterfaceMockRecorder) InstancesGivenProviderAccount(namesp
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstancesGivenProviderAccount", reflect.TypeOf((*MockComputeInterface)(nil).InstancesGivenProviderAccount), namespacedName)
 }
 
-// IsVirtualPrivateCloudPresent mocks base method.
-func (m *MockComputeInterface) IsVirtualPrivateCloudPresent(uniqueIdentifier string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsVirtualPrivateCloudPresent", uniqueIdentifier)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsVirtualPrivateCloudPresent indicates an expected call of IsVirtualPrivateCloudPresent.
-func (mr *MockComputeInterfaceMockRecorder) IsVirtualPrivateCloudPresent(uniqueIdentifier interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVirtualPrivateCloudPresent", reflect.TypeOf((*MockComputeInterface)(nil).IsVirtualPrivateCloudPresent), uniqueIdentifier)
-}
-
 // MockSecurityInterface is a mock of SecurityInterface interface.
 type MockSecurityInterface struct {
 	ctrl     *gomock.Controller
@@ -429,7 +401,7 @@ func (m *MockSecurityInterface) EXPECT() *MockSecurityInterfaceMockRecorder {
 }
 
 // CreateSecurityGroup mocks base method.
-func (m *MockSecurityInterface) CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResourceID, membershipOnly bool) (*string, error) {
+func (m *MockSecurityInterface) CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecurityGroup", addressGroupIdentifier, membershipOnly)
 	ret0, _ := ret[0].(*string)
@@ -444,7 +416,7 @@ func (mr *MockSecurityInterfaceMockRecorder) CreateSecurityGroup(addressGroupIde
 }
 
 // DeleteSecurityGroup mocks base method.
-func (m *MockSecurityInterface) DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResourceID, membershipOnly bool) error {
+func (m *MockSecurityInterface) DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecurityGroup", addressGroupIdentifier, membershipOnly)
 	ret0, _ := ret[0].(error)
@@ -472,7 +444,7 @@ func (mr *MockSecurityInterfaceMockRecorder) GetEnforcedSecurity() *gomock.Call 
 }
 
 // UpdateSecurityGroupMembers mocks base method.
-func (m *MockSecurityInterface) UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResourceID, computeResourceIdentifier []*securitygroup.CloudResource, membershipOnly bool) error {
+func (m *MockSecurityInterface) UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource, membershipOnly bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupMembers", addressGroupIdentifier, computeResourceIdentifier, membershipOnly)
 	ret0, _ := ret[0].(error)
@@ -486,7 +458,7 @@ func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupMembers(addressG
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockSecurityInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResourceID, ingressRules []*securitygroup.IngressRule, egressRules []*securitygroup.EgressRule) error {
+func (m *MockSecurityInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, ingressRules []*securitygroup.IngressRule, egressRules []*securitygroup.EgressRule) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", addressGroupIdentifier, ingressRules, egressRules)
 	ret0, _ := ret[0].(error)

--- a/pkg/cloud-provider/cloudapi/common/cloud.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud.go
@@ -33,6 +33,7 @@ var (
 	AnnotationCloudAssignedIDKey    = "cloud-assigned-id"
 	AnnotationCloudAssignedNameKey  = "cloud-assigned-name"
 	AnnotationCloudAssignedVPCIDKey = "cloud-assigned-vpc-id"
+	AnnotationCloudAccountIDKey     = "cloud-account-id"
 )
 
 type ProviderType v1alpha1.CloudProvider
@@ -70,28 +71,26 @@ type ComputeInterface interface {
 	Instances() ([]*v1alpha1.VirtualMachine, error)
 	// InstancesGivenProviderAccount returns VirtualMachineStatus for a given account of a cloud provider.
 	InstancesGivenProviderAccount(namespacedName *types.NamespacedName) ([]*v1alpha1.VirtualMachine, error)
-	// IsVirtualPrivateCloudPresent returns true if given virtual private cloud uniqueIdentifier is managed by the cloud, else false.
-	IsVirtualPrivateCloudPresent(uniqueIdentifier string) bool
 }
 
 type SecurityInterface interface {
 	// CreateSecurityGroup creates cloud security group corresponding to provided address group, if it does not already exist.
 	// If it exists, returns the existing cloud SG ID
-	CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResourceID, membershipOnly bool) (*string, error)
+	CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error)
 	// UpdateSecurityGroupRules updates cloud security group corresponding to provided address group with provided ingress and egress rules
-	UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResourceID, ingressRules []*securitygroup.IngressRule,
+	UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, ingressRules []*securitygroup.IngressRule,
 		egressRules []*securitygroup.EgressRule) error
 	// UpdateSecurityGroupMembers updates membership of cloud security group corresponding to provided address group. Only
 	// provided computeResources will remain attached to cloud security group. UpdateSecurityGroupMembers will also make sure that
 	// after membership update, if compute resource is no longer attached to any nephe created cloud security group, then
 	// compute resource will get moved to cloud default security group
-	UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResourceID, computeResourceIdentifier []*securitygroup.CloudResource,
+	UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource,
 		membershipOnly bool) error
 	// DeleteSecurityGroup will delete the cloud security group corresponding to provided address group. DeleteSecurityGroup expects that
 	// UpdateSecurityGroupMembers and UpdateSecurityGroupRules is called prior to calling delete. DeleteSecurityGroup as part of delete,
 	// do the best effort to find resources using this address group and detach the cloud security group from those resources.Also if the
 	// compute resource is attached to only this security group, it will be moved to cloud default security group.
-	DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResourceID, membershipOnly bool) error
+	DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error
 	// GetEnforcedSecurity returns the cloud view of enforced security
 	GetEnforcedSecurity() []securitygroup.SynchronizationContent
 }

--- a/pkg/cloud-provider/cloudapi/internal/services_common.go
+++ b/pkg/cloud-provider/cloudapi/internal/services_common.go
@@ -54,7 +54,7 @@ type CloudServiceInterface interface {
 	// GetInventoryStats returns Inventory statistics for the service.
 	GetInventoryStats() *CloudServiceStats
 	// GetResourceCRDs returns Service resource saved in CloudServiceResourcesCache in terms of CRD.
-	GetResourceCRDs(namespace string) *CloudServiceResourceCRDs
+	GetResourceCRDs(namespace string, accountId string) *CloudServiceResourceCRDs
 	// GetName returns cloud name of the service.
 	GetName() CloudServiceName
 	// GetType returns service type (compute, any other type etc.)
@@ -105,11 +105,11 @@ func (cfg *CloudServiceCommon) getInventoryStats() *CloudServiceStats {
 	return cfg.serviceInterface.GetInventoryStats()
 }
 
-func (cfg *CloudServiceCommon) getResourceCRDs(namespace string) *CloudServiceResourceCRDs {
+func (cfg *CloudServiceCommon) getResourceCRDs(namespace string, accountId string) *CloudServiceResourceCRDs {
 	cfg.mutex.Lock()
 	defer cfg.mutex.Unlock()
 
-	return cfg.serviceInterface.GetResourceCRDs(namespace)
+	return cfg.serviceInterface.GetResourceCRDs(namespace, accountId)
 }
 
 func (cfg *CloudServiceCommon) getName() CloudServiceName {

--- a/pkg/cloud-provider/securitygroup/helpers.go
+++ b/pkg/cloud-provider/securitygroup/helpers.go
@@ -45,10 +45,10 @@ func FindResourcesBasedOnKind(cloudResources []*CloudResource) (map[string]struc
 
 	for _, cloudResource := range cloudResources {
 		if strings.Compare(string(cloudResource.Type), string(CloudResourceTypeVM)) == 0 {
-			virtualMachineIDs[strings.ToLower(cloudResource.Name.Name)] = struct{}{}
+			virtualMachineIDs[strings.ToLower(cloudResource.Name)] = struct{}{}
 		}
 		if strings.Compare(string(cloudResource.Type), string(CloudResourceTypeNIC)) == 0 {
-			networkInterfaceIDs[strings.ToLower(cloudResource.Name.Name)] = struct{}{}
+			networkInterfaceIDs[strings.ToLower(cloudResource.Name)] = struct{}{}
 		}
 	}
 	return virtualMachineIDs, networkInterfaceIDs

--- a/pkg/cloud-provider/securitygroup/securitygroup.go
+++ b/pkg/cloud-provider/securitygroup/securitygroup.go
@@ -128,16 +128,18 @@ var (
 // CloudResource uniquely identify a cloud resource.
 type CloudResource struct {
 	Type CloudResourceType
-	Name CloudResourceID
-}
-
-func (c *CloudResource) String() string {
-	return string(c.Type) + "/" + c.Name.String()
+	CloudResourceID
+	AccountID     string
+	CloudProvider string
 }
 
 type CloudResourceID struct {
 	Name string
 	Vpc  string
+}
+
+func (c *CloudResource) String() string {
+	return string(c.Type) + "/" + c.CloudResourceID.String()
 }
 
 func (c *CloudResourceID) GetCloudName(membershipOnly bool) string {
@@ -169,7 +171,7 @@ type EgressRule struct {
 
 // SynchronizationContent returns a SecurityGroup content in cloud.
 type SynchronizationContent struct {
-	Resource                   CloudResourceID
+	Resource                   CloudResource
 	MembershipOnly             bool
 	Members                    []CloudResource
 	MembersWithOtherSGAttached []CloudResource
@@ -183,24 +185,24 @@ type CloudSecurityGroupAPI interface {
 	// membershipOnly is true if the SecurityGroup is used for membership tracking, not
 	// applying ingress/egress rules.
 	// Caller expects to wait on returned channel for status
-	CreateSecurityGroup(name *CloudResourceID, membershipOnly bool) <-chan error
+	CreateSecurityGroup(name *CloudResource, membershipOnly bool) <-chan error
 
 	// UpdateSecurityGroupMembers updates SecurityGroup name with members.
 	// SecurityGroup name must already have been created.
 	// For appliedSecurityGroup, UpdateSecurityGroupMembers is called only if SG has
 	// rules configured.
-	UpdateSecurityGroupMembers(name *CloudResourceID, members []*CloudResource, membershipOnly bool) <-chan error
+	UpdateSecurityGroupMembers(name *CloudResource, members []*CloudResource, membershipOnly bool) <-chan error
 
 	// DeleteSecurityGroup deletes SecurityGroup name.
 	// SecurityGroup name must already been created, is empty.
-	DeleteSecurityGroup(name *CloudResourceID, membershipOnly bool) <-chan error
+	DeleteSecurityGroup(name *CloudResource, membershipOnly bool) <-chan error
 
 	// UpdateSecurityGroupRules updates SecurityGroup name's ingress/egress rules in entirety.
 	// SecurityGroup name must already been created. SecurityGroups referred to in ingressRules and
 	// egressRules must have been already created.
 	// For appliedSecurityGroup, call with ingressRules=nil and egressRules=nil (clear rules) can be invoked
 	// only if SG has no members.
-	UpdateSecurityGroupRules(name *CloudResourceID, ingressRules []*IngressRule, egressRules []*EgressRule) <-chan error
+	UpdateSecurityGroupRules(name *CloudResource, ingressRules []*IngressRule, egressRules []*EgressRule) <-chan error
 
 	// GetSecurityGroupSyncChan returns a channel that networkPolicy controller waits on to retrieve complete SGs
 	// configured by cloud plug-in.

--- a/pkg/cloud-provider/utils/crd_generator.go
+++ b/pkg/cloud-provider/utils/crd_generator.go
@@ -27,7 +27,7 @@ import (
 
 func GenerateVirtualMachineCRD(crdName string, cloudName string, cloudID string, namespace string, cloudNetwork string,
 	shortNetworkID string, state cloudv1alpha1.VMState, tags map[string]string, networkInterfaces []cloudv1alpha1.NetworkInterface,
-	provider cloudcommon.ProviderType) *cloudv1alpha1.VirtualMachine {
+	provider cloudcommon.ProviderType, accountId string) *cloudv1alpha1.VirtualMachine {
 	vmStatus := &cloudv1alpha1.VirtualMachineStatus{
 		Provider:            cloudv1alpha1.CloudProvider(provider),
 		VirtualPrivateCloud: shortNetworkID,
@@ -39,6 +39,7 @@ func GenerateVirtualMachineCRD(crdName string, cloudName string, cloudID string,
 		cloudcommon.AnnotationCloudAssignedIDKey:    cloudID,
 		cloudcommon.AnnotationCloudAssignedNameKey:  cloudName,
 		cloudcommon.AnnotationCloudAssignedVPCIDKey: cloudNetwork,
+		cloudcommon.AnnotationCloudAccountIDKey:     accountId,
 	}
 
 	vmCrd := &cloudv1alpha1.VirtualMachine{

--- a/pkg/testing/cloudsecurity/mock.go
+++ b/pkg/testing/cloudsecurity/mock.go
@@ -50,7 +50,7 @@ func (m *MockCloudSecurityGroupAPI) EXPECT() *MockCloudSecurityGroupAPIMockRecor
 }
 
 // CreateSecurityGroup mocks base method.
-func (m *MockCloudSecurityGroupAPI) CreateSecurityGroup(arg0 *securitygroup.CloudResourceID, arg1 bool) <-chan error {
+func (m *MockCloudSecurityGroupAPI) CreateSecurityGroup(arg0 *securitygroup.CloudResource, arg1 bool) <-chan error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecurityGroup", arg0, arg1)
 	ret0, _ := ret[0].(<-chan error)
@@ -64,7 +64,7 @@ func (mr *MockCloudSecurityGroupAPIMockRecorder) CreateSecurityGroup(arg0, arg1 
 }
 
 // DeleteSecurityGroup mocks base method.
-func (m *MockCloudSecurityGroupAPI) DeleteSecurityGroup(arg0 *securitygroup.CloudResourceID, arg1 bool) <-chan error {
+func (m *MockCloudSecurityGroupAPI) DeleteSecurityGroup(arg0 *securitygroup.CloudResource, arg1 bool) <-chan error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecurityGroup", arg0, arg1)
 	ret0, _ := ret[0].(<-chan error)
@@ -92,7 +92,7 @@ func (mr *MockCloudSecurityGroupAPIMockRecorder) GetSecurityGroupSyncChan() *gom
 }
 
 // UpdateSecurityGroupMembers mocks base method.
-func (m *MockCloudSecurityGroupAPI) UpdateSecurityGroupMembers(arg0 *securitygroup.CloudResourceID, arg1 []*securitygroup.CloudResource, arg2 bool) <-chan error {
+func (m *MockCloudSecurityGroupAPI) UpdateSecurityGroupMembers(arg0 *securitygroup.CloudResource, arg1 []*securitygroup.CloudResource, arg2 bool) <-chan error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupMembers", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan error)
@@ -106,7 +106,7 @@ func (mr *MockCloudSecurityGroupAPIMockRecorder) UpdateSecurityGroupMembers(arg0
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockCloudSecurityGroupAPI) UpdateSecurityGroupRules(arg0 *securitygroup.CloudResourceID, arg1 []*securitygroup.IngressRule, arg2 []*securitygroup.EgressRule) <-chan error {
+func (m *MockCloudSecurityGroupAPI) UpdateSecurityGroupRules(arg0 *securitygroup.CloudResource, arg1 []*securitygroup.IngressRule, arg2 []*securitygroup.EgressRule) <-chan error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan error)


### PR DESCRIPTION
Following changes are taken care:
- Introduced accountID field in CloudResource structure
- Add new annotation in vm CRD which populates accountID
- Retreiving accCfg using accountID instead of vpc
- Introduced CloudProvider type in CloudResource structure
- Retrieve CloudInterface directly using CloudProvider
- Changes to unit test and integration tests for using updated CloudResource structure

Signed-off-by: Archana Holla <harchana@vmware.com>