### PR TITLE
Extend External Node Integration test for VPC ID and VM Name.

### DIFF
--- a/test/integration/externalnode_test.go
+++ b/test/integration/externalnode_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -43,6 +44,13 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 	const (
 		namespaceName   = "external-node-test"
 		testAccountName = "external-node-test-account"
+		vmPrefix        = "virtualmachine"
+	)
+
+	const (
+		vpcIDMatch  = "vpc-id"
+		vmIDMatch   = "vm-id"
+		vmNameMatch = "vm-name"
 	)
 
 	var (
@@ -52,11 +60,13 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 		selector      *v1alpha1.CloudEntitySelector
 		secret        *corev1.Secret
 		cloudProvider string
-		vmIdToMatch   string
-		testVm        string
-		nic           string
-		publicIp      string
-		privateIp     string
+		vpcID         string
+		vmList        []string
+		vmIDList      []string
+		vmNameList    []string
+		nics          []string
+		publicIps     []string
+		privateIps    []string
 	)
 
 	createNS := func() {
@@ -88,22 +98,57 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	applyCloudEntitySelector := func(selectorExists bool, agented bool) error {
-		logf.Log.Info("Apply entity selector with VM ID as a matchID", "VM ID", vmIdToMatch)
-		if len(selector.Spec.VMSelector) == 0 {
-			selector.Spec.VMSelector = append(selector.Spec.VMSelector,
-				v1alpha1.VirtualMachineSelector{
-					VMMatch: []v1alpha1.EntityMatch{
-						{
-							MatchID: vmIdToMatch,
+	applyCloudEntitySelector := func(matchKey string, matchValue string, agented bool, selectorExists bool) error {
+		logf.Log.Info("Apply entity selector with", matchKey, matchValue)
+		switch matchKey {
+		case vpcIDMatch:
+			if len(selector.Spec.VMSelector) == 0 {
+				selector.Spec.VMSelector = append(selector.Spec.VMSelector,
+					v1alpha1.VirtualMachineSelector{
+						VpcMatch: &v1alpha1.EntityMatch{
+							MatchID: matchValue,
 						},
-					},
-					Agented: agented,
-				})
-		} else {
-			selector.Spec.VMSelector[0].VMMatch[0].MatchID = vmIdToMatch
-			selector.Spec.VMSelector[0].Agented = agented
+						Agented: agented,
+					})
+			} else {
+				selector.Spec.VMSelector[0].VpcMatch.MatchID = matchValue
+				selector.Spec.VMSelector[0].Agented = agented
+			}
+
+		case vmIDMatch:
+			if len(selector.Spec.VMSelector) == 0 {
+				selector.Spec.VMSelector = append(selector.Spec.VMSelector,
+					v1alpha1.VirtualMachineSelector{
+						VMMatch: []v1alpha1.EntityMatch{
+							{
+								MatchID: matchValue,
+							},
+						},
+						Agented: agented,
+					})
+			} else {
+				selector.Spec.VMSelector[0].VMMatch[0].MatchID = matchValue
+				selector.Spec.VMSelector[0].Agented = agented
+			}
+		case vmNameMatch:
+			if len(selector.Spec.VMSelector) == 0 {
+				selector.Spec.VMSelector = append(selector.Spec.VMSelector,
+					v1alpha1.VirtualMachineSelector{
+						VMMatch: []v1alpha1.EntityMatch{
+							{
+								MatchName: matchValue,
+							},
+						},
+						Agented: agented,
+					})
+			} else {
+				selector.Spec.VMSelector[0].VMMatch[0].MatchName = matchValue
+				selector.Spec.VMSelector[0].Agented = agented
+			}
+		default:
+			Fail("invalid matchKey")
 		}
+
 		var err error
 		if selectorExists {
 			err = k8sClient.Update(context.TODO(), selector)
@@ -119,58 +164,99 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 		return err
 	}
 
-	validateResult := func(expectedResult string, kubectlCmd string, agented bool, en *antreav1alpha1.ExternalNode,
-		ee *antreav1alpha2.ExternalEntity) {
-		var actualResult string
+	removeEmptyStr := func(input []string) []string {
+		var output []string
+		for _, vm := range input {
+			if vm != "" {
+				output = append(output, vm)
+			}
+		}
+		return output
+	}
+
+	checkEqual := func(actual, expected []string) bool {
+		if len(actual) != len(expected) {
+			logf.Log.Error(fmt.Errorf(""), "number of items is not same",
+				"actual", actual, "expected", expected)
+			return false
+		}
+		sort.Slice(actual, func(i, j int) bool {
+			return strings.Compare(actual[i], actual[j]) < 0
+		})
+		sort.Slice(expected, func(i, j int) bool {
+			return strings.Compare(expected[i], expected[j]) < 0
+		})
+		for i, v := range actual {
+			if v != expected[i] {
+				logf.Log.Error(fmt.Errorf(""), "mismatch between the actual and expected value",
+					"actual", actual, "expected", expected)
+				return false
+			}
+		}
+		return true
+	}
+
+	validateResult := func(expectedResult []string, kubectlCmd string, agented bool, enList []antreav1alpha1.ExternalNode,
+		eeList []antreav1alpha2.ExternalEntity) {
+		var actualResult []string
+		// Keep a copy of expectedResult as the content of slice gets reordered in checkEqual() function.
+		copyExpected := make([]string, len(expectedResult))
+		copy(copyExpected, expectedResult)
 
 		output, err := kubeCtl.Cmd(kubectlCmd)
 		Expect(err).ToNot(HaveOccurred())
-
 		// Trim ' from output and remove trailing "\n".
 		stringList := strings.Split(strings.Trim(output, "'"), "\n")
 		if len(stringList) > 0 {
-			actualResult = stringList[0]
+			actualResult = removeEmptyStr(stringList)
 		} else {
-			actualResult = ""
+			actualResult = nil
 		}
+
 		if agented == true {
-			logf.Log.Info("Validate External Node Name", "Actual", actualResult, "Expected", expectedResult)
-			Expect(actualResult == expectedResult).To(BeTrue())
+			logf.Log.V(2).Info("Validate generated External Node Name(s) with Expected",
+				"Actual", actualResult, "Expected", copyExpected)
+			Expect(checkEqual(actualResult, copyExpected)).To(BeTrue())
 
-			// Validate spec field in the generated External Node CR.
-			spec := &antreav1alpha1.ExternalNodeSpec{
-				Interfaces: []antreav1alpha1.NetworkInterface{
-					{
-						Name: strings.ToLower(nic),
-						IPs:  []string{privateIp, publicIp},
+			// Validate spec field of each generated External Node CR against expected.
+			for index, en := range enList {
+				expectedSpec := &antreav1alpha1.ExternalNodeSpec{
+					Interfaces: []antreav1alpha1.NetworkInterface{
+						{
+							Name: strings.ToLower(nics[index]),
+							IPs:  []string{privateIps[index], publicIps[index]},
+						},
 					},
-				},
+				}
+				logf.Log.V(2).Info("Validate External Node Spec", "Actual", &en.Spec, "Expected", expectedSpec)
+				Expect(&en.Spec).To(Equal(expectedSpec))
 			}
-			logf.Log.Info("Validate External Node Spec", "Actual", &en.Spec, "Expected", spec)
-			Expect(&en.Spec).To(Equal(spec))
+
 		} else {
-			logf.Log.Info("Validate External Entity Name", "Actual", actualResult, "Expected", expectedResult)
-			Expect(actualResult == expectedResult).To(BeTrue())
+			logf.Log.V(2).Info("Validate generated External Entity Name(s) with Expected",
+				"Actual", actualResult, "Expected", expectedResult)
+			Expect(checkEqual(actualResult, copyExpected)).To(BeTrue())
 
-			// Validate spec field in the generated External Entity CR.
-			spec := &antreav1alpha2.ExternalEntitySpec{
-				Endpoints: []antreav1alpha2.Endpoint{
-					{
-						IP: privateIp,
+			// Validate spec field of each generated External Entity CR against expected.
+			for index, ee := range eeList {
+				expectedSpec := &antreav1alpha2.ExternalEntitySpec{
+					Endpoints: []antreav1alpha2.Endpoint{
+						{
+							IP: privateIps[index],
+						},
+						{
+							IP: publicIps[index],
+						},
 					},
-					{
-						IP: publicIp,
-					},
-				},
-				ExternalNode: config.ANPNepheController,
+					ExternalNode: config.ANPNepheController,
+				}
+				logf.Log.V(2).Info("Validate External Entity Spec", "Actual", &ee.Spec, "Expected", expectedSpec)
+				Expect(&ee.Spec).To(Equal(expectedSpec))
 			}
-			logf.Log.Info("Validate External Entity Spec", "Actual", &ee.Spec, "Expected", spec)
-			Expect(&ee.Spec).To(Equal(spec))
 		}
 	}
 
 	checkEnCreated := func(key client.ObjectKey, en *antreav1alpha1.ExternalNode) error {
-		logf.Log.Info("Check for External Node creation")
 		err := wait.PollImmediate(time.Second*5, time.Second*60, func() (bool, error) {
 			ret := k8sClient.Get(context.TODO(), key, en)
 			if ret != nil {
@@ -182,7 +268,6 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 	}
 
 	checkEeCreated := func(key client.ObjectKey, ee *antreav1alpha2.ExternalEntity) error {
-		logf.Log.Info("Check for External Entity creation")
 		err := wait.PollImmediate(time.Second*5, time.Second*60, func() (bool, error) {
 			ret := k8sClient.Get(context.TODO(), key, ee)
 			if ret != nil {
@@ -193,12 +278,12 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 		return err
 	}
 
-	checkEnDeleted := func(key client.ObjectKey) error {
+	checkAllEnDeleted := func() error {
 		logf.Log.Info("Check for External Node deletion")
 		err := wait.PollImmediate(time.Second*5, time.Second*60, func() (bool, error) {
-			en := &antreav1alpha1.ExternalNode{}
-			ret := k8sClient.Get(context.TODO(), key, en)
-			if ret != nil && errors.IsNotFound(ret) {
+			enList := &antreav1alpha1.ExternalNodeList{}
+			ret := k8sClient.List(context.TODO(), enList, client.InNamespace(namespace.Name))
+			if ret == nil && len(enList.Items) == 0 {
 				return true, nil
 			}
 			return false, nil
@@ -207,7 +292,6 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 	}
 
 	checkEeDeleted := func(key client.ObjectKey) error {
-		logf.Log.Info("Check for External Entity deletion")
 		err := wait.PollImmediate(time.Second*5, time.Second*60, func() (bool, error) {
 			ee := &antreav1alpha2.ExternalEntity{}
 			ret := k8sClient.Get(context.TODO(), key, ee)
@@ -219,57 +303,73 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 		return err
 	}
 
-	tester := func(expectedResult string, selectorExists bool, agented bool, isDelete bool) {
-		fetchKey := client.ObjectKey{
-			Name:      expectedResult,
-			Namespace: namespace.Name,
-		}
+	tester := func(matchKey string, matchValue string, agented bool, expectedResult []string, selectorExists bool,
+		isDelete bool) {
 		if agented == true && isDelete == true {
 			err := deleteCloudEntitySelector()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = checkEnDeleted(fetchKey)
+			err = checkAllEnDeleted()
 			if err != nil {
-				logf.Log.Error(err, "External Node delete failed", "fetch key", fetchKey)
+				logf.Log.Error(err, "external node delete failed", "namespace", namespace.Name)
 			}
 			Expect(err).NotTo(HaveOccurred())
 		} else {
-			err := applyCloudEntitySelector(selectorExists, agented)
+			err := applyCloudEntitySelector(matchKey, matchValue, agented, selectorExists)
 			Expect(err).ToNot(HaveOccurred())
 
 			var kubectlCmd string
 			en := &antreav1alpha1.ExternalNode{}
 			ee := &antreav1alpha2.ExternalEntity{}
+			var enList []antreav1alpha1.ExternalNode
+			var eeList []antreav1alpha2.ExternalEntity
 			if agented == true {
-				// Check if External Node is getting created.
-				err := checkEnCreated(fetchKey, en)
-				if err != nil {
-					logf.Log.Error(err, "External Node creation failed", "fetch key", fetchKey)
-				}
-				Expect(err).NotTo(HaveOccurred())
-
-				// Check if External entity is deleted when transitioned from agented = false.
-				if selectorExists == true {
-					err = checkEeDeleted(fetchKey)
+				logf.Log.Info("Check for External Node creation")
+				for _, expectedEn := range expectedResult {
+					fetchKey := client.ObjectKey{
+						Name:      expectedEn,
+						Namespace: namespace.Name,
+					}
+					// Check if each External Node(matching expectedResult) is getting created.
+					err := checkEnCreated(fetchKey, en)
 					if err != nil {
-						logf.Log.Error(err, "External Entity deletion failed", "fetch key", fetchKey)
+						logf.Log.Error(err, "external node creation failed", "fetch key", fetchKey)
 					}
 					Expect(err).NotTo(HaveOccurred())
+					// For future validation purpose, store External Nodes in the order processed.
+					enList = append(enList, *en)
+
+					// Check if External entity(corresponding to External Node) is deleted when moved from agented = false.
+					if selectorExists == true {
+						err = checkEeDeleted(fetchKey)
+						if err != nil {
+							logf.Log.Error(err, "external entity deletion failed", "fetch Key", fetchKey)
+						}
+						Expect(err).NotTo(HaveOccurred())
+					}
 				}
 
 				kubectlCmd = fmt.Sprintf("get externalnode -n %s -o=jsonpath='{range.items[*]}{.metadata.name}{\"\\n\"}{end}'", namespace.Name)
 			} else {
 				// Check if External Entity is getting created.
-				err := checkEeCreated(fetchKey, ee)
-				if err != nil {
-					logf.Log.Error(err, "External Entity creation failed", "fetch key", fetchKey)
+				logf.Log.Info("Check for External Entity creation")
+				for _, expectedEe := range expectedResult {
+					fetchKey := client.ObjectKey{
+						Name:      expectedEe,
+						Namespace: namespace.Name,
+					}
+					err := checkEeCreated(fetchKey, ee)
+					if err != nil {
+						logf.Log.Error(err, "external entity creation failed", "fetch key", fetchKey)
+					}
+					Expect(err).NotTo(HaveOccurred())
+					// For future validation purpose, store External Entities in the order processed.
+					eeList = append(eeList, *ee)
 				}
-				Expect(err).NotTo(HaveOccurred())
-
-				// Check if External Node is deleted when transitioned from agented = true.
-				err = checkEnDeleted(fetchKey)
+				// Check if External Nodes are deleted when transitioned from agented = true.
+				err = checkAllEnDeleted()
 				if err != nil {
-					logf.Log.Error(err, "External Node deletion failed", "fetch key", fetchKey)
+					logf.Log.Error(err, "external node deletion failed", "namespace", namespace.Name)
 				}
 				Expect(err).NotTo(HaveOccurred())
 
@@ -277,7 +377,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 			}
 
 			// Validate generated CR and the spec.
-			validateResult(expectedResult, kubectlCmd, agented, en, ee)
+			validateResult(expectedResult, kubectlCmd, agented, enList, eeList)
 		}
 	}
 
@@ -288,11 +388,13 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 		namespace = &corev1.Namespace{}
 		namespace.Name = namespaceName + "-" + fmt.Sprintf("%x", rand.Int())
 
-		vmIdToMatch = cloudVPC.GetVMIDs()[0]
-		testVm = cloudVPC.GetVMs()[0]
-		nic = cloudVPC.GetPrimaryNICs()[0]
-		publicIp = cloudVPC.GetVMIPs()[0]
-		privateIp = cloudVPC.GetVMPrivateIPs()[0]
+		vpcID = cloudVPC.GetVPCID()
+		vmList = cloudVPC.GetVMs()
+		vmIDList = cloudVPC.GetVMIDs()
+		vmNameList = cloudVPC.GetVMNames()
+		nics = cloudVPC.GetPrimaryNICs()
+		publicIps = cloudVPC.GetVMIPs()
+		privateIps = cloudVPC.GetVMPrivateIPs()
 
 		accountParameters := cloudVPC.GetCloudAccountParameters(testAccountName, namespace.Name, cloudCluster)
 		cloudProvider = strings.Split(cloudProviders, ",")[0]
@@ -377,22 +479,41 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 	})
 
 	table.DescribeTable("Testing agented and agentless configuration through CES",
-		func() {
-			expectedResult := fmt.Sprintf("virtualmachine-%s", testVm)
+		func(matchKey string) {
+			var matchValue string
+			var expectedResult []string
+
+			switch matchKey {
+			case vpcIDMatch:
+				matchValue = vpcID
+				for _, vm := range vmList {
+					expectedResult = append(expectedResult, fmt.Sprintf("%s-%s", vmPrefix, vm))
+				}
+			case vmIDMatch:
+				matchValue = vmIDList[0]
+				expectedResult = append(expectedResult, fmt.Sprintf("%s-%s", vmPrefix, vmList[0]))
+			case vmNameMatch:
+				matchValue = vmNameList[0]
+				expectedResult = append(expectedResult, fmt.Sprintf("%s-%s", vmPrefix, vmList[0]))
+			default:
+				Fail("Invalid match key")
+			}
 
 			By("Configure entity selector with agented field set to true, check ExternalNode creation")
-			tester(expectedResult, false, true, false)
+			tester(matchKey, matchValue, true, expectedResult, false, false)
 
 			By("Change entity selector with agented field set to false, check ExternalEntity creation")
-			tester(expectedResult, true, false, false)
+			tester(matchKey, matchValue, false, expectedResult, true, false)
 
 			By("Change entity selector back to agented field set to true, check ExternalNode creation")
-			tester(expectedResult, true, true, false)
+			tester(matchKey, matchValue, true, expectedResult, true, false)
 
 			By("Delete entity selector and check for External Node deletion")
-			tester(expectedResult, true, true, true)
+			tester(matchKey, matchValue, true, expectedResult, true, true)
 
 		},
-		table.Entry("Test External Node Lifecycle"),
+		table.Entry("Test External Node Lifecycle: VPC ID Match", vpcIDMatch),
+		table.Entry("Test External Node Lifecycle: VM ID Match", vmIDMatch),
+		table.Entry("Test External Node Lifecycle: VM Name Match", vmNameMatch),
 	)
 })


### PR DESCRIPTION
- Use VPC ID as match criteria in CES for external node life cycle test.
- Similarly use VM Name as another match criteria.