### PR TITLE
Update generation number upon anp update

### DIFF
--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -1243,6 +1243,7 @@ func (n *networkPolicy) update(anp *antreanetworking.NetworkPolicy, recompute bo
 			r.Log.V(1).Info("AddressGroup changes in NetworkPolicy", "old", n.Rules, "new", anp.Rules,
 				"diff", removedAddr)
 			n.Rules = anp.Rules
+			n.Generation = anp.Generation
 			if err := r.networkPolicyIndexer.Add(n); err != nil {
 				r.Log.Error(err, "Add networkPolicy indexer", "Name", n.Name)
 			}
@@ -1257,6 +1258,7 @@ func (n *networkPolicy) update(anp *antreanetworking.NetworkPolicy, recompute bo
 			}
 			addedAppliedTo, removedAppliedTo = diffAppliedToGrp(n.AppliedToGroups, anp.AppliedToGroups)
 			n.AppliedToGroups = anp.AppliedToGroups
+			n.Generation = anp.Generation
 			if err := r.networkPolicyIndexer.Add(n); err != nil {
 				r.Log.Error(err, "Add networkPolicy indexer", "Name", n.Name)
 			}


### PR DESCRIPTION
Rule realization was not getting updated if realized ANP is modified. This was due to ANP Generation number mismatch. In nephe controller, generation number of anp was not updated for modify case.

Signed-off-by: Rahul Jain <rahulj@vmware.com>