### PR TITLE
Add Windows VM support in CI

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -26,7 +26,8 @@
           ./ci/jenkins/nephe-ci.sh --buildnumber "${BUILD_NUMBER}" --vchost "${VC_HOST}" \
                   --vcuser "${VC_USER}" --datacenter "${DATACENTERNAME}" --datastore "${DATA_STORE}" \
                   --vcCluster "${VC_CLUSTER}" --resourcePool "${RESOURCEPOOLPATH}" --vcNetwork "${VMC_NETWORK_1}" \
-                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType aws
+                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType aws \
+                  --dockerUser "${DOCKER_USERNAME}" --dockerPassword "${DOCKER_PASSWORD}"
 - builder:
     name: deploy-vm-and-run-azure-tests-for-nephe
     builders:
@@ -35,7 +36,8 @@
           ./ci/jenkins/nephe-ci.sh --buildnumber "${BUILD_NUMBER}" --vchost "${VC_HOST}" \
                   --vcuser "${VC_USER}" --datacenter "${DATACENTERNAME}" --datastore "${DATA_STORE}" \
                   --vcCluster "${VC_CLUSTER}" --resourcePool "${RESOURCEPOOLPATH}" --vcNetwork "${VMC_NETWORK_1}" \
-                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType azure
+                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType azure \
+                  --dockerUser "${DOCKER_USERNAME}" --dockerPassword "${DOCKER_PASSWORD}"
 - builder:
     name: deploy-vm-and-run-eks-tests-for-nephe
     builders:
@@ -44,7 +46,8 @@
           ./ci/jenkins/nephe-ci.sh --buildnumber "${BUILD_NUMBER}" --vchost "${VC_HOST}" \
                   --vcuser "${VC_USER}" --datacenter "${DATACENTERNAME}" --datastore "${DATA_STORE}" \
                   --vcCluster "${VC_CLUSTER}" --resourcePool "${RESOURCEPOOLPATH}" --vcNetwork "${VMC_NETWORK_1}" \
-                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType eks
+                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType eks \
+                  --dockerUser "${DOCKER_USERNAME}" --dockerPassword "${DOCKER_PASSWORD}"
 - builder:
     name: deploy-vm-and-run-aks-tests-for-nephe
     builders:
@@ -53,7 +56,8 @@
           ./ci/jenkins/nephe-ci.sh --buildnumber "${BUILD_NUMBER}" --vchost "${VC_HOST}" \
                   --vcuser "${VC_USER}" --datacenter "${DATACENTERNAME}" --datastore "${DATA_STORE}" \
                   --vcCluster "${VC_CLUSTER}" --resourcePool "${RESOURCEPOOLPATH}" --vcNetwork "${VMC_NETWORK_1}" \
-                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType aks
+                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType aks \
+                  --dockerUser "${DOCKER_USERNAME}" --dockerPassword "${DOCKER_PASSWORD}"
 - builder:
     name: deploy-vm-with-agent-and-run-eks-tests-for-nephe
     builders:
@@ -62,7 +66,8 @@
           ./ci/jenkins/nephe-ci.sh --buildnumber "${BUILD_NUMBER}" --vchost "${VC_HOST}" \
                   --vcuser "${VC_USER}" --datacenter "${DATACENTERNAME}" --datastore "${DATA_STORE}" \
                   --vcCluster "${VC_CLUSTER}" --resourcePool "${RESOURCEPOOLPATH}" --vcNetwork "${VMC_NETWORK_1}" \
-                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType eks-with-agent
+                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType eks-with-agent \
+                  --dockerUser "${DOCKER_USERNAME}" --dockerPassword "${DOCKER_PASSWORD}"
 - builder:
     name: deploy-vm-with-agent-and-run-aks-tests-for-nephe
     builders:
@@ -71,7 +76,28 @@
           ./ci/jenkins/nephe-ci.sh --buildnumber "${BUILD_NUMBER}" --vchost "${VC_HOST}" \
                   --vcuser "${VC_USER}" --datacenter "${DATACENTERNAME}" --datastore "${DATA_STORE}" \
                   --vcCluster "${VC_CLUSTER}" --resourcePool "${RESOURCEPOOLPATH}" --vcNetwork "${VMC_NETWORK_1}" \
-                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType aks-with-agent
+                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType aks-with-agent \
+                  --dockerUser "${DOCKER_USERNAME}" --dockerPassword "${DOCKER_PASSWORD}"
+- builder:
+    name: deploy-windows-vm-with-agent-and-run-eks-tests-for-nephe
+    builders:
+      - shell: |-
+          #!/bin/bash
+          ./ci/jenkins/nephe-ci.sh --buildnumber "${BUILD_NUMBER}" --vchost "${VC_HOST}" \
+                  --vcuser "${VC_USER}" --datacenter "${DATACENTERNAME}" --datastore "${DATA_STORE}" \
+                  --vcCluster "${VC_CLUSTER}" --resourcePool "${RESOURCEPOOLPATH}" --vcNetwork "${VMC_NETWORK_1}" \
+                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType eks-with-windows-agent \
+                  --dockerUser "${DOCKER_USERNAME}" --dockerPassword "${DOCKER_PASSWORD}"
+- builder:
+    name: deploy-windows-vm-with-agent-and-run-aks-tests-for-nephe
+    builders:
+      - shell: |-
+          #!/bin/bash
+          ./ci/jenkins/nephe-ci.sh --buildnumber "${BUILD_NUMBER}" --vchost "${VC_HOST}" \
+                  --vcuser "${VC_USER}" --datacenter "${DATACENTERNAME}" --datastore "${DATA_STORE}" \
+                  --vcCluster "${VC_CLUSTER}" --resourcePool "${RESOURCEPOOLPATH}" --vcNetwork "${VMC_NETWORK_1}" \
+                  --virtualMachine "${VIRTUAL_MACHINE}" --goVcPassword "${GOVC_PASSWORD}" --testType aks-with-windows-agent \
+                  --dockerUser "${DOCKER_USERNAME}" --dockerPassword "${DOCKER_PASSWORD}"
 
 - builder:
     name: nephe-gc-cronjob

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -69,11 +69,11 @@
                     credential-id: VIRTUAL_MACHINE
                     variable: VIRTUAL_MACHINE
                 - text:
-                    credential-id: ANTREA_DOCKER_USERNAME
-                    variable: ANTREA_DOCKER_USERNAME
+                    credential-id: DOCKER_USERNAME
+                    variable: DOCKER_USERNAME
                 - text:
-                    credential-id: ANTREA_DOCKER_PWD
-                    variable: ANTREA_DOCKER_PWD
+                    credential-id: DOCKER_PASSWORD
+                    variable: DOCKER_PASSWORD
                 - text:
                     credential-id: AWS_ACCESS_KEY_ID
                     variable: AWS_ACCESS_KEY_ID
@@ -159,11 +159,11 @@
                             credential-id: VIRTUAL_MACHINE
                             variable: VIRTUAL_MACHINE
                       - text:
-                            credential-id: ANTREA_DOCKER_USERNAME
-                            variable: ANTREA_DOCKER_USERNAME
+                            credential-id: DOCKER_USERNAME
+                            variable: DOCKER_USERNAME
                       - text:
-                            credential-id: ANTREA_DOCKER_PWD
-                            variable: ANTREA_DOCKER_PWD
+                            credential-id: DOCKER_PASSWORD
+                            variable: DOCKER_PASSWORD
                       - text:
                             credential-id: AZURE_APP_ID
                             variable: AZURE_APP_ID
@@ -252,11 +252,11 @@
                             credential-id: VIRTUAL_MACHINE
                             variable: VIRTUAL_MACHINE
                       - text:
-                            credential-id: ANTREA_DOCKER_USERNAME
-                            variable: ANTREA_DOCKER_USERNAME
+                            credential-id: DOCKER_USERNAME
+                            variable: DOCKER_USERNAME
                       - text:
-                            credential-id: ANTREA_DOCKER_PWD
-                            variable: ANTREA_DOCKER_PWD
+                            credential-id: DOCKER_PASSWORD
+                            variable: DOCKER_PASSWORD
                       - text:
                             credential-id: AWS_ACCESS_KEY_ID
                             variable: AWS_ACCESS_KEY_ID
@@ -348,11 +348,11 @@
                             credential-id: VIRTUAL_MACHINE
                             variable: VIRTUAL_MACHINE
                       - text:
-                            credential-id: ANTREA_DOCKER_USERNAME
-                            variable: ANTREA_DOCKER_USERNAME
+                            credential-id: DOCKER_USERNAME
+                            variable: DOCKER_USERNAME
                       - text:
-                            credential-id: ANTREA_DOCKER_PWD
-                            variable: ANTREA_DOCKER_PWD
+                            credential-id: DOCKER_PASSWORD
+                            variable: DOCKER_PASSWORD
                       - text:
                             credential-id: AZURE_APP_ID
                             variable: AZURE_APP_ID
@@ -441,11 +441,11 @@
                     credential-id: VIRTUAL_MACHINE
                     variable: VIRTUAL_MACHINE
                 - text:
-                    credential-id: ANTREA_DOCKER_USERNAME
-                    variable: ANTREA_DOCKER_USERNAME
+                    credential-id: DOCKER_USERNAME
+                    variable: DOCKER_USERNAME
                 - text:
-                    credential-id: ANTREA_DOCKER_PWD
-                    variable: ANTREA_DOCKER_PWD
+                    credential-id: DOCKER_PASSWORD
+                    variable: DOCKER_PASSWORD
                 - text:
                     credential-id: AWS_ACCESS_KEY_ID
                     variable: AWS_ACCESS_KEY_ID
@@ -537,11 +537,11 @@
                     credential-id: VIRTUAL_MACHINE
                     variable: VIRTUAL_MACHINE
                 - text:
-                    credential-id: ANTREA_DOCKER_USERNAME
-                    variable: ANTREA_DOCKER_USERNAME
+                    credential-id: DOCKER_USERNAME
+                    variable: DOCKER_USERNAME
                 - text:
-                    credential-id: ANTREA_DOCKER_PWD
-                    variable: ANTREA_DOCKER_PWD
+                    credential-id: DOCKER_PASSWORD
+                    variable: DOCKER_PASSWORD
                 - text:
                     credential-id: AZURE_APP_ID
                     variable: AZURE_APP_ID
@@ -562,6 +562,196 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
+      - '{test_name}-for-pull-request':
+          test_name: nephe-test-e2e-with-windows-eks
+          node: 'nephe'
+          description: 'This is the {test_name}.'
+          branches:
+            - ${{sha1}}
+          builders:
+            - deploy-windows-vm-with-agent-and-run-eks-tests-for-nephe
+          trigger_phrase: .*/nephe-test-e2e-with-windows-eks.*
+          white_list_target_branches: [ ]
+          allow_whitelist_orgs_as_admins: true
+          admin_list: '{nephe_admin_list}'
+          org_list: '{nephe_org_list}'
+          white_list: '{nephe_white_list}'
+          only_trigger_phrase: true
+          trigger_permit_all: false
+          status_context: nephe-test-e2e-with-windows-eks
+          status_url: ""
+          success_status: Build finished.
+          failure_status: Failed. Add comment /nephe-test-e2e-with-windows-eks to re-trigger.
+          error_status: Failed. Add comment /nephe-test-e2e-with-windows-eks to re-trigger.
+          triggered_status: null
+          started_status: null
+          concurrent: true
+          wrappers:
+            - credentials-binding:
+                - text:
+                    credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                    variable: CODECOV_TOKEN
+            - timeout:
+                fail: true
+                timeout: 120
+                type: absolute
+            - credentials-binding:
+                - text:
+                    credential-id: VMC_NETWORK_0
+                    variable: VMC_NETWORK_0
+                - text:
+                    credential-id: VMC_NETWORK_1
+                    variable: VMC_NETWORK_1
+                - text:
+                    credential-id: VCENTERNAME
+                    variable: VCENTERNAME
+                - text:
+                    credential-id: DATACENTERNAME
+                    variable: DATACENTERNAME
+                - text:
+                    credential-id: RESOURCEPOOLPATH
+                    variable: RESOURCEPOOLPATH
+                - text:
+                    credential-id: VC_USER
+                    variable: VC_USER
+                - text:
+                    credential-id: GOVC_PASSWORD
+                    variable: GOVC_PASSWORD
+                - text:
+                    credential-id: VC_HOST
+                    variable: VC_HOST
+                - text:
+                    credential-id: DATA_STORE
+                    variable: DATA_STORE
+                - text:
+                    credential-id: VC_CLUSTER
+                    variable: VC_CLUSTER
+                - text:
+                    credential-id: VIRTUAL_MACHINE
+                    variable: VIRTUAL_MACHINE
+                - text:
+                    credential-id: DOCKER_USERNAME
+                    variable: DOCKER_USERNAME
+                - text:
+                    credential-id: DOCKER_PASSWORD
+                    variable: DOCKER_PASSWORD
+                - text:
+                    credential-id: AWS_ACCESS_KEY_ID
+                    variable: AWS_ACCESS_KEY_ID
+                - text:
+                    credential-id: AWS_ACCESS_KEY_SECRET
+                    variable: AWS_ACCESS_KEY_SECRET
+                - text:
+                    credential-id: AWS_KEY_PAIR_NAME
+                    variable: AWS_KEY_PAIR_NAME
+                - text:
+                    credential-id: EKS_IAM_ROLE
+                    variable: EKS_IAM_ROLE
+                - text:
+                    credential-id: EKS_IAM_INSTANCE_PROFILE
+                    variable: EKS_IAM_INSTANCE_PROFILE
+          publishers:
+            - archive:
+                allow-empty: true
+                artifacts: "logs.tar.gz"
+                case-sensitive: true
+                default-excludes: true
+                fingerprint: false
+                only-if-success: false
+      - '{test_name}-for-pull-request':
+          test_name: nephe-test-e2e-with-windows-aks
+          node: 'nephe'
+          description: 'This is the {test_name}.'
+          branches:
+            - ${{sha1}}
+          builders:
+            - deploy-windows-vm-with-agent-and-run-aks-tests-for-nephe
+          trigger_phrase: .*/nephe-test-e2e-with-windows-aks.*
+          white_list_target_branches: [ ]
+          allow_whitelist_orgs_as_admins: true
+          admin_list: '{nephe_admin_list}'
+          org_list: '{nephe_org_list}'
+          white_list: '{nephe_white_list}'
+          only_trigger_phrase: true
+          trigger_permit_all: false
+          status_context: nephe-test-e2e-with-windows-aks
+          status_url: ""
+          success_status: Build finished.
+          failure_status: Failed. Add comment /nephe-test-e2e-with-windows-aks to re-trigger.
+          error_status: Failed. Add comment /nephe-test-e2e-with-windows-aks to re-trigger.
+          triggered_status: null
+          started_status: null
+          concurrent: true
+          wrappers:
+            - credentials-binding:
+                - text:
+                    credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                    variable: CODECOV_TOKEN
+            - timeout:
+                fail: true
+                timeout: 120
+                type: absolute
+            - credentials-binding:
+                - text:
+                    credential-id: VMC_NETWORK_0
+                    variable: VMC_NETWORK_0
+                - text:
+                    credential-id: VMC_NETWORK_1
+                    variable: VMC_NETWORK_1
+                - text:
+                    credential-id: VCENTERNAME
+                    variable: VCENTERNAME
+                - text:
+                    credential-id: DATACENTERNAME
+                    variable: DATACENTERNAME
+                - text:
+                    credential-id: RESOURCEPOOLPATH
+                    variable: RESOURCEPOOLPATH
+                - text:
+                    credential-id: VC_USER
+                    variable: VC_USER
+                - text:
+                    credential-id: GOVC_PASSWORD
+                    variable: GOVC_PASSWORD
+                - text:
+                    credential-id: VC_HOST
+                    variable: VC_HOST
+                - text:
+                    credential-id: DATA_STORE
+                    variable: DATA_STORE
+                - text:
+                    credential-id: VC_CLUSTER
+                    variable: VC_CLUSTER
+                - text:
+                    credential-id: VIRTUAL_MACHINE
+                    variable: VIRTUAL_MACHINE
+                - text:
+                    credential-id: DOCKER_USERNAME
+                    variable: DOCKER_USERNAME
+                - text:
+                    credential-id: DOCKER_PASSWORD
+                    variable: DOCKER_PASSWORD
+                - text:
+                    credential-id: AZURE_APP_ID
+                    variable: AZURE_APP_ID
+                - text:
+                    credential-id: AZURE_PASSWORD
+                    variable: AZURE_PASSWORD
+                - text:
+                    credential-id: AZURE_SUBSCRIPTION_ID
+                    variable: AZURE_SUBSCRIPTION_ID
+                - text:
+                    credential-id: AZURE_TENANT_ID
+                    variable: AZURE_TENANT_ID
+          publishers:
+            - archive:
+                allow-empty: true
+                artifacts: "logs.tar.gz"
+                case-sensitive: true
+                default-excludes: true
+                fingerprint: false
+                only-if-success: false
+
       - '{test_name}-testbed-gc-on-all-nodes':
           test_name: nephe
           node: nephe-gc
@@ -651,11 +841,11 @@
                     credential-id: VIRTUAL_MACHINE
                     variable: VIRTUAL_MACHINE
                 - text:
-                    credential-id: ANTREA_DOCKER_USERNAME
-                    variable: ANTREA_DOCKER_USERNAME
+                    credential-id: DOCKER_USERNAME
+                    variable: DOCKER_USERNAME
                 - text:
-                    credential-id: ANTREA_DOCKER_PWD
-                    variable: ANTREA_DOCKER_PWD
+                    credential-id: DOCKER_PASSWORD
+                    variable: DOCKER_PASSWORD
                 - text:
                     credential-id: AWS_ACCESS_KEY_ID
                     variable: AWS_ACCESS_KEY_ID
@@ -777,11 +967,11 @@
                     credential-id: VIRTUAL_MACHINE
                     variable: VIRTUAL_MACHINE
                 - text:
-                    credential-id: ANTREA_DOCKER_USERNAME
-                    variable: ANTREA_DOCKER_USERNAME
+                    credential-id: DOCKER_USERNAME
+                    variable: DOCKER_USERNAME
                 - text:
-                    credential-id: ANTREA_DOCKER_PWD
-                    variable: ANTREA_DOCKER_PWD
+                    credential-id: DOCKER_PASSWORD
+                    variable: DOCKER_PASSWORD
                 - text:
                     credential-id: AZURE_APP_ID
                     variable: AZURE_APP_ID

--- a/ci/jenkins/nephe-ci.sh
+++ b/ci/jenkins/nephe-ci.sh
@@ -218,4 +218,14 @@ case $testType in
     ssh -i id_rsa ubuntu@${ip_addr} "cd ~/nephe; ./ci/jenkins/scripts/test-aks.sh --azure-subscription-id ${AZURE_SUBSCRIPTION_ID} --azure-app-id ${AZURE_APP_ID} \
                                                    --azure-tenant-id ${AZURE_TENANT_ID} --azure-secret ${AZURE_PASSWORD} --with-agent"
     ;;
+    eks-with-windows-agent)
+    echo "Run tests on EKS cluster with AWS agented VMs"
+    ssh -i id_rsa ubuntu@${ip_addr} "cd ~/nephe; ./ci/jenkins/scripts/test-eks.sh --aws-access-key-id ${AWS_ACCESS_KEY_ID} --aws-secret-key ${AWS_ACCESS_KEY_SECRET} \
+                                                   --eks-cluster-role ${EKS_IAM_ROLE} --eks-node-role ${EKS_IAM_INSTANCE_PROFILE} --with-agent --with-agent-windows"
+    ;;
+    aks-with-windows-agent)
+    echo "Run tests on AKS cluster with Azure agented VMs"
+    ssh -i id_rsa ubuntu@${ip_addr} "cd ~/nephe; ./ci/jenkins/scripts/test-aks.sh --azure-subscription-id ${AZURE_SUBSCRIPTION_ID} --azure-app-id ${AZURE_APP_ID} \
+                                                   --azure-tenant-id ${AZURE_TENANT_ID} --azure-secret ${AZURE_PASSWORD} --with-agent --with-agent-windows"
+    ;;
  esac

--- a/ci/jenkins/scripts/test-aks.sh
+++ b/ci/jenkins/scripts/test-aks.sh
@@ -31,7 +31,8 @@ Setup and Run integration tests on AKS cluster with Azure VMs.
         [--azure-secret <Secret>]                   Azure Service Principal Secret.
         [--azure-location <Location>]               The Azure location where the setup will be deployed. Defaults to West US 2.
         [--owner <OwnerName>]                       Setup will be prefixed with owner name.
-        [--with-agent]                              Run test with agented VMs."
+        [--with-agent]                              Run test with agented Linux VMs.
+        [--with-agent-windows]                      Run test with agented Windows VMs."
 
 function print_usage {
     echoerr "$_usage"
@@ -45,6 +46,7 @@ function print_help {
 export TF_VAR_owner="ci"
 export TF_VAR_location="West US 2"
 export WITH_AGENT=false
+export WITH_WINDOWS=false
 export TEST_FOCUS=".*test-cloud-cluster.*"
 
 while [[ $# -gt 0 ]]
@@ -79,6 +81,10 @@ case $key in
     --with-agent)
     export WITH_AGENT=true
     export TEST_FOCUS=".*test-with-agent*"
+    shift 1
+    ;;
+    --with-agent-windows)
+    export WITH_WINDOWS=true
     shift 1
     ;;
     -h|--help)
@@ -139,4 +145,4 @@ docker tag antrea/nephe:latest projects.registry.vmware.com/antrea/nephe:latest
 $HOME/terraform/aks load projects.registry.vmware.com/antrea/nephe
 
 mkdir -p $HOME/logs
-ci/bin/integration.test -ginkgo.v -ginkgo.focus=$TEST_FOCUS -kubeconfig=$HOME/tmp/terraform-aks/kubeconfig -cloud-provider=Azure -support-bundle-dir=$HOME/logs -with-agent=${WITH_AGENT}
+ci/bin/integration.test -ginkgo.v -ginkgo.focus=$TEST_FOCUS -kubeconfig=$HOME/tmp/terraform-aks/kubeconfig -cloud-provider=Azure -support-bundle-dir=$HOME/logs -with-agent=${WITH_AGENT} -with-windows=${WITH_WINDOWS}

--- a/ci/jenkins/scripts/test-eks.sh
+++ b/ci/jenkins/scripts/test-eks.sh
@@ -30,7 +30,8 @@ Setup and run integration tests on EKS cluster with AWS VMs.
         [--eks-cluster-role <ClusterRole>]   IAM Role for Cluster Control Plane.
         [--eks-node-role <NodeRole>]         IAM Role for EKS worker node.
         [--owner <OwnerName>]                Setup will be prefixed with owner name.
-        [--with-agent]                       Run test with agented VMs."
+        [--with-agent]                       Run test with agented Linux VMs.
+        [--with-agent-windows]               Run test with agented Windows VMs."
 
 function print_usage {
     echoerr "$_usage"
@@ -44,6 +45,7 @@ function print_help {
 export TF_VAR_owner="ci"
 export AWS_DEFAULT_REGION="us-west-2"
 export WITH_AGENT=false
+export WITH_WINDOWS=false
 export TEST_FOCUS=".*test-cloud-cluster.*"
 
 while [[ $# -gt 0 ]]
@@ -78,6 +80,10 @@ case $key in
     --with-agent)
     export WITH_AGENT=true
     export TEST_FOCUS=".*test-with-agent*"
+    shift 1
+    ;;
+    --with-agent-windows)
+    export WITH_WINDOWS=true
     shift 1
     ;;
     -h|--help)
@@ -154,4 +160,4 @@ docker tag antrea/nephe:latest projects.registry.vmware.com/antrea/nephe:latest
 $HOME/terraform/eks load projects.registry.vmware.com/antrea/nephe
 
 mkdir -p $HOME/logs
-ci/bin/integration.test -ginkgo.v -ginkgo.focus=$TEST_FOCUS -kubeconfig=$HOME/tmp/terraform-eks/kubeconfig -cloud-provider=AWS -support-bundle-dir=$HOME/logs -with-agent=${WITH_AGENT}
+ci/bin/integration.test -ginkgo.v -ginkgo.focus=$TEST_FOCUS -kubeconfig=$HOME/tmp/terraform-eks/kubeconfig -cloud-provider=AWS -support-bundle-dir=$HOME/logs -with-agent=${WITH_AGENT} -with-windows=${WITH_WINDOWS}

--- a/hack/install-vm-agent-wrapper.ps1
+++ b/hack/install-vm-agent-wrapper.ps1
@@ -99,8 +99,10 @@ function InitCloud() {
 }
 
 function UpdateAntreaURL() {
-    # Generate branch name release-1.XX from version v1.XX.0.
-    $Script:AntreaBranch = "release-$($AntreaVersion.Substring(1, $AntreaVersion.LastIndexOf('.')-1))"
+    # Convert v1.xx.0 to 1.xx
+    $tempVersion = $AntreaVersion.Substring(0, $AntreaVersion.Length-2)
+    $branchTag = $tempVersion.Substring(1)
+    $Script:AntreaBranch = "release-${branchTag}"
     $Script:AntreaInstallScript = "https://github.com/antrea-io/antrea/releases/download/${AntreaVersion}/install-vm.ps1"
     $Script:AgentBin = "https://github.com/antrea-io/antrea/releases/download/${AntreaVersion}/antrea-agent-windows-x86_64.exe"
     $Script:AntreaConfig = "https://raw.githubusercontent.com/antrea-io/antrea/${AntreaBranch}/build/yamls/externalnode/conf/antrea-agent.conf"

--- a/hack/terraform/aws/init_script_windows.ps1
+++ b/hack/terraform/aws/init_script_windows.ps1
@@ -1,0 +1,29 @@
+<powershell>
+# Create temporary directory.
+$TempDir = "C:\nephe-temp\"
+New-Item -Path $TempDir -ItemType Directory
+$InstallLog = "$TempDir\terraform.log"
+
+function Log($Info) {
+    $time = $(get-date -Format g)
+    "$time $Info " | Tee-Object $InstallLog -Append | Write-Host
+}
+
+Log "Dumping with_agent ${WITH_AGENT}, namespace ${NAMESPACE}, version ${ANTREA_VERSION}"
+# Create files from the terraform variables.
+$FileContent = '${INSTALL_VM_AGENT_WRAPPER}'
+Set-Content -Path "$TempDir\install-vm-agent-wrapper.ps1" -Value $FileContent
+$FileContent = '${K8S_CONF}'
+Set-Content -Path "$TempDir\antrea-agent.kubeconfig" -Value $FileContent
+$FileContent = '${ANTREA_CONF}'
+Set-Content -Path "$TempDir\antrea-agent.antrea.kubeconfig" -Value $FileContent
+$FileContent = '${SSH_PUBLIC_KEY}'
+$UserProfile = "C:\cygwin64\home\Administrator\"
+Set-Content -Path "$UserProfile\.ssh\authorized_keys" -Value $FileContent
+
+# Run install script for antrea-agent installation.
+$InstallArgs = "-Namespace ${NAMESPACE} -AntreaVersion ${ANTREA_VERSION} -KubeConfigPath $TempDir\antrea-agent.kubeconfig -AntreaKubeConfigPath $TempDir\antrea-agent.antrea.kubeconfig"
+$cmd = "$TempDir\install-vm-agent-wrapper.ps1 $InstallArgs"
+Invoke-Expression $cmd
+
+</powershell>

--- a/hack/terraform/aws/variables.tf
+++ b/hack/terraform/aws/variables.tf
@@ -9,6 +9,14 @@ variable aws_vm_type {
   default = "t2.micro"
 }
 
+variable aws_win_vm_type {
+  default = "t3.medium"
+}
+
+variable "ssh_public_key" {
+  default = "~/.ssh/id_rsa.pub"
+}
+
 variable peer_vpc_id {
   default = ""
 }
@@ -87,6 +95,39 @@ variable "aws_vm_os_types_agented" {
   ]
 }
 
+variable "aws_vm_os_types_agented_windows" {
+  type = list(object({
+    name            = string
+    login           = string
+    init            = string
+    ami_name_search = string
+    ami_owner       = string
+  }))
+  default = [
+    {
+      name            = "windows2019-1"
+      login           = "Administrator"
+      init            = "init_script_windows.ps1"
+      ami_name_search = "NepheWin2019Image"
+      ami_owner       = "092722883498"
+    },
+    {
+      name            = "windows2019-2"
+      login           = "Administrator"
+      init            = "init_script_windows.ps1"
+      ami_name_search = "NepheWin2019Image"
+      ami_owner       = "092722883498"
+    },
+    {
+      name            = "windows2019-3"
+      login           = "Administrator"
+      init            = "init_script_windows.ps1"
+      ami_name_search = "NepheWin2019Image"
+      ami_owner       = "092722883498"
+    },
+  ]
+}
+
 variable "aws_security_groups_postfix" {
   type    = list(string)
   default = [
@@ -96,6 +137,11 @@ variable "aws_security_groups_postfix" {
 }
 
 variable "with_agent" {
+  type    = bool
+  default = false
+}
+
+variable "with_windows" {
   type    = bool
   default = false
 }

--- a/hack/terraform/azure/init_script_windows.ps1
+++ b/hack/terraform/azure/init_script_windows.ps1
@@ -1,0 +1,36 @@
+# Create temporary directory.
+$TempDir = "C:\nephe-temp\"
+New-Item -Path $TempDir -ItemType Directory
+$ScriptDir = "C:\cygwin64\tmp"
+$InstallLog = "$TempDir\terraform.log"
+
+function Log($Info) {
+    $time = $(get-date -Format g)
+    "$time $Info " | Tee-Object $InstallLog -Append | Write-Host
+}
+
+Log "Dumping with_agent ${WITH_AGENT}, namespace ${NAMESPACE}, version ${ANTREA_VERSION}"
+# Create files from the terraform variables.
+$FileContent = '${K8S_CONF}'
+Set-Content -Path "$TempDir\antrea-agent.kubeconfig" -Value $FileContent
+$FileContent = '${ANTREA_CONF}'
+Set-Content -Path "$TempDir\antrea-agent.antrea.kubeconfig" -Value $FileContent
+Log "Copying script to $TempDir"
+cp "$ScriptDir\install-vm-agent-wrapper.ps1" $TempDir
+
+# Create ssh directory and copy public key
+$UserProfile = "C:\cygwin64\home\azureuser\"
+$sshPath = "$UserProfile\.ssh"
+if (Test-Path "$sshPath") {
+    Log "Directory $sshPath exists"
+} else {
+    New-Item -Path "$sshPath" -ItemType Directory
+}
+
+$FileContent = '${SSH_PUBLIC_KEY}'
+Set-Content -Path "$sshPath\authorized_keys" -Value $FileContent
+$LatestContent = Get-Content "$sshPath\authorized_keys"
+
+$InstallArgs = "-Namespace ${NAMESPACE} -AntreaVersion ${ANTREA_VERSION} -KubeConfigPath $TempDir\antrea-agent.kubeconfig -AntreaKubeConfigPath $TempDir\antrea-agent.antrea.kubeconfig"
+$cmd = "$TempDir\install-vm-agent-wrapper.ps1 $InstallArgs"
+Invoke-Expression $cmd

--- a/hack/terraform/azure/init_script_windows.ps1
+++ b/hack/terraform/azure/init_script_windows.ps1
@@ -29,8 +29,8 @@ if (Test-Path "$sshPath") {
 
 $FileContent = '${SSH_PUBLIC_KEY}'
 Set-Content -Path "$sshPath\authorized_keys" -Value $FileContent
-$LatestContent = Get-Content "$sshPath\authorized_keys"
 
+# Run install script for antrea-agent installation.
 $InstallArgs = "-Namespace ${NAMESPACE} -AntreaVersion ${ANTREA_VERSION} -KubeConfigPath $TempDir\antrea-agent.kubeconfig -AntreaKubeConfigPath $TempDir\antrea-agent.antrea.kubeconfig"
 $cmd = "$TempDir\install-vm-agent-wrapper.ps1 $InstallArgs"
 Invoke-Expression $cmd

--- a/hack/terraform/azure/outputs.tf
+++ b/hack/terraform/azure/outputs.tf
@@ -31,9 +31,9 @@ output "vnet_id" {
 output "tags" {
   description = "List of tags"
   value       = [
-    { Name = var.with_agent ? var.azure_vm_os_types_agented[0].name : var.azure_vm_os_types[0].name },
-    { Name = var.with_agent ? var.azure_vm_os_types_agented[1].name : var.azure_vm_os_types[1].name },
-    { Name = var.with_agent ? var.azure_vm_os_types_agented[2].name : var.azure_vm_os_types[2].name }
+    { Name = var.with_agent ? (var.with_windows ? var.azure_vm_os_types_agented_windows[0].name : var.azure_vm_os_types_agented[0].name) : var.azure_vm_os_types[0].name },
+    { Name = var.with_agent ? (var.with_windows ? var.azure_vm_os_types_agented_windows[1].name : var.azure_vm_os_types_agented[1].name) : var.azure_vm_os_types[1].name },
+    { Name = var.with_agent ? (var.with_windows ? var.azure_vm_os_types_agented_windows[2].name : var.azure_vm_os_types_agented[2].name) : var.azure_vm_os_types[2].name }
   ]
 }
 

--- a/hack/terraform/azure/variables.tf
+++ b/hack/terraform/azure/variables.tf
@@ -32,6 +32,10 @@ variable azure_vm_type {
   default = "Standard_DS1_v2"
 }
 
+variable azure_win_vm_type {
+  default = "Standard_D2s_v3"
+}
+
 variable "azure_vm_os_types" {
   type = list(object({
     name      = string
@@ -98,7 +102,45 @@ variable "azure_vm_os_types_agented" {
   ]
 }
 
+variable "azure_vm_os_types_agented_windows" {
+  type = list(object({
+    name      = string
+    image     = string
+    init      = string
+    rg        = string
+    gallery   = string
+  }))
+  default = [
+    {
+      name      = "win-1"
+      image     = "WindowsNepheCI"
+      init      = "init_script_windows.ps1"
+      rg        = "nephe-ci"
+      gallery   = "NepheGallery"
+    },
+    {
+      name      = "win-2"
+      image     = "WindowsNepheCI"
+      init      = "init_script_windows.ps1"
+      rg        = "nephe-ci"
+      gallery   = "NepheGallery"
+    },
+    {
+      name      = "win-3"
+      image     = "WindowsNepheCI"
+      init      = "init_script_windows.ps1"
+      rg        = "nephe-ci"
+      gallery   = "NepheGallery"
+    }
+  ]
+}
+
 variable "with_agent" {
+  type    = bool
+  default = false
+}
+
+variable "with_windows" {
   type    = bool
   default = false
 }
@@ -126,4 +168,9 @@ variable "antrea_agent_antrea_config" {
 variable "install_vm_agent_wrapper" {
   type    = string
   default = "install-vm-agent-wrapper.sh"
+}
+
+variable "username" {
+  type    = string
+  default = "azureuser"
 }

--- a/test/integration/crd_rw_test.go
+++ b/test/integration/crd_rw_test.go
@@ -73,7 +73,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: Basic CRD Read-Write", focusAws, focusAzure
 			if len(supportBundleDir) > 0 {
 				logf.Log.Info("Collect support bundles for test failure.")
 				fileName := utils.GenerateNameFromText(result.FullTestText, testFocus)
-				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent)
+				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent, withWindows)
 			}
 		}
 	})

--- a/test/integration/entityselector_test.go
+++ b/test/integration/entityselector_test.go
@@ -24,9 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/extensions/table"
-
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -296,7 +295,7 @@ var _ = Describe(fmt.Sprintf("%s: Entity selector test", focusAws), func() {
 			if len(supportBundleDir) > 0 {
 				logf.Log.Info("Collect support bundles for test failure.")
 				fileName := utils.GenerateNameFromText(result.FullTestText, testFocus)
-				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent)
+				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent, withWindows)
 			}
 			if preserveSetupOnFail {
 				logf.Log.V(1).Info("Preserve setup on failure")

--- a/test/integration/externalentity_test.go
+++ b/test/integration/externalentity_test.go
@@ -78,7 +78,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalEntity", focusAws, focusAzure), fun
 			if len(supportBundleDir) > 0 {
 				logf.Log.Info("Collect support bundles for test failure.")
 				fileName := utils.GenerateNameFromText(result.FullTestText, testFocus)
-				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent)
+				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent, withWindows)
 			}
 			if preserveSetupOnFail {
 				logf.Log.V(1).Info("Preserve setup on failure")

--- a/test/integration/externalnode_test.go
+++ b/test/integration/externalnode_test.go
@@ -466,7 +466,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: ExternalNode", focusAws, focusAzure), func(
 			if len(supportBundleDir) > 0 {
 				logf.Log.Info("Collect support bundles for test failure.")
 				fileName := utils.GenerateNameFromText(result.FullTestText, testFocus)
-				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent)
+				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent, withWindows)
 			}
 			if preserveSetupOnFail {
 				logf.Log.V(1).Info("Preserve setup on failure")

--- a/test/integration/pod_e2e_test.go
+++ b/test/integration/pod_e2e_test.go
@@ -92,7 +92,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Pods", focusAws, focusAzur
 			if len(supportBundleDir) > 0 {
 				logf.Log.Info("Collect support bundles for test failure.")
 				fileName := utils.GenerateNameFromText(result.FullTestText, testFocus)
-				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent)
+				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, withAgent, withWindows)
 			}
 			if preserveSetupOnFail {
 				logf.Log.V(1).Info("Preserve setup on failure")

--- a/test/utils/cloud_provider.go
+++ b/test/utils/cloud_provider.go
@@ -38,7 +38,7 @@ type CloudVPC interface {
 
 	VMCmd(vm string, vmCmd []string, timeout time.Duration) (string, error)
 	Delete(duration time.Duration) error
-	Reapply(duration time.Duration) error
+	Reapply(duration time.Duration, withAgent bool) error
 	GetCloudAccountParameters(name, namespace string, cloudCluster bool) k8stemplates.CloudAccountParameters
 	GetEntitySelectorParameters(name, namespace, kind string) k8stemplates.CloudEntitySelectorParameters
 }

--- a/test/utils/cloud_provider_azure.go
+++ b/test/utils/cloud_provider_azure.go
@@ -195,24 +195,23 @@ func (p *azureVPC) Delete(timeout time.Duration) error {
 	return nil
 }
 
-func (p *azureVPC) Reapply(timeout time.Duration) error {
+func (p *azureVPC) Reapply(timeout time.Duration, withAgent bool) error {
 	output, err := createAzureVPC(timeout)
 	if err != nil {
 		return err
 	}
 	p.output = output
-	// Wait for servers on VMs come to live.
-	for _, ip := range p.GetVMIPs() {
-		err = wait.Poll(time.Second*10, time.Second*600, func() (bool, error) {
-			cmd := exec.Command("timeout", []string{"5", "curl", "http://" + ip}...)
-			if _, err = cmd.CombinedOutput(); err != nil {
-				return false, nil
+	if !withAgent {
+		// Wait for servers on VMs come to live.
+		err = wait.Poll(time.Second*5, time.Second*240, func() (bool, error) {
+			for _, ip := range p.GetVMIPs() {
+				cmd := exec.Command("timeout", []string{"5", "curl", "http://" + ip}...)
+				if _, err = cmd.CombinedOutput(); err != nil {
+					return false, nil
+				}
 			}
 			return true, nil
 		})
-		if err != nil {
-			return fmt.Errorf("failed to run curl ip %v, err %v", ip, err)
-		}
 	}
 	return err
 }


### PR DESCRIPTION
To run the tests pass an addtional option -with-windows true along with -with-agent true.

The windows image contains the following
- WebServer, listening on port 80,8080
- Enable Hyper-v , install and configure OVS
- Enable ssh

Use t3.medium/Standard_D2s_v3 for the instance size.

Signed-off-by: Anand Kumar <kumaranand@vmware.com>