### PR TITLE
Specify version for Azure/vnet/azurerm module

### DIFF
--- a/hack/terraform/azure/main.tf
+++ b/hack/terraform/azure/main.tf
@@ -88,6 +88,7 @@ module "vm_cluster" {
 
 module "network" {
   source              = "Azure/vnet/azurerm"
+  version             = "3.1.0"
   resource_group_name = azurerm_resource_group.vm.name
   address_space       = [var.network_address_space]
   subnet_prefixes     = [var.subnet_prefix]


### PR DESCRIPTION
Fixes the errror, argument "use_for_each" is required, but no definition was found

Signed-off-by: Anand Kumar <kumaranand@vmware.com>