### PR TITLE
Use 4.0.0 version of azurerm module

### DIFF
--- a/hack/terraform/azure/main.tf
+++ b/hack/terraform/azure/main.tf
@@ -59,6 +59,7 @@ data "template_file" user_data {
 
 module "vm_cluster" {
   source                  = "Azure/compute/azurerm"
+  version                 = "4.0.0"
   resource_group_name     = azurerm_resource_group.vm.name
   count                   = length(local.azure_vm_os_types)
   nb_instances            = 1


### PR DESCRIPTION
In the latest version of azurerm module,
there appears to be regression, which
causes the failure while intializing
terraform

Signed-off-by: Anand Kumar <kumaranand@vmware.com>