### PR TITLE
per ANP rule realization and status report

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,8 @@ require (
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 )
 
+require github.com/satori/go.uuid v1.2.0
+
 // antrea dependency.
 replace (
 	// Variadic arguments are not supported in 1.6 and controller-runtime module

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.24.1
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/satori/go.uuid v1.2.0
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
@@ -129,8 +130,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 )
-
-require github.com/satori/go.uuid v1.2.0
 
 // antrea dependency.
 replace (

--- a/go.sum
+++ b/go.sum
@@ -476,6 +476,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seancfoley/bintree v1.1.0 h1:6J0rj9hLNLIcWSsfYdZ4ZHkMHokaK/PHkak8qyBO/mc=
 github.com/seancfoley/bintree v1.1.0/go.mod h1:CtE6qO6/n9H3V2CAGEC0lpaYr6/OijhNaMG/dt7P70c=

--- a/pkg/cloud-provider/cloudapi/azure/azure_nsg_rules.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_nsg_rules.go
@@ -84,7 +84,7 @@ func updateSecurityRuleNameAndPriority(existingRules []network.SecurityRule, new
 	return rules
 }
 
-func convertIngressToAzureNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.IngressRule,
+func convertIngressToAzureNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
 	agAsgMapByNepheControllerName map[string]network.ApplicationSecurityGroup,
 	atAsgMapByNepheControllerName map[string]network.ApplicationSecurityGroup) ([]network.SecurityRule, error) {
 	var securityRules []network.SecurityRule
@@ -96,7 +96,8 @@ func convertIngressToAzureNsgSecurityRules(appliedToGroupID *securitygroup.Cloud
 
 	rulePriority := int32(ruleStartPriority)
 	description := appliedToGroupID.GetCloudName(false)
-	for _, rule := range rules {
+	for _, obj := range rules {
+		rule := obj.Rule.(*securitygroup.IngressRule)
 		if rule == nil {
 			continue
 		}
@@ -139,14 +140,15 @@ func convertIngressToAzureNsgSecurityRules(appliedToGroupID *securitygroup.Cloud
 	return securityRules, nil
 }
 
-func convertIngressToAzurePeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.IngressRule,
+func convertIngressToAzurePeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
 	agAsgMapByNepheControllerName map[string]network.ApplicationSecurityGroup,
 	ruleIP *string) ([]network.SecurityRule, error) {
 	var securityRules []network.SecurityRule
 
 	rulePriority := int32(ruleStartPriority)
 	description := appliedToGroupID.GetCloudName(false)
-	for _, rule := range rules {
+	for _, obj := range rules {
+		rule := obj.Rule.(*securitygroup.IngressRule)
 		if rule == nil {
 			continue
 		}
@@ -203,7 +205,7 @@ func convertIngressToAzurePeerNsgSecurityRules(appliedToGroupID *securitygroup.C
 	return securityRules, nil
 }
 
-func convertEgressToAzureNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.EgressRule,
+func convertEgressToAzureNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
 	agAsgMapByNepheControllerName map[string]network.ApplicationSecurityGroup,
 	atAsgMapByNepheControllerName map[string]network.ApplicationSecurityGroup) ([]network.SecurityRule, error) {
 	var securityRules []network.SecurityRule
@@ -215,7 +217,8 @@ func convertEgressToAzureNsgSecurityRules(appliedToGroupID *securitygroup.CloudR
 
 	rulePriority := int32(ruleStartPriority)
 	description := appliedToGroupID.GetCloudName(false)
-	for _, rule := range rules {
+	for _, obj := range rules {
+		rule := obj.Rule.(*securitygroup.EgressRule)
 		if rule == nil {
 			continue
 		}
@@ -257,14 +260,15 @@ func convertEgressToAzureNsgSecurityRules(appliedToGroupID *securitygroup.CloudR
 	return securityRules, nil
 }
 
-func convertEgressToAzurePeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.EgressRule,
+func convertEgressToAzurePeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
 	agAsgMapByNepheControllerName map[string]network.ApplicationSecurityGroup,
 	ruleIP *string) ([]network.SecurityRule, error) {
 	var securityRules []network.SecurityRule
 
 	rulePriority := int32(ruleStartPriority)
 	description := appliedToGroupID.GetCloudName(false)
-	for _, rule := range rules {
+	for _, obj := range rules {
+		rule := obj.Rule.(*securitygroup.EgressRule)
 		if rule == nil {
 			continue
 		}

--- a/pkg/cloud-provider/cloudapi/azure/azure_security_test.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_security_test.go
@@ -381,26 +381,24 @@ var _ = Describe("Azure Cloud Security", func() {
 
 				fromSrcIP := getFromSrcIP(testCidrStr)
 
-				ingressrules := []*securitygroup.IngressRule{
-					{
+				addRules := []*securitygroup.CloudRule{{
+					Rule: &securitygroup.IngressRule{
 						Protocol:  &testProtocol,
 						FromPort:  &testFromPort,
 						FromSrcIP: fromSrcIP,
-					},
-				}
-
-				egressrules := []*securitygroup.EgressRule{
+					}},
 					{
-						Protocol: &testProtocol,
-						ToPort:   &testToPort,
-						ToDstIP:  fromSrcIP,
-						ToSecurityGroups: []*securitygroup.CloudResourceID{
-							&webAddressGroupIdentifier03.CloudResourceID,
-						},
-					},
+						Rule: &securitygroup.EgressRule{
+							Protocol: &testProtocol,
+							ToPort:   &testToPort,
+							ToDstIP:  fromSrcIP,
+							ToSecurityGroups: []*securitygroup.CloudResourceID{
+								&webAddressGroupIdentifier03.CloudResourceID,
+							},
+						}},
 				}
 
-				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, ingressrules, egressrules)
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
 				Expect(err).Should(BeNil())
 			})
 
@@ -417,26 +415,24 @@ var _ = Describe("Azure Cloud Security", func() {
 
 				fromSrcIP := getFromSrcIP(testCidrStr)
 
-				ingressrules := []*securitygroup.IngressRule{
-					{
+				addRules := []*securitygroup.CloudRule{{
+					Rule: &securitygroup.IngressRule{
 						Protocol:  &testProtocol,
 						FromPort:  &testFromPort,
 						FromSrcIP: fromSrcIP,
-					},
-				}
-
-				egressrules := []*securitygroup.EgressRule{
+					}},
 					{
-						Protocol: &testProtocol,
-						ToPort:   &testToPort,
-						ToDstIP:  fromSrcIP,
-						ToSecurityGroups: []*securitygroup.CloudResourceID{
-							&webAddressGroupIdentifier03.CloudResourceID,
-						},
-					},
+						Rule: &securitygroup.EgressRule{
+							Protocol: &testProtocol,
+							ToPort:   &testToPort,
+							ToDstIP:  fromSrcIP,
+							ToSecurityGroups: []*securitygroup.CloudResourceID{
+								&webAddressGroupIdentifier03.CloudResourceID,
+							},
+						}},
 				}
 
-				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, ingressrules, egressrules)
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
 				Expect(err).Should(Not(BeNil()))
 			})
 
@@ -461,26 +457,24 @@ var _ = Describe("Azure Cloud Security", func() {
 					&ipNet,
 				}
 
-				ingressrules := []*securitygroup.IngressRule{
-					{
+				addRules := []*securitygroup.CloudRule{{
+					Rule: &securitygroup.IngressRule{
 						Protocol:  &testProtocol,
 						FromPort:  &testFromPort,
 						FromSrcIP: fromSrcIP,
-					},
-				}
-
-				egressrules := []*securitygroup.EgressRule{
+					}},
 					{
-						Protocol: &testProtocol,
-						ToPort:   &testToPort,
-						ToDstIP:  fromSrcIP,
-						ToSecurityGroups: []*securitygroup.CloudResourceID{
-							&webAddressGroupIdentifier03.CloudResourceID,
-						},
-					},
+						Rule: &securitygroup.EgressRule{
+							Protocol: &testProtocol,
+							ToPort:   &testToPort,
+							ToDstIP:  fromSrcIP,
+							ToSecurityGroups: []*securitygroup.CloudResourceID{
+								&webAddressGroupIdentifier03.CloudResourceID,
+							},
+						}},
 				}
 
-				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, ingressrules, egressrules)
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
 				Expect(err).Should(BeNil())
 			})
 		})

--- a/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
@@ -221,17 +221,17 @@ func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupMembers(addressGrou
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockCloudInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, ingressRules []*securitygroup.IngressRule, egressRules []*securitygroup.EgressRule) error {
+func (m *MockCloudInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, addRules, rmRules, targetRules []*securitygroup.CloudRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", addressGroupIdentifier, ingressRules, egressRules)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", addressGroupIdentifier, addRules, rmRules, targetRules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupRules(addressGroupIdentifier, ingressRules, egressRules interface{}) *gomock.Call {
+func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupRules(addressGroupIdentifier, addRules, rmRules, targetRules interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupRules), addressGroupIdentifier, ingressRules, egressRules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupRules), addressGroupIdentifier, addRules, rmRules, targetRules)
 }
 
 // MockAccountMgmtInterface is a mock of AccountMgmtInterface interface.
@@ -458,15 +458,15 @@ func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupMembers(addressG
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockSecurityInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, ingressRules []*securitygroup.IngressRule, egressRules []*securitygroup.EgressRule) error {
+func (m *MockSecurityInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, addRules, rmRules, targetRules []*securitygroup.CloudRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", addressGroupIdentifier, ingressRules, egressRules)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", addressGroupIdentifier, addRules, rmRules, targetRules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupRules(addressGroupIdentifier, ingressRules, egressRules interface{}) *gomock.Call {
+func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupRules(addressGroupIdentifier, addRules, rmRules, targetRules interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockSecurityInterface)(nil).UpdateSecurityGroupRules), addressGroupIdentifier, ingressRules, egressRules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockSecurityInterface)(nil).UpdateSecurityGroupRules), addressGroupIdentifier, addRules, rmRules, targetRules)
 }

--- a/pkg/cloud-provider/cloudapi/common/cloud.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud.go
@@ -78,8 +78,8 @@ type SecurityInterface interface {
 	// If it exists, returns the existing cloud SG ID
 	CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error)
 	// UpdateSecurityGroupRules updates cloud security group corresponding to provided address group with provided ingress and egress rules
-	UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, ingressRules []*securitygroup.IngressRule,
-		egressRules []*securitygroup.EgressRule) error
+	UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, addRules, rmRules,
+		targetRules []*securitygroup.CloudRule) error
 	// UpdateSecurityGroupMembers updates membership of cloud security group corresponding to provided address group. Only
 	// provided computeResources will remain attached to cloud security group. UpdateSecurityGroupMembers will also make sure that
 	// after membership update, if compute resource is no longer attached to any nephe created cloud security group, then

--- a/pkg/cloud-provider/securitygroup_impl.go
+++ b/pkg/cloud-provider/securitygroup_impl.go
@@ -89,7 +89,7 @@ func (sg *SecurityGroupImpl) UpdateSecurityGroupMembers(addressGroupIdentifier *
 }
 
 func (sg *SecurityGroupImpl) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource,
-	ingressRules []*securitygroup.IngressRule, egressRules []*securitygroup.EgressRule) <-chan error {
+	addRules, rmRules, targetRules []*securitygroup.CloudRule) <-chan error {
 	ch := make(chan error)
 
 	go func() {
@@ -101,7 +101,7 @@ func (sg *SecurityGroupImpl) UpdateSecurityGroupRules(addressGroupIdentifier *se
 			return
 		}
 
-		err = cloudInterface.UpdateSecurityGroupRules(addressGroupIdentifier, ingressRules, egressRules)
+		err = cloudInterface.UpdateSecurityGroupRules(addressGroupIdentifier, addRules, rmRules, targetRules)
 		if err != nil {
 			ch <- err
 			return

--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -1261,7 +1261,6 @@ func (n *networkPolicy) update(anp *antreanetworking.NetworkPolicy, recompute bo
 			_, removedAddr = diffAddressGrp(n.Rules, anp.Rules)
 			r.Log.V(1).Info("AddressGroup changes in NetworkPolicy", "old", n.Rules, "new", anp.Rules,
 				"diff", removedAddr)
-			// TODO: observation count?
 			n.Rules = anp.Rules
 			n.Generation = anp.Generation
 			if err := r.networkPolicyIndexer.Add(n); err != nil {

--- a/pkg/controllers/cloud/networkpolicy_controller.go
+++ b/pkg/controllers/cloud/networkpolicy_controller.go
@@ -54,7 +54,7 @@ const (
 	virtualMachineIndexerByCloudName            = "metadata.annotations.cloud-assigned-name"
 
 	operationCount    = 15
-	cloudSyncInterval = 0x80 // 128 Seconds
+	cloudSyncInterval = 0xff // 256 Seconds
 
 	// NetworkPolicy controller is ready to sync after it receives bookmarks from
 	// networkpolicy, addrssGroup and appliedToGroup.
@@ -129,6 +129,7 @@ func (r *NetworkPolicyReconciler) isNetworkPolicySupported(anp *antreanetworking
 	return nil
 }
 
+// updateRuleRealizationStatus check rule realization status on all appliedTo groups for a np and send status.
 func (r *NetworkPolicyReconciler) updateRuleRealizationStatus(np *networkPolicy, err error) {
 	if err == nil {
 		for _, at := range np.AppliedToGroups {
@@ -168,7 +169,7 @@ func (r *NetworkPolicyReconciler) sendRuleRealizationStatus(anp *antreanetworkin
 		status.Nodes[0].RealizationFailure = true
 		status.Nodes[0].Message = err.Error()
 	}
-	r.Log.V(1).Info("Updating rule realization.", "NP", anp.Name, "Namespace", anp.Namespace, "err", err, "generation", anp.Generation)
+	r.Log.V(1).Info("Updating rule realization.", "NP", anp.Name, "Namespace", anp.Namespace, "err", err)
 	if e := r.antreaClient.NetworkPolicies().UpdateStatus(context.TODO(), status.Name, status); e != nil {
 		r.Log.Error(e, "rule realization send failed.", "NP", anp.Name, "Namespace", anp.Namespace)
 	}

--- a/pkg/controllers/cloud/networkpolicy_pendingitem.go
+++ b/pkg/controllers/cloud/networkpolicy_pendingitem.go
@@ -244,7 +244,7 @@ func (s *securityGroupImpl) runPendingItemImpl(c cloudSecurityGroup, memberOnly 
 		if s.state != securityGroupStateGarbageCollectState {
 			if ag, ok := c.(*appliedToSecurityGroup); ok {
 				ag.hasMembers = false
-				_ = ag.updateRules(r)
+				_ = ag.updateAllRules(r)
 			} else {
 				_ = s.updateImpl(c, nil, nil, memberOnly, r)
 			}
@@ -263,7 +263,7 @@ func (s *securityGroupImpl) runPendingItemImpl(c cloudSecurityGroup, memberOnly 
 		err = s.deleteImpl(c, memberOnly, r)
 	} else if op == securityGroupOperationClearMembers || op == securityGroupOperationUpdateRules {
 		ag := c.(*appliedToSecurityGroup)
-		err = ag.updateRules(r)
+		err = ag.updateAllRules(r)
 	}
 	if err != nil {
 		// TODO

--- a/pkg/controllers/cloud/networkpolicy_test.go
+++ b/pkg/controllers/cloud/networkpolicy_test.go
@@ -444,9 +444,19 @@ var _ = Describe("NetworkPolicy", func() {
 			var ruleCall *mock.Call
 			if sgConfig.sgRuleNoOrder {
 				ruleCall = mockCloudSecurityAPI.EXPECT().UpdateSecurityGroupRules(
-					grpID, mock.Any(), mock.Any()).
+					grpID, mock.Any(), mock.Any(), mock.Any()).
 					Return(ch).After(createCall).MaxTimes(sgConfig.appSgRuleTimes).
-					Do(func(id *securitygroup.CloudResource, in []*securitygroup.IngressRule, eg []*securitygroup.EgressRule) {
+					Do(func(id *securitygroup.CloudResource, add, rm, target []*securitygroup.CloudRule) {
+						in := make([]*securitygroup.IngressRule, 0)
+						eg := make([]*securitygroup.EgressRule, 0)
+						for _, rule := range target {
+							switch rule.Rule.(type) {
+							case *securitygroup.IngressRule:
+								in = append(in, rule.Rule.(*securitygroup.IngressRule))
+							case *securitygroup.EgressRule:
+								eg = append(eg, rule.Rule.(*securitygroup.EgressRule))
+							}
+						}
 						Expect(len(in)).To(Equal(1))
 						Expect(len(eg)).To(Equal(1))
 						Expect(sortIngressRuleIPs(in[0])).To(Equal(sortIngressRuleIPs(ingressRule)))
@@ -454,9 +464,19 @@ var _ = Describe("NetworkPolicy", func() {
 					})
 			} else {
 				ruleCall = mockCloudSecurityAPI.EXPECT().UpdateSecurityGroupRules(
-					grpID, mock.Any(), mock.Any()).
+					grpID, mock.Any(), mock.Any(), mock.Any()).
 					Return(ch).After(createCall).Times(sgConfig.appSgRuleTimes).
-					Do(func(id *securitygroup.CloudResource, in []*securitygroup.IngressRule, eg []*securitygroup.EgressRule) {
+					Do(func(id *securitygroup.CloudResource, add, rm, target []*securitygroup.CloudRule) {
+						in := make([]*securitygroup.IngressRule, 0)
+						eg := make([]*securitygroup.EgressRule, 0)
+						for _, rule := range target {
+							switch rule.Rule.(type) {
+							case *securitygroup.IngressRule:
+								in = append(in, rule.Rule.(*securitygroup.IngressRule))
+							case *securitygroup.EgressRule:
+								eg = append(eg, rule.Rule.(*securitygroup.EgressRule))
+							}
+						}
 						Expect(len(in)).To(Equal(1))
 						Expect(len(eg)).To(Equal(1))
 						Expect(sortIngressRuleIPs(in[0])).To(Equal(sortIngressRuleIPs(ingressRule)))
@@ -607,9 +627,19 @@ var _ = Describe("NetworkPolicy", func() {
 					AccountID: accountID,
 				}
 				mockCloudSecurityAPI.EXPECT().UpdateSecurityGroupRules(
-					grpID, mock.Any(), mock.Any()).
+					grpID, mock.Any(), mock.Any(), mock.Any()).
 					Return(ch).
-					Do(func(_ *securitygroup.CloudResource, in []*securitygroup.IngressRule, eg []*securitygroup.EgressRule) {
+					Do(func(_ *securitygroup.CloudResource, add, rm, target []*securitygroup.CloudRule) {
+						in := make([]*securitygroup.IngressRule, 0)
+						eg := make([]*securitygroup.EgressRule, 0)
+						for _, rule := range target {
+							switch rule.Rule.(type) {
+							case *securitygroup.IngressRule:
+								in = append(in, rule.Rule.(*securitygroup.IngressRule))
+							case *securitygroup.EgressRule:
+								eg = append(eg, rule.Rule.(*securitygroup.EgressRule))
+							}
+						}
 						Expect(len(in)).To(Equal(1))
 						Expect(len(eg)).To(Equal(1))
 						Expect(sortIngressRuleIPs(in[0])).To(Equal(sortIngressRuleIPs(ingressRule)))
@@ -635,9 +665,19 @@ var _ = Describe("NetworkPolicy", func() {
 					AccountID: accountID,
 				}
 				mockCloudSecurityAPI.EXPECT().UpdateSecurityGroupRules(
-					grpID, mock.Any(), mock.Any()).
+					grpID, mock.Any(), mock.Any(), mock.Any()).
 					Return(ch).
-					Do(func(_ *securitygroup.CloudResource, in []*securitygroup.IngressRule, eg []*securitygroup.EgressRule) {
+					Do(func(_ *securitygroup.CloudResource, add, rm, target []*securitygroup.CloudRule) {
+						in := make([]*securitygroup.IngressRule, 0)
+						eg := make([]*securitygroup.EgressRule, 0)
+						for _, rule := range target {
+							switch rule.Rule.(type) {
+							case *securitygroup.IngressRule:
+								in = append(in, rule.Rule.(*securitygroup.IngressRule))
+							case *securitygroup.EgressRule:
+								eg = append(eg, rule.Rule.(*securitygroup.EgressRule))
+							}
+						}
 						Expect(len(in)).To(Equal(1))
 						Expect(len(eg)).To(Equal(1))
 						Expect(sortIngressRuleIPs(in[0])).To(Equal(sortIngressRuleIPs(ingressRule)))

--- a/pkg/testing/cloudsecurity/mock.go
+++ b/pkg/testing/cloudsecurity/mock.go
@@ -106,15 +106,15 @@ func (mr *MockCloudSecurityGroupAPIMockRecorder) UpdateSecurityGroupMembers(arg0
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockCloudSecurityGroupAPI) UpdateSecurityGroupRules(arg0 *securitygroup.CloudResource, arg1 []*securitygroup.IngressRule, arg2 []*securitygroup.EgressRule) <-chan error {
+func (m *MockCloudSecurityGroupAPI) UpdateSecurityGroupRules(arg0 *securitygroup.CloudResource, arg1, arg2, arg3 []*securitygroup.CloudRule) <-chan error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(<-chan error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockCloudSecurityGroupAPIMockRecorder) UpdateSecurityGroupRules(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCloudSecurityGroupAPIMockRecorder) UpdateSecurityGroupRules(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudSecurityGroupAPI)(nil).UpdateSecurityGroupRules), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudSecurityGroupAPI)(nil).UpdateSecurityGroupRules), arg0, arg1, arg2, arg3)
 }


### PR DESCRIPTION
## Description

This PR implements per ANP rule realization and ANP status report. This avoids ANP rule realization failure affecting other successfully applied ANPs' status. Currently if multiple ANP are applied on the same VM, one ANP failure will case all ANP status to be shown as fail, regardless of their actual status.

## Changes
WIP