### PR TITLE
Add VM Name indexer and CES webhook changes to support Agented feature.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ mock: docker-builder
 # Run unit-tests
 unit-test: mock
 	$(DOCKERIZE) go test -coverprofile=coverage-unit.txt \
-		-covermode=atomic -count 1 $$(go list antrea.io/nephe/pkg/... antrea.io/nephe/apis/crd/v1alpha1/...)
+		-covermode=atomic -count 1 $$(go list antrea.io/nephe/pkg/...)
 
 # Run lint against code
 golangci-lint: docker-builder

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ mock: docker-builder
 # Run unit-tests
 unit-test: mock
 	$(DOCKERIZE) go test -coverprofile=coverage-unit.txt \
-		-covermode=atomic -count 1 $$(go list antrea.io/nephe/pkg/...)
+		-covermode=atomic -count 1 $$(go list antrea.io/nephe/pkg/... antrea.io/nephe/apis/crd/v1alpha1/...)
 
 # Run lint against code
 golangci-lint: docker-builder

--- a/apis/crd/v1alpha1/cloudentityselector_webhook.go
+++ b/apis/crd/v1alpha1/cloudentityselector_webhook.go
@@ -218,25 +218,105 @@ func (r *CloudEntitySelector) validateMatchSections() error {
 	// In AWS, Vpc name(in vpcMatch section) with either vm id or vm name(in vmMatch section) is not supported
 	if cloudProviderType == AzureCloudProvider {
 		for _, m := range r.Spec.VMSelector {
-			if m.VpcMatch != nil {
-				if len(strings.TrimSpace(m.VpcMatch.MatchName)) != 0 {
-					return fmt.Errorf("matchName is not supported in vpcMatch, " +
-						"use matchID instead of matchName")
-				}
+			if m.VpcMatch != nil && len(strings.TrimSpace(m.VpcMatch.MatchName)) != 0 {
+				return fmt.Errorf("matchName is not supported in vpcMatch, " +
+					"use matchID instead of matchName")
 			}
 		}
 	} else {
 		for _, m := range r.Spec.VMSelector {
-			if m.VpcMatch != nil {
-				if len(strings.TrimSpace(m.VpcMatch.MatchName)) != 0 {
-					for _, vmMatch := range m.VMMatch {
-						if len(strings.TrimSpace(vmMatch.MatchID)) != 0 ||
-							len(strings.TrimSpace(vmMatch.MatchName)) != 0 {
-							return fmt.Errorf("vpc matchName with either vm matchID" +
-								" or vm matchName is not supported, use vpc matchID instead" +
-								" of vpc matchName")
+			if m.VpcMatch != nil && len(strings.TrimSpace(m.VpcMatch.MatchName)) != 0 {
+				for _, vmMatch := range m.VMMatch {
+					if len(strings.TrimSpace(vmMatch.MatchID)) != 0 ||
+						len(strings.TrimSpace(vmMatch.MatchName)) != 0 {
+						return fmt.Errorf("vpc matchName with either vm matchID" +
+							" or vm matchName is not supported, use vpc matchID instead" +
+							" of vpc matchName")
+					}
+				}
+				if m.Agented {
+					return fmt.Errorf("vpc matchName with agented flag set to true " +
+						"is not supported, use vpc matchID instead")
+				}
+			}
+		}
+	}
+
+	// Block ambiguous match combinations as it can result in unpredictable behavior w.r.t agented configuration.
+	if err := r.validateMatchCombinations(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateMatchCombinations function validates VMSelector to find if it conflicts with other VMSelectors.
+// Block same VPC ID configuration in two VMSelectors with only vpcMatch section.
+// Block same VM ID configuration in any two VMSelectors, same is not applicable for VM Name as VM Name need not be unique.
+// Block same combination of VPC ID and VM ID configuration in any two VMSelectors.
+// Block same combination of VPC ID and VM Name configuration in any two VMSelectors.
+// Block same VM Name configuration in any two VMSelectors with only VMMatch section, when used along with VPCMatch, it is allowed.
+func (r *CloudEntitySelector) validateMatchCombinations() error {
+	// vpcIDOnlyMatch map - VPC ID as key for selector with only vpcMatch matchID.
+	// vmIDOnlyMatch map - VM ID as key for selector with only vmMatch matchID.
+	// vmNameOnlyMatch map - VM Name as key for selector with only vmMatch matchName.
+	// vmIDWithVpcMatch map - VM ID and VPC ID as key for selector with vpcMatch matchID and vmMatch matchID.
+	// vmNameWithVpcMatch map - VM Name and VPC ID as key for selector with vpcMatch matchID and vmMatch matchName.
+	vpcIDOnlyMatch := make(map[string]struct{})
+	vmIDOnlyMatch := make(map[string]struct{})
+	vmNameOnlyMatch := make(map[string]struct{})
+	vmIDWithVpcMatch := make(map[string]struct{})
+	vmNameWithVpcMatch := make(map[string]struct{})
+	exists := struct{}{}
+
+	for _, selector := range r.Spec.VMSelector {
+		if selector.VpcMatch != nil {
+			if selector.VpcMatch.MatchID != "" {
+				if len(selector.VMMatch) == 0 {
+					if _, found := vpcIDOnlyMatch[selector.VpcMatch.MatchID]; found {
+						return fmt.Errorf("same vpcMatch matchID %v configured in two match selectors",
+							selector.VpcMatch.MatchID)
+					}
+					vpcIDOnlyMatch[selector.VpcMatch.MatchID] = exists
+				} else {
+					for _, n := range selector.VMMatch {
+						if n.MatchID != "" {
+							index := n.MatchID + "/" + selector.VpcMatch.MatchID
+							if _, found := vmIDWithVpcMatch[index]; found {
+								return fmt.Errorf("same vpcMatch matchID %v and vmMatch matchID %v configured"+
+									" in two match selectors", selector.VpcMatch.MatchID, n.MatchID)
+							}
+							vmIDWithVpcMatch[index] = exists
+
+							// VM ID is unique across account. Irrespective of VPC match,
+							// same VM ID config in two VMSelector is not allowed.
+							if _, found := vmIDOnlyMatch[n.MatchID]; found {
+								return fmt.Errorf("same vmMatch matchID %v configured in two match selectors", n.MatchID)
+							}
+							vmIDOnlyMatch[n.MatchID] = exists
+						} else { // Applicable for matchName.
+							index := n.MatchName + "/" + selector.VpcMatch.MatchID
+							if _, found := vmNameWithVpcMatch[index]; found {
+								return fmt.Errorf("same vpcMatch matchID %v and vmMatch matchName %v configured"+
+									" in two match selectors", selector.VpcMatch.MatchID, n.MatchName)
+							}
+							vmNameWithVpcMatch[index] = exists
 						}
 					}
+				}
+			}
+		} else {
+			for _, n := range selector.VMMatch {
+				if n.MatchID != "" {
+					if _, found := vmIDOnlyMatch[n.MatchID]; found {
+						return fmt.Errorf("same vmMatch matchID %v configured in two match selectors", n.MatchID)
+					}
+					vmIDOnlyMatch[n.MatchID] = exists
+				} else {
+					if _, found := vmNameOnlyMatch[n.MatchName]; found {
+						return fmt.Errorf("same vmMatch matchName %v configured in two match selectors", n.MatchName)
+					}
+					vmNameOnlyMatch[n.MatchName] = exists
 				}
 			}
 		}

--- a/apis/crd/v1alpha1/cloudentityselector_webhook_test.go
+++ b/apis/crd/v1alpha1/cloudentityselector_webhook_test.go
@@ -1,0 +1,521 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("CloudEntitySelectorWebhook", func() {
+	Context("Validation of CES configuration", func() {
+		var (
+			testAccountNamespacedName = types.NamespacedName{Namespace: "namespace01", Name: "account01"}
+			testSecretNamespacedName  = types.NamespacedName{Namespace: "namespace01", Name: "secret01"}
+			credentials               = "credentials"
+			account                   *CloudProviderAccount
+			selector                  *CloudEntitySelector
+			fakeClient                k8sclient.WithWatch
+			err                       error
+			newScheme                 *runtime.Scheme
+			pollIntv                  uint = 1
+		)
+
+		BeforeEach(func() {
+			account = &CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AWSConfig: &CloudProviderAccountAWSConfig{
+						Region: "us-east-1",
+						SecretRef: &SecretReference{
+							Name:      testSecretNamespacedName.Name,
+							Namespace: testSecretNamespacedName.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+
+			newScheme = runtime.NewScheme()
+			utilruntime.Must(clientgoscheme.AddToScheme(newScheme))
+			utilruntime.Must(AddToScheme(newScheme))
+			fakeClient = fake.NewClientBuilder().WithScheme(newScheme).Build()
+			client = fakeClient
+		})
+		It("Validate vpcMatch matchName with vmMatch in AWS", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchName: "abc",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "def",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err = selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("vpc matchName with either vm matchID" +
+				" or vm matchName is not supported"))
+		})
+		It("Validate vpcMatch matchName with Agented = true in AWS", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchName: "abc",
+							},
+							Agented: true,
+						},
+					},
+				},
+			}
+
+			err = selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("vpc matchName with agented flag set to true" +
+				" is not supported"))
+		})
+		It("Validate vpcMatch matchName in Azure", func() {
+			account = &CloudProviderAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudProviderAccountSpec{
+					PollIntervalInSeconds: &pollIntv,
+					AzureConfig: &CloudProviderAccountAzureConfig{
+						Region: "us-east-1",
+						SecretRef: &SecretReference{
+							Name:      testSecretNamespacedName.Name,
+							Namespace: testSecretNamespacedName.Namespace,
+							Key:       credentials,
+						},
+					},
+				},
+			}
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchName: "abc",
+							},
+						},
+					},
+				},
+			}
+			err = selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("matchName is not supported in vpcMatch"))
+		})
+
+		It("Validate same vpcMatch matchID in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+						},
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("same vpcMatch matchID abc configured in two match selectors"))
+		})
+		It("Validate same vmMatch matchID(with vpcMatch in one) in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "def",
+								},
+							},
+						},
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "def",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("same vmMatch matchID def configured in" +
+				" two match selectors"))
+		})
+		It("Validate same vpcMatch matchID and vmMatch matchID in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "def",
+								},
+							},
+						},
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "def",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("same vpcMatch matchID abc and vmMatch matchID def" +
+				" configured in two match selectors"))
+		})
+		It("Validate same vmMatch matchID in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "abc",
+								},
+							},
+						},
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "abc",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("same vmMatch matchID abc configured in two" +
+				" match selectors"))
+		})
+		It("Validate different vmMatch matchID in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "def",
+								},
+							},
+						},
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchID: "xyz",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Validate same vpcMatch matchID and vmMatch matchName in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "def",
+								},
+							},
+						},
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "def",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("same vpcMatch matchID abc and vmMatch matchName def" +
+				" configured"))
+		})
+		It("Validate different vpcMatch matchID and same vmMatch matchName in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "def",
+								},
+							},
+						},
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "xyz",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "def",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Validate same vmMatch matchName(vpcMatch matchID in one) in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VpcMatch: &EntityMatch{
+								MatchID: "abc",
+							},
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "def",
+								},
+							},
+						},
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "def",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Validate same vmMatch matchName in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "abc",
+								},
+							},
+						},
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "abc",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("same vmMatch matchName abc configured in two match selectors"))
+		})
+		It("Validate different vmMatch matchName in two vmSelectors", func() {
+			err = fakeClient.Create(context.Background(), account)
+			Expect(err).Should(BeNil())
+
+			selector = &CloudEntitySelector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testAccountNamespacedName.Name,
+					Namespace: testAccountNamespacedName.Namespace,
+				},
+				Spec: CloudEntitySelectorSpec{
+					AccountName: testAccountNamespacedName.Name,
+					VMSelector: []VirtualMachineSelector{
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "def",
+								},
+							},
+						},
+						{
+							VMMatch: []EntityMatch{
+								{
+									MatchName: "xyz",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := selector.validateMatchSections()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/apis/crd/v1alpha1/cloudentityselector_webhook_test.go
+++ b/apis/crd/v1alpha1/cloudentityselector_webhook_test.go
@@ -16,7 +16,6 @@ package v1alpha1
 
 import (
 	"context"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +33,9 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			testAccountNamespacedName = types.NamespacedName{Namespace: "namespace01", Name: "account01"}
 			testSecretNamespacedName  = types.NamespacedName{Namespace: "namespace01", Name: "secret01"}
 			credentials               = "credentials"
+			testAbc                   = "abc"
+			testDef                   = "def"
+			testXyz                   = "xyz"
 			account                   *CloudProviderAccount
 			selector                  *CloudEntitySelector
 			fakeClient                k8sclient.WithWatch
@@ -81,11 +83,11 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchName: "abc",
+								MatchName: testAbc,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "def",
+									MatchID: testDef,
 								},
 							},
 						},
@@ -95,8 +97,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 
 			err = selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("vpc matchName with either vm matchID" +
-				" or vm matchName is not supported"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgUnsupportedVPCMatchName02))
 		})
 		It("Validate vpcMatch matchName with Agented = true in AWS", func() {
 			err = fakeClient.Create(context.Background(), account)
@@ -112,7 +113,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchName: "abc",
+								MatchName: testAbc,
 							},
 							Agented: true,
 						},
@@ -122,8 +123,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 
 			err = selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("vpc matchName with agented flag set to true" +
-				" is not supported"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgUnsupportedAgented))
 		})
 		It("Validate vpcMatch matchName in Azure", func() {
 			account = &CloudProviderAccount{
@@ -156,7 +156,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchName: "abc",
+								MatchName: testAbc,
 							},
 						},
 					},
@@ -164,7 +164,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			}
 			err = selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("matchName is not supported in vpcMatch"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgUnsupportedVPCMatchName01))
 		})
 
 		It("Validate same vpcMatch matchID in two vmSelectors", func() {
@@ -181,12 +181,12 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 						},
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 						},
 					},
@@ -194,7 +194,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			}
 			err := selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("same vpcMatch matchID abc configured in two match selectors"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgSameVPCMatchID))
 		})
 		It("Validate same vmMatch matchID(with vpcMatch in one) in two vmSelectors", func() {
 			err = fakeClient.Create(context.Background(), account)
@@ -210,18 +210,18 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "def",
+									MatchID: testDef,
 								},
 							},
 						},
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "def",
+									MatchID: testDef,
 								},
 							},
 						},
@@ -230,8 +230,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			}
 			err := selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("same vmMatch matchID def configured in" +
-				" two match selectors"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgSameVMMatchID))
 		})
 		It("Validate same vpcMatch matchID and vmMatch matchID in two vmSelectors", func() {
 			err = fakeClient.Create(context.Background(), account)
@@ -247,21 +246,21 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "def",
+									MatchID: testDef,
 								},
 							},
 						},
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "def",
+									MatchID: testDef,
 								},
 							},
 						},
@@ -270,8 +269,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			}
 			err := selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("same vpcMatch matchID abc and vmMatch matchID def" +
-				" configured in two match selectors"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgSameVMAndVPCMatch))
 		})
 		It("Validate same vmMatch matchID in two vmSelectors", func() {
 			err = fakeClient.Create(context.Background(), account)
@@ -288,14 +286,14 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "abc",
+									MatchID: testAbc,
 								},
 							},
 						},
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "abc",
+									MatchID: testAbc,
 								},
 							},
 						},
@@ -304,8 +302,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			}
 			err := selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("same vmMatch matchID abc configured in two" +
-				" match selectors"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgSameVMMatchID))
 		})
 		It("Validate different vmMatch matchID in two vmSelectors", func() {
 			err = fakeClient.Create(context.Background(), account)
@@ -322,14 +319,14 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "def",
+									MatchID: testDef,
 								},
 							},
 						},
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchID: "xyz",
+									MatchID: testXyz,
 								},
 							},
 						},
@@ -353,21 +350,21 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "def",
+									MatchName: testDef,
 								},
 							},
 						},
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "def",
+									MatchName: testDef,
 								},
 							},
 						},
@@ -376,8 +373,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			}
 			err := selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("same vpcMatch matchID abc and vmMatch matchName def" +
-				" configured"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgSameVMAndVPCMatch))
 		})
 		It("Validate different vpcMatch matchID and same vmMatch matchName in two vmSelectors", func() {
 			err = fakeClient.Create(context.Background(), account)
@@ -393,21 +389,21 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "def",
+									MatchName: testDef,
 								},
 							},
 						},
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "xyz",
+								MatchID: testXyz,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "def",
+									MatchName: testDef,
 								},
 							},
 						},
@@ -417,6 +413,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			err := selector.validateMatchSections()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
+
 		It("Validate same vmMatch matchName(vpcMatch matchID in one) in two vmSelectors", func() {
 			err = fakeClient.Create(context.Background(), account)
 			Expect(err).Should(BeNil())
@@ -431,18 +428,18 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 					VMSelector: []VirtualMachineSelector{
 						{
 							VpcMatch: &EntityMatch{
-								MatchID: "abc",
+								MatchID: testAbc,
 							},
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "def",
+									MatchName: testDef,
 								},
 							},
 						},
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "def",
+									MatchName: testDef,
 								},
 							},
 						},
@@ -467,14 +464,14 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "abc",
+									MatchName: testAbc,
 								},
 							},
 						},
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "abc",
+									MatchName: testAbc,
 								},
 							},
 						},
@@ -483,7 +480,7 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 			}
 			err := selector.validateMatchSections()
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("same vmMatch matchName abc configured in two match selectors"))
+			Expect(err.Error()).Should(ContainSubstring(errorMsgSameVMMatchName))
 		})
 		It("Validate different vmMatch matchName in two vmSelectors", func() {
 			err = fakeClient.Create(context.Background(), account)
@@ -500,14 +497,14 @@ var _ = Describe("CloudEntitySelectorWebhook", func() {
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "def",
+									MatchName: testDef,
 								},
 							},
 						},
 						{
 							VMMatch: []EntityMatch{
 								{
-									MatchName: "xyz",
+									MatchName: testXyz,
 								},
 							},
 						},

--- a/apis/crd/v1alpha1/v1alpha1_suite_test.go
+++ b/apis/crd/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "V1alpha1 Suite")
+}

--- a/pkg/controllers/cloud/cloudentityselector_controller.go
+++ b/pkg/controllers/cloud/cloudentityselector_controller.go
@@ -36,9 +36,10 @@ import (
 )
 
 const (
-	virtualMachineIndexerByCloudAccount     = "virtualmachine.cloudaccount"
-	virtualMachineSelectorMatchIndexerByID  = "virtualmachine.selector.id"
-	virtualMachineSelectorMatchIndexerByVPC = "virtualmachine.selector.vpc.id"
+	virtualMachineIndexerByCloudAccount      = "virtualmachine.cloudaccount"
+	virtualMachineSelectorMatchIndexerByID   = "virtualmachine.selector.id"
+	virtualMachineSelectorMatchIndexerByName = "virtualmachine.selector.name"
+	virtualMachineSelectorMatchIndexerByVPC  = "virtualmachine.selector.vpc.id"
 )
 
 // CloudEntitySelectorReconciler reconciles a CloudEntitySelector object.
@@ -217,6 +218,19 @@ func (r *CloudEntitySelectorReconciler) addAccountPoller(selector *cloudv1alpha1
 				for _, vmMatch := range m.VMMatch {
 					if len(vmMatch.MatchID) > 0 {
 						match = append(match, strings.ToLower(vmMatch.MatchID))
+					}
+				}
+				return match, nil
+			},
+			virtualMachineSelectorMatchIndexerByName: func(obj interface{}) ([]string, error) {
+				m := obj.(*cloudv1alpha1.VirtualMachineSelector)
+				if len(m.VMMatch) == 0 {
+					return nil, nil
+				}
+				var match []string
+				for _, vmMatch := range m.VMMatch {
+					if len(vmMatch.MatchName) > 0 {
+						match = append(match, strings.ToLower(vmMatch.MatchName))
 					}
 				}
 				return match, nil


### PR DESCRIPTION
- Webhook changes to not allow conflicting configuration in CES.
- Add VM name indexer to match imported cloud VM to the available vmSelectors.

Signed-off-by: Archana Holla <harchana@vmware.com>