### PR TITLE
Add integration test for antrea group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/seancfoley/bintree v1.1.0 // indirect
-	github.com/seancfoley/ipaddress-go v1.2.1 // indirect
+	github.com/seancfoley/ipaddress-go v1.2.1
 	github.com/spf13/cobra v1.4.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.1 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.1 // indirect

--- a/test/integration/cloudresource_e2e_test.go
+++ b/test/integration/cloudresource_e2e_test.go
@@ -227,7 +227,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Cloud Resources", focusAws
 	}
 
 	verifyAppliedTo := func(kind string, ids, ips []string, srcVM, srcIP string, applied []bool) {
-		// Applied ANP and check configuration.
+		// Apply ANP and check configuration.
 		err := utils.ConfigureK8s(kubeCtl, anpParams, k8stemplates.CloudAntreaNetworkPolicy, false)
 		Expect(err).ToNot(HaveOccurred())
 		for i, ok := range applied {
@@ -355,6 +355,56 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Cloud Resources", focusAws
 			anpParams.AppliedTo = configANPApplyTo(kind, "", "", "name", cloudVPC.GetTags()[appliedIdx]["Name"])
 			verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
 		}
+	}
+
+	testAppliedToUsingGroup := func(kind string) {
+		var ids []string
+		var ips []string
+		if kind == reflect.TypeOf(v1alpha1.VirtualMachine{}).Name() {
+			ids = cloudVPC.GetVMs()
+			ips = cloudVPC.GetVMPrivateIPs()
+		} else {
+			Fail("Unsupported type")
+		}
+
+		srcVM := cloudVPC.GetVMs()[0]
+		srcIP := cloudVPC.GetVMPrivateIPs()[0]
+
+		setup(kind, len(ids), false, []string{"22"}, false)
+		nsName := namespace.Name
+
+		// Configure Group.
+		groupParameters := k8stemplates.GroupParameters{
+			Namespace: nsName,
+			Name:      "test-group",
+		}
+		By(fmt.Sprintf("Applied NetworkPolicy to %v by kind label selector using group", kind))
+		groupParameters.Entity = &k8stemplates.EntitySelectorParameters{
+			Kind: strings.ToLower(kind),
+		}
+		err := utils.ConfigureK8s(kubeCtl, groupParameters, k8stemplates.CloudAntreaGroup, false)
+		Expect(err).ToNot(HaveOccurred())
+
+		anpParams.From = configANPToFrom(kind, "", "", "", "", "", nsName, []string{apachePort}, false)
+		anpParams.AppliedToGroup = &groupParameters
+		applied := make([]bool, len(ids))
+		for i := range applied {
+			applied[i] = true
+		}
+		verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
+
+		By(fmt.Sprintf("Applied NetworkPolicy to %v by name label selector using group", kind))
+		appliedIdx := len(ids) - 1
+		applied = make([]bool, len(ids))
+		applied[appliedIdx] = true
+
+		// Update Group.
+		groupParameters.Entity = &k8stemplates.EntitySelectorParameters{
+			CloudInstanceName: ids[appliedIdx],
+		}
+		err = utils.ConfigureK8s(kubeCtl, groupParameters, k8stemplates.CloudAntreaGroup, false)
+		Expect(err).ToNot(HaveOccurred())
+		verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
 	}
 
 	testEgress := func(kind string, diffNS bool) {
@@ -496,6 +546,14 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Cloud Resources", focusAws
 			reflect.TypeOf(v1alpha1.VirtualMachine{}).Name(), false),
 		table.Entry("VM In Different Namespaces",
 			reflect.TypeOf(v1alpha1.VirtualMachine{}).Name(), true),
+	)
+
+	table.DescribeTable("AppliedToUsingGroup",
+		func(kind string, diffNS bool) {
+			testAppliedToUsingGroup(kind)
+		},
+		table.Entry(fmt.Sprintf("%s: VM In Same Namespace", focusAws),
+			reflect.TypeOf(v1alpha1.VirtualMachine{}).Name(), false),
 	)
 
 	table.DescribeTable("Egress",

--- a/test/templates/vm_anp.go
+++ b/test/templates/vm_anp.go
@@ -39,12 +39,19 @@ type PortParameters struct {
 }
 
 type ANPParameters struct {
-	Name         string
-	Namespace    string
-	To           *ToFromParameters
-	From         *ToFromParameters
-	AppliedTo    *EntitySelectorParameters
-	FederatedKey *string
+	Name           string
+	Namespace      string
+	To             *ToFromParameters
+	From           *ToFromParameters
+	AppliedTo      *EntitySelectorParameters
+	AppliedToGroup *GroupParameters
+	FederatedKey   *string
+}
+
+type GroupParameters struct {
+	Name      string
+	Namespace string
+	Entity    *EntitySelectorParameters
 }
 
 const CloudAntreaNetworkPolicy = `
@@ -60,6 +67,9 @@ metadata:
 spec:
   priority: 1
   appliedTo:
+{{- if  .AppliedToGroup }}
+  - group : {{ .AppliedToGroup.Name }}
+{{ end }}
 {{- if  .AppliedTo }}
   - externalEntitySelector:
       matchLabels:
@@ -162,4 +172,27 @@ spec:
 {{ end }}
 {{- end }}{{/* .To.Ports */}}
 {{ end }} {{/* .To */}}
+`
+const CloudAntreaGroup = `
+apiVersion: crd.antrea.io/v1alpha3
+kind: Group
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+{{- if .Entity }}
+    externalEntitySelector:
+{{- if .Entity.Kind }}
+      matchLabels:
+        kind.nephe: {{.Entity.Kind}}
+{{ end }}
+{{- if .Entity.CloudInstanceName }}
+      matchLabels:
+        name.nephe: {{ .Entity.CloudInstanceName }}
+{{ end }}
+{{- if .Entity.VPC }}
+      matchLabels:
+        vpc.nephe: {{ .Entity.VPC }}
+{{ end }}
+{{ end }}
 `


### PR DESCRIPTION
Added integration test for ANP using appliedTo as
Antrea Groups rather than external entity selector. Test will first create Antrea Group and use that group as AppliedTo field in ANP

Signed-off-by: Rahul Jain <rahulj@vmware.com>