### PR TITLE
Normalizes ANP Object for Azure Cloud

### DIFF
--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -124,6 +124,11 @@ func getGroupIDFromUniqueName(name string) (string, bool) {
 	return name, false
 }
 
+// getNormalizedName replaces any occurrence of / with -.
+func getNormalizedName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, "/", "-"))
+}
+
 // diffAppliedToGrp returned added and removed groups from appliedToGroup a to b.
 func diffAppliedToGrp(a, b []string) ([]string, []string) {
 	temp := map[string]int{}


### PR DESCRIPTION
Azure Cloud doesn't handle / in any cloud resource name. So we normalize the object before calling cloud plugin. This is temporary workaround till https://github.com/antrea-io/antrea/issues/4264 issue is fixed in Antrea.

Signed-off-by: Rahul Jain <reachjainrahul@gmail.com>