### PR TITLE
Fix agented ci test vpc destroy issue

### DIFF
--- a/hack/aks
+++ b/hack/aks
@@ -60,7 +60,7 @@ function apply {
   validate
   mkdir -p $RUN_PATH
   if [ $? -ne 0 ]; then
-     echo $RUN_PATH cannot be created
+     echo "$RUN_PATH cannot be created"
      exit 1
   fi
   cp $CONFIG_PATH/* $RUN_PATH
@@ -75,9 +75,9 @@ function apply {
     echo "aks creation failed"
     exit 1
   fi
-  echo aks cluster created.
+  echo "aks cluster created"
   $TERRAFORM output -json kube_config | jq -r . > $RUN_PATH/kubeconfig
-  echo run aks kubectl ... to acess it.
+  echo "run aks kubectl ... to access it"
 
   if [ -z $CREATE_ONLY ]; then
      KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-aks-node-init.yml
@@ -95,6 +95,11 @@ function destroy {
   # Remove any resources created by antrea.
   KUBECONFIG=$RUN_PATH/kubeconfig kubectl delete -f antrea-aks.yml
   $TERRAFORM destroy -auto-approve
+  if [[ $? -ne 0 ]]; then
+    echo "vm cluster deletion failed"
+    exit 1
+  fi
+  echo "aks cluster deleted"
 }
 
 function load {
@@ -112,6 +117,10 @@ function output {
   fi
   cd $RUN_PATH
   $TERRAFORM output
+  if [[ $? -ne 0 ]]; then
+    echo "aks output failed"
+    exit 1
+  fi
 }
 
 while [[ $# -gt 0 ]]

--- a/hack/aks
+++ b/hack/aks
@@ -30,45 +30,45 @@ _usage="Usage: $0 :
                 [load] : load image to aks cluster
                 [--help|h]"
 
-function print_help {
-    echo "Try '$0 --help' for more information."
+function print_help() {
+  echo "Try '$0 --help' for more information."
 }
 
-function print_usage {
-    echo "$_usage"
+function print_usage() {
+  echo "$_usage"
 }
 
-function validate {
+function validate() {
   for cmd in ${CMD_ARRAY[@]}; do
-     which $cmd > /dev/null 2>&1
-     if [ $? -ne 0 ]; then
-       echo $cmd not found, please install first
-       exit 1
-     fi
+    which $cmd >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      echo $cmd not found, please install first
+      exit 1
+    fi
   done
 
   for env in ${ENV_ARRAY[@]}; do
-     printenv $env > /dev/null 2>&1
-     if [ $? -ne 0 ]; then
-       echo required environment variable $env is not set.
-       exit 1
-     fi
+    printenv $env >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      echo required environment variable $env is not set.
+      exit 1
+    fi
   done
 }
 
-function apply {
+function apply() {
   validate
   mkdir -p $RUN_PATH
   if [ $? -ne 0 ]; then
-     echo "$RUN_PATH cannot be created"
-     exit 1
+    echo "$RUN_PATH cannot be created"
+    exit 1
   fi
   cp $CONFIG_PATH/* $RUN_PATH
 
   cd $RUN_PATH
   $TERRAFORM init
   if [ $? -ne 0 ]; then
-     exit 1
+    exit 1
   fi
   $TERRAFORM apply -auto-approve
   if [[ $? -ne 0 ]]; then
@@ -76,18 +76,18 @@ function apply {
     exit 1
   fi
   echo "aks cluster created"
-  $TERRAFORM output -json kube_config | jq -r . > $RUN_PATH/kubeconfig
+  $TERRAFORM output -json kube_config | jq -r . >$RUN_PATH/kubeconfig
   echo "run aks kubectl ... to access it"
 
   if [ -z $CREATE_ONLY ]; then
-     KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-aks-node-init.yml
-     KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-aks.yml
-     KUBECONFIG=$RUN_PATH/kubeconfig kubectl create namespace cert-manager
-     KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply --validate=false -f "https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml"
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-aks-node-init.yml
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-aks.yml
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl create namespace cert-manager
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply --validate=false -f "https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml"
   fi
 }
 
-function destroy {
+function destroy() {
   if [ ! -d $RUN_PATH ]; then
     exit 0
   fi
@@ -102,7 +102,7 @@ function destroy {
   echo "aks cluster deleted"
 }
 
-function load {
+function load() {
   image=$1
   nodes=$(KUBECONFIG=$RUN_PATH/kubeconfig kubectl get nodes -o json | jq -r '.items[] | .status | .addresses[] | select(.type == "ExternalIP") |.address')
   for node in $(echo $nodes); do
@@ -111,7 +111,7 @@ function load {
   done
 }
 
-function output {
+function output() {
   if [ ! -d $RUN_PATH ]; then
     exit 1
   fi
@@ -123,43 +123,42 @@ function output {
   fi
 }
 
-while [[ $# -gt 0 ]]
-do
-key="$1"
+while [[ $# -gt 0 ]]; do
+  key="$1"
 
-case $key in
-    create)
-      shift 1
+  case $key in
+  create)
+    shift 1
     ;;
-    --create-only)
-      CREATE_ONLY=true
-      shift 1
+  --create-only)
+    CREATE_ONLY=true
+    shift 1
     ;;
-    destroy)
-      destroy
-      exit 0
+  destroy)
+    destroy
+    exit 0
     ;;
-    output)
-      output
-      exit 0
+  output)
+    output
+    exit 0
     ;;
-    kubectl)
-      KUBECONFIG=$RUN_PATH/kubeconfig kubectl ${@:2}
-      exit $?
+  kubectl)
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl ${@:2}
+    exit $?
     ;;
-    load)
-      load $2
-      exit $?
+  load)
+    load $2
+    exit $?
     ;;
-    -h|--help)
+  -h | --help)
     print_usage
     exit 0
     ;;
-    *)    # unknown option
+  *) # unknown option
     echo "Unknown option $1"
     exit 1
     ;;
-esac
+  esac
 done
 
 apply

--- a/hack/aws-tf
+++ b/hack/aws-tf
@@ -30,21 +30,21 @@ _usage="Usage: $0 :
                 [output] : display vm cluster output variables
                 [help]"
 
-function print_usage {
-    echo -e "$_usage"
+function print_usage() {
+  echo -e "$_usage"
 }
 
-function apply {
+function apply() {
   mkdir -p $RUN_PATH
   if [ $? -ne 0 ]; then
-     echo "$RUN_PATH cannot be created"
-     exit 1
+    echo "$RUN_PATH cannot be created"
+    exit 1
   fi
   cp $CONFIG_PATH/* $RUN_PATH
   cd $RUN_PATH
   $TERRAFORM init
   if [ $? -ne 0 ]; then
-     exit 1
+    exit 1
   fi
   $TERRAFORM apply -auto-approve
   if [[ $? -ne 0 ]]; then
@@ -54,7 +54,7 @@ function apply {
   echo "vm cluster created"
 }
 
-function destroy {
+function destroy() {
   if [ ! -d $RUN_PATH ]; then
     exit 0
   fi
@@ -67,7 +67,7 @@ function destroy {
   echo "vm cluster deleted"
 }
 
-function output {
+function output() {
   if [ ! -d $RUN_PATH ]; then
     exit 1
   fi
@@ -79,30 +79,30 @@ function output {
   fi
 }
 
-while [[ $# -gt 0 ]]
-do
-key="$1"
-outputKey="${@:2}"
-case $key in
-    create)
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  outputKey="${@:2}"
+
+  case $key in
+  create)
     apply
     exit 0
     ;;
-    destroy)
+  destroy)
     destroy
     exit 0
     ;;
-    output)
+  output)
     output $outputKey
     exit 0
     ;;
-    help)
+  help)
     print_usage
     exit 0
     ;;
-    *) # unknown option
+  *) # unknown option
     echo -e "Unknown option $1"
     exit 1
     ;;
-esac
+  esac
 done

--- a/hack/aws-tf
+++ b/hack/aws-tf
@@ -37,7 +37,7 @@ function print_usage {
 function apply {
   mkdir -p $RUN_PATH
   if [ $? -ne 0 ]; then
-     echo $RUN_PATH cannot be created
+     echo "$RUN_PATH cannot be created"
      exit 1
   fi
   cp $CONFIG_PATH/* $RUN_PATH
@@ -51,7 +51,7 @@ function apply {
     echo "vm cluster creation failed"
     exit 1
   fi
-  echo vm cluster created.
+  echo "vm cluster created"
 }
 
 function destroy {
@@ -60,6 +60,11 @@ function destroy {
   fi
   cd $RUN_PATH
   $TERRAFORM destroy -auto-approve
+  if [[ $? -ne 0 ]]; then
+    echo "vm cluster deletion failed"
+    exit 1
+  fi
+  echo "vm cluster deleted"
 }
 
 function output {
@@ -68,6 +73,10 @@ function output {
   fi
   cd $RUN_PATH
   $TERRAFORM output ${@}
+  if [[ $? -ne 0 ]]; then
+    echo "vm cluster output failed"
+    exit 1
+  fi
 }
 
 while [[ $# -gt 0 ]]

--- a/hack/azure-tf
+++ b/hack/azure-tf
@@ -30,21 +30,21 @@ _usage="Usage: $0 :
                 [output] : display vm cluster output variables
                 [help]"
 
-function print_usage {
-    echo -e "$_usage"
+function print_usage() {
+  echo -e "$_usage"
 }
 
-function apply {
+function apply() {
   mkdir -p $RUN_PATH
   if [ $? -ne 0 ]; then
-     echo "$RUN_PATH cannot be created"
-     exit 1
+    echo "$RUN_PATH cannot be created"
+    exit 1
   fi
   cp $CONFIG_PATH/* $RUN_PATH
   cd $RUN_PATH
   $TERRAFORM init
   if [ $? -ne 0 ]; then
-     exit 1
+    exit 1
   fi
   $TERRAFORM apply -auto-approve
   if [[ $? -ne 0 ]]; then
@@ -54,7 +54,7 @@ function apply {
   echo "vm cluster created"
 }
 
-function destroy {
+function destroy() {
   if [ ! -d $RUN_PATH ]; then
     exit 0
   fi
@@ -67,7 +67,7 @@ function destroy {
   echo "vm cluster deleted"
 }
 
-function output {
+function output() {
   if [ ! -d $RUN_PATH ]; then
     exit 1
   fi
@@ -79,31 +79,30 @@ function output {
   fi
 }
 
-while [[ $# -gt 0 ]]
-do
-key="$1"
-outputKey="${@:2}"
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  outputKey="${@:2}"
 
-case $key in
-    create)
+  case $key in
+  create)
     apply
     exit 0
     ;;
-    destroy)
+  destroy)
     destroy
     exit 0
     ;;
-    output)
+  output)
     output $outputKey
     exit 0
     ;;
-    help)
+  help)
     print_usage
     exit 0
     ;;
-    *)    # unknown option
+  *) # unknown option
     echo -e "Unknown option $1"
     exit 1
     ;;
-esac
+  esac
 done

--- a/hack/azure-tf
+++ b/hack/azure-tf
@@ -37,7 +37,7 @@ function print_usage {
 function apply {
   mkdir -p $RUN_PATH
   if [ $? -ne 0 ]; then
-     echo $RUN_PATH cannot be created
+     echo "$RUN_PATH cannot be created"
      exit 1
   fi
   cp $CONFIG_PATH/* $RUN_PATH
@@ -51,7 +51,7 @@ function apply {
     echo "vm cluster creation failed"
     exit 1
   fi
-  echo vm cluster created.
+  echo "vm cluster created"
 }
 
 function destroy {
@@ -60,6 +60,11 @@ function destroy {
   fi
   cd $RUN_PATH
   $TERRAFORM destroy -auto-approve
+  if [[ $? -ne 0 ]]; then
+    echo "vm cluster deletion failed"
+    exit 1
+  fi
+  echo "vm cluster deleted"
 }
 
 function output {
@@ -68,6 +73,10 @@ function output {
   fi
   cd $RUN_PATH
   $TERRAFORM output ${@}
+  if [[ $? -ne 0 ]]; then
+    echo "vm cluster output failed"
+    exit 1
+  fi
 }
 
 while [[ $# -gt 0 ]]

--- a/hack/eks
+++ b/hack/eks
@@ -44,7 +44,7 @@ function validate {
   for cmd in ${CMD_ARRAY[@]}; do
      which $cmd > /dev/null 2>&1
      if [ $? -ne 0 ]; then
-       echo $cmd not found, please install first
+       echo "$cmd not found, please install first"
        exit 1
      fi
   done
@@ -52,7 +52,7 @@ function validate {
   for env in ${ENV_ARRAY[@]}; do
      printenv $env > /dev/null 2>&1
      if [ $? -ne 0 ]; then
-       echo required environment variable $env is not set.
+       echo "required environment variable $env is not set"
        exit 1
      fi
   done
@@ -62,7 +62,7 @@ function apply {
   validate
   mkdir -p $RUN_PATH
   if [ $? -ne 0 ]; then
-     echo $RUN_PATH cannot be created
+     echo "$RUN_PATH cannot be created"
      exit 1
   fi
   cp -r $CONFIG_PATH/* $RUN_PATH
@@ -76,7 +76,7 @@ function apply {
     echo "eks creation failed"
     exit 1
   fi
-  echo eks cluster created.
+  echo "eks cluster created"
   $TERRAFORM output -json kubectl_config | jq -r . > $RUN_PATH/kubeconfig
 
   if [ -z $CREATE_ONLY ]; then
@@ -86,7 +86,7 @@ function apply {
      KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply --validate=false -f "https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml"
   fi
 
-  echo run eks kubectl ... to acess it.
+  echo "run eks kubectl ... to acess it"
 }
 
 function destroy {
@@ -98,6 +98,11 @@ function destroy {
   # Remove any resources created by antrea.
   KUBECONFIG=$RUN_PATH/kubeconfig kubectl delete -f antrea-eks.yml
   $TERRAFORM destroy -auto-approve
+  if [[ $? -ne 0 ]]; then
+    echo "eks deletion failed"
+    exit 1
+  fi
+  echo "eks cluster deleted"
 }
 
 function load {
@@ -115,6 +120,10 @@ function output {
   fi
   cd $RUN_PATH
   $TERRAFORM output
+  if [[ $? -ne 0 ]]; then
+    echo "eks output failed"
+    exit 1
+  fi
 }
 
 while [[ $# -gt 0 ]]

--- a/hack/eks
+++ b/hack/eks
@@ -32,44 +32,44 @@ _usage="Usage: $0 :
                 [load] : load container image from local machine to eks cluster
                 [--help|h]"
 
-function print_help {
-    echo "Try '$0 --help' for more information."
+function print_help() {
+  echo "Try '$0 --help' for more information."
 }
 
-function print_usage {
-    echo "$_usage"
+function print_usage() {
+  echo "$_usage"
 }
 
-function validate {
+function validate() {
   for cmd in ${CMD_ARRAY[@]}; do
-     which $cmd > /dev/null 2>&1
-     if [ $? -ne 0 ]; then
-       echo "$cmd not found, please install first"
-       exit 1
-     fi
+    which $cmd >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      echo "$cmd not found, please install first"
+      exit 1
+    fi
   done
 
   for env in ${ENV_ARRAY[@]}; do
-     printenv $env > /dev/null 2>&1
-     if [ $? -ne 0 ]; then
-       echo "required environment variable $env is not set"
-       exit 1
-     fi
+    printenv $env >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      echo "required environment variable $env is not set"
+      exit 1
+    fi
   done
 }
 
-function apply {
+function apply() {
   validate
   mkdir -p $RUN_PATH
   if [ $? -ne 0 ]; then
-     echo "$RUN_PATH cannot be created"
-     exit 1
+    echo "$RUN_PATH cannot be created"
+    exit 1
   fi
   cp -r $CONFIG_PATH/* $RUN_PATH
   cd $RUN_PATH
   $TERRAFORM init
   if [ $? -ne 0 ]; then
-     exit 1
+    exit 1
   fi
   $TERRAFORM apply -auto-approve
   if [[ $? -ne 0 ]]; then
@@ -77,19 +77,19 @@ function apply {
     exit 1
   fi
   echo "eks cluster created"
-  $TERRAFORM output -json kubectl_config | jq -r . > $RUN_PATH/kubeconfig
+  $TERRAFORM output -json kubectl_config | jq -r . >$RUN_PATH/kubeconfig
 
   if [ -z $CREATE_ONLY ]; then
-     KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-eks-node-init.yml
-     KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-eks.yml
-     KUBECONFIG=$RUN_PATH/kubeconfig kubectl create namespace cert-manager
-     KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply --validate=false -f "https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml"
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-eks-node-init.yml
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply -f antrea-eks.yml
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl create namespace cert-manager
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl apply --validate=false -f "https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml"
   fi
 
-  echo "run eks kubectl ... to acess it"
+  echo "run eks kubectl ... to access it"
 }
 
-function destroy {
+function destroy() {
   validate
   if [ ! -d $RUN_PATH ]; then
     exit 0
@@ -105,7 +105,7 @@ function destroy {
   echo "eks cluster deleted"
 }
 
-function load {
+function load() {
   image=$1
   nodes=$(KUBECONFIG=$RUN_PATH/kubeconfig kubectl get nodes -o json | jq -r '.items[] | .status | .addresses[] | select(.type == "ExternalIP") |.address')
   for node in $(echo $nodes); do
@@ -114,7 +114,7 @@ function load {
   done
 }
 
-function output {
+function output() {
   if [ ! -d $RUN_PATH ]; then
     exit 1
   fi
@@ -126,43 +126,42 @@ function output {
   fi
 }
 
-while [[ $# -gt 0 ]]
-do
-key="$1"
+while [[ $# -gt 0 ]]; do
+  key="$1"
 
-case $key in
-    create)
-      shift 1
+  case $key in
+  create)
+    shift 1
     ;;
-    --create-only)
-      CREATE_ONLY=true
-      shift 1
+  --create-only)
+    CREATE_ONLY=true
+    shift 1
     ;;
-    destroy)
-      destroy
-      exit 0
+  destroy)
+    destroy
+    exit 0
     ;;
-    output)
-      output
-      exit 0
+  output)
+    output
+    exit 0
     ;;
-    kubectl)
-      KUBECONFIG=$RUN_PATH/kubeconfig kubectl ${@:2}
-      exit $?
+  kubectl)
+    KUBECONFIG=$RUN_PATH/kubeconfig kubectl ${@:2}
+    exit $?
     ;;
-    load)
-      load $2
-      exit $?
+  load)
+    load $2
+    exit $?
     ;;
-    -h|--help)
+  -h | --help)
     print_usage
     exit 0
     ;;
-    *)    # unknown option
+  *) # unknown option
     echo "Unknown option $1"
     exit 1
     ;;
-esac
+  esac
 done
 
 apply

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -239,13 +239,6 @@ var _ = AfterSuite(func(done Done) {
 		}
 	}
 
-	if withAgent {
-		By(cluster + ": Deleting namespace" + staticVMNS.Name)
-		err = k8sClient.Delete(context.TODO(), staticVMNS)
-		Expect(err).ToNot(HaveOccurred())
-		_ = os.RemoveAll(tmpDir)
-	}
-
 	// Delete VM VPC in parallel.
 	wg := sync.WaitGroup{}
 	wgChan := make(chan error)
@@ -273,6 +266,14 @@ var _ = AfterSuite(func(done Done) {
 		}
 		Expect(err).ToNot(HaveOccurred())
 	}
+
+	if withAgent {
+		By(cluster + ": Deleting namespace " + staticVMNS.Name)
+		err = k8sClient.Delete(context.TODO(), staticVMNS)
+		Expect(err).ToNot(HaveOccurred())
+		_ = os.RemoveAll(tmpDir)
+	}
+
 	// Last, consider controller core as failure.
 	Expect(controllersCored).To(BeNil(), "Controller restart detected")
 	close(done)


### PR DESCRIPTION
## Description

We were seeing resource clean up issue for agented CI  tests. The problem is caused by agent kubeconfig requirement by terraform to create agented VMs. Although destroy does't need the kubeconfigs, terraform treats destroy and apply with the same requirements. Thus when we clean up the generated kubeconfigs first, terraform destroy failed for agented VMs and VPC.

Relevant terraform discussion: https://github.com/hashicorp/terraform/issues/23552

## Changes
1. Move kubeconfig clean up to after VPC clean up.
2. Add exit code check after terraform destroy and output.
3. Reformat scripts.