### PR TITLE
Sync with cloud feature hardening - 1

### DIFF
--- a/pkg/cloud-provider/cloudapi/aws/aws_security.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_security.go
@@ -602,7 +602,6 @@ func (ec2Cfg *ec2ServiceConfig) getNepheControllerManagedSecurityGroupsCloudView
 }
 
 func getCloudSecurityGroupsByType(cloudSecurityGroups []*ec2.SecurityGroup) (map[string]*ec2.SecurityGroup, map[string]*ec2.SecurityGroup) {
-	cloudSgIDToNameMap := make(map[string]string)
 	managedSgIDToCloudSecurityGroupObj := make(map[string]*ec2.SecurityGroup)
 	unmanagedSgIDToCloudSecurityGroupObj := make(map[string]*ec2.SecurityGroup)
 	for _, cloudSecurityGroup := range cloudSecurityGroups {
@@ -615,7 +614,6 @@ func getCloudSecurityGroupsByType(cloudSecurityGroups []*ec2.SecurityGroup) (map
 		} else {
 			unmanagedSgIDToCloudSecurityGroupObj[sgID] = cloudSecurityGroup
 		}
-		cloudSgIDToNameMap[sgID] = cloudSgName
 	}
 
 	return managedSgIDToCloudSecurityGroupObj, unmanagedSgIDToCloudSecurityGroupObj

--- a/pkg/cloud-provider/cloudapi/azure/azure_security.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_security.go
@@ -506,6 +506,7 @@ func getAsgsToAdd(asgs *[]network.ApplicationSecurityGroup, addrGroupNepheContro
 	return &asgsToKeep, updated
 }
 
+// processAndBuildATSgView creates synchronization content for AppliedTo SG.
 func (computeCfg *computeServiceConfig) processAndBuildAGSgView(
 	networkInterfaces []*networkInterfaceTable) ([]securitygroup.SynchronizationContent, error) {
 	nepheControllerAGSgNameToMemberCloudResourcesMap := make(map[string][]securitygroup.CloudResource)
@@ -549,6 +550,7 @@ func (computeCfg *computeServiceConfig) processAndBuildAGSgView(
 	return addressGroupSgEnforcedView, err
 }
 
+// processAndBuildAGSgView creates synchronization content for AdressGroup SG.
 func (computeCfg *computeServiceConfig) processAndBuildATSgView(networkInterfaces []*networkInterfaceTable) (
 	[]securitygroup.SynchronizationContent, error) {
 	nepheControllerATSgNameToMemberCloudResourcesMap := make(map[string][]securitygroup.CloudResource)
@@ -609,6 +611,7 @@ func (computeCfg *computeServiceConfig) processAndBuildATSgView(networkInterface
 	return appliedToSgEnforcedView, err
 }
 
+// getATGroupView creates synchronization content for NSGs created by nephe under managed VNETs.
 func (computeCfg *computeServiceConfig) getATGroupView(nepheControllerATSGNameToCloudResourcesMap map[string][]securitygroup.CloudResource,
 	perVnetNsgIDToNepheControllerATSGNameSet map[string]map[string]struct{}, nsgIDToVnetID map[string]string) (
 	[]securitygroup.SynchronizationContent, error) {
@@ -652,6 +655,7 @@ func (computeCfg *computeServiceConfig) getATGroupView(nepheControllerATSGNameTo
 	return enforcedSecurityCloudView, nil
 }
 
+// getAGGroupView creates synchronization content for ASGs created by nephe under managed VNETs.
 func (computeCfg *computeServiceConfig) getAGGroupView(nepheControllerAGSgNameToCloudResourcesMap map[string][]securitygroup.CloudResource,
 	asgIDToVnetID map[string]string) ([]securitygroup.SynchronizationContent, error) {
 	appSecurityGroups, err := computeCfg.asgAPIClient.listAllComplete(context.Background())
@@ -662,7 +666,7 @@ func (computeCfg *computeServiceConfig) getAGGroupView(nepheControllerAGSgNameTo
 	var enforcedSecurityCloudView []securitygroup.SynchronizationContent
 	for _, appSecurityGroup := range appSecurityGroups {
 		asgIDLowercase := strings.ToLower(*appSecurityGroup.ID)
-		// if Asg is not associated with a managed VPC, do not create sync content for it.
+		// if ASG is not associated with a managed VNET, do not create sync content for it.
 		if _, found := asgIDToVnetID[asgIDLowercase]; !found {
 			continue
 		}

--- a/pkg/cloud-provider/cloudapi/azure/azure_security.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_security.go
@@ -27,9 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"antrea.io/nephe/apis/crd/v1alpha1"
-	"antrea.io/nephe/pkg/cloud-provider/cloudapi/common"
 	"antrea.io/nephe/pkg/cloud-provider/securitygroup"
-	"antrea.io/nephe/pkg/cloud-provider/utils"
 )
 
 const (
@@ -508,8 +506,8 @@ func getAsgsToAdd(asgs *[]network.ApplicationSecurityGroup, addrGroupNepheContro
 	return &asgsToKeep, updated
 }
 
-func (computeCfg *computeServiceConfig) processAndBuildAGSgView(networkInterfaces []*networkInterfaceTable,
-	antreaATSgNameSet map[string]struct{}) ([]securitygroup.SynchronizationContent, error) {
+func (computeCfg *computeServiceConfig) processAndBuildAGSgView(
+	networkInterfaces []*networkInterfaceTable) ([]securitygroup.SynchronizationContent, error) {
 	nepheControllerAGSgNameToMemberCloudResourcesMap := make(map[string][]securitygroup.CloudResource)
 	asgIDToVnetIDMap := make(map[string]string)
 	for _, networkInterface := range networkInterfaces {
@@ -533,7 +531,7 @@ func (computeCfg *computeServiceConfig) processAndBuildAGSgView(networkInterface
 			cloudResource := securitygroup.CloudResource{
 				Type: securitygroup.CloudResourceTypeNIC,
 				CloudResourceID: securitygroup.CloudResourceID{
-					Name: utils.GenerateShortResourceIdentifier(*networkInterface.ID, common.NetworkInterfaceCRDKind),
+					Name: strings.ToLower(*networkInterface.ID),
 					Vpc:  vnetIDLowerCase,
 				},
 				AccountID:     computeCfg.accountName,
@@ -547,13 +545,12 @@ func (computeCfg *computeServiceConfig) processAndBuildAGSgView(networkInterface
 		}
 	}
 
-	addressGroupSgEnforcedView, err := computeCfg.getAGGroupView(nepheControllerAGSgNameToMemberCloudResourcesMap, asgIDToVnetIDMap,
-		antreaATSgNameSet)
+	addressGroupSgEnforcedView, err := computeCfg.getAGGroupView(nepheControllerAGSgNameToMemberCloudResourcesMap, asgIDToVnetIDMap)
 	return addressGroupSgEnforcedView, err
 }
 
 func (computeCfg *computeServiceConfig) processAndBuildATSgView(networkInterfaces []*networkInterfaceTable) (
-	[]securitygroup.SynchronizationContent, map[string]struct{}, error) {
+	[]securitygroup.SynchronizationContent, error) {
 	nepheControllerATSgNameToMemberCloudResourcesMap := make(map[string][]securitygroup.CloudResource)
 	perVnetNsgIDToNepheControllerAppliedToSGNameSet := make(map[string]map[string]struct{})
 	nsgIDToVnetIDMap := make(map[string]string)
@@ -576,7 +573,7 @@ func (computeCfg *computeServiceConfig) processAndBuildATSgView(networkInterface
 		}
 		vnetIDLowerCase := strings.ToLower(*networkInterface.VnetID)
 		nsgIDToVnetIDMap[nsgIDLowerCase] = vnetIDLowerCase
-		if strings.Compare(sgName, strings.ToLower(appliedToSecurityGroupNamePerVnet)) == 0 {
+		if strings.Contains(strings.ToLower(sgName), appliedToSecurityGroupNamePerVnet) {
 			// from tags find nephe AT SG(s) and build membership map
 			newNepheControllerAppliedToSGNameSet := make(map[string]struct{})
 			for key := range networkInterface.Tags[0] {
@@ -587,7 +584,7 @@ func (computeCfg *computeServiceConfig) processAndBuildATSgView(networkInterface
 				cloudResource := securitygroup.CloudResource{
 					Type: securitygroup.CloudResourceTypeNIC,
 					CloudResourceID: securitygroup.CloudResourceID{
-						Name: utils.GenerateShortResourceIdentifier(*networkInterface.ID, common.NetworkInterfaceCRDKind),
+						Name: strings.ToLower(*networkInterface.ID),
 						Vpc:  vnetIDLowerCase,
 					},
 					AccountID:     computeCfg.accountName,
@@ -607,20 +604,19 @@ func (computeCfg *computeServiceConfig) processAndBuildATSgView(networkInterface
 		}
 	}
 
-	appliedToSgEnforcedView, antreaAtSgNameSet, err := computeCfg.getATGroupView(nepheControllerATSgNameToMemberCloudResourcesMap,
+	appliedToSgEnforcedView, err := computeCfg.getATGroupView(nepheControllerATSgNameToMemberCloudResourcesMap,
 		perVnetNsgIDToNepheControllerAppliedToSGNameSet, nsgIDToVnetIDMap)
-	return appliedToSgEnforcedView, antreaAtSgNameSet, err
+	return appliedToSgEnforcedView, err
 }
 
 func (computeCfg *computeServiceConfig) getATGroupView(nepheControllerATSGNameToCloudResourcesMap map[string][]securitygroup.CloudResource,
 	perVnetNsgIDToNepheControllerATSGNameSet map[string]map[string]struct{}, nsgIDToVnetID map[string]string) (
-	[]securitygroup.SynchronizationContent, map[string]struct{}, error) {
+	[]securitygroup.SynchronizationContent, error) {
 	networkSecurityGroups, err := computeCfg.nsgAPIClient.listAllComplete(context.Background())
 	if err != nil {
-		return []securitygroup.SynchronizationContent{}, nil, err
+		return []securitygroup.SynchronizationContent{}, err
 	}
 
-	nepheControllerATSgNameSet := make(map[string]struct{})
 	var enforcedSecurityCloudView []securitygroup.SynchronizationContent
 	for _, networkSecurityGroup := range networkSecurityGroups {
 		nsgIDLowercase := strings.ToLower(*networkSecurityGroup.ID)
@@ -650,16 +646,14 @@ func (computeCfg *computeServiceConfig) getATGroupView(nepheControllerATSGNameTo
 				EgressRules:    nepheControllerATSgNameToEgressRulesMap[atSgName],
 			}
 			enforcedSecurityCloudView = append(enforcedSecurityCloudView, groupSyncObj)
-
-			nepheControllerATSgNameSet[atSgName] = struct{}{}
 		}
 	}
 
-	return enforcedSecurityCloudView, nepheControllerATSgNameSet, nil
+	return enforcedSecurityCloudView, nil
 }
 
 func (computeCfg *computeServiceConfig) getAGGroupView(nepheControllerAGSgNameToCloudResourcesMap map[string][]securitygroup.CloudResource,
-	asgIDToVnetID map[string]string, nepheControllerATSgNameSet map[string]struct{}) ([]securitygroup.SynchronizationContent, error) {
+	asgIDToVnetID map[string]string) ([]securitygroup.SynchronizationContent, error) {
 	appSecurityGroups, err := computeCfg.asgAPIClient.listAllComplete(context.Background())
 	if err != nil {
 		return []securitygroup.SynchronizationContent{}, err
@@ -668,6 +662,10 @@ func (computeCfg *computeServiceConfig) getAGGroupView(nepheControllerAGSgNameTo
 	var enforcedSecurityCloudView []securitygroup.SynchronizationContent
 	for _, appSecurityGroup := range appSecurityGroups {
 		asgIDLowercase := strings.ToLower(*appSecurityGroup.ID)
+		// if Asg is not associated with a managed VPC, do not create sync content for it.
+		if _, found := asgIDToVnetID[asgIDLowercase]; !found {
+			continue
+		}
 
 		_, _, cloudAsgName, err := extractFieldsFromAzureResourceID(asgIDLowercase)
 		if err != nil {
@@ -676,12 +674,6 @@ func (computeCfg *computeServiceConfig) getAGGroupView(nepheControllerAGSgNameTo
 
 		AGSgName, isAG, _ := securitygroup.IsNepheControllerCreatedSG(cloudAsgName)
 		if !isAG {
-			continue
-		}
-
-		// skip asg if it belongs to AT SG
-		_, found := nepheControllerATSgNameSet[AGSgName]
-		if found {
 			continue
 		}
 
@@ -989,12 +981,12 @@ func (computeCfg *computeServiceConfig) getNepheControllerManagedSecurityGroupsC
 		return []securitygroup.SynchronizationContent{}
 	}
 
-	appliedToSgEnforcedView, antreaATSgNameSet, err := computeCfg.processAndBuildATSgView(networkInterfaces)
+	appliedToSgEnforcedView, err := computeCfg.processAndBuildATSgView(networkInterfaces)
 	if err != nil {
 		return []securitygroup.SynchronizationContent{}
 	}
 
-	addressGroupSgEnforcedView, err := computeCfg.processAndBuildAGSgView(networkInterfaces, antreaATSgNameSet)
+	addressGroupSgEnforcedView, err := computeCfg.processAndBuildAGSgView(networkInterfaces)
 	if err != nil {
 		return []securitygroup.SynchronizationContent{}
 	}

--- a/pkg/controllers/cloud/networkpolicy_controller.go
+++ b/pkg/controllers/cloud/networkpolicy_controller.go
@@ -51,7 +51,6 @@ const (
 	cloudResourceNPTrackerIndexerByAppliedToGrp = "AppliedToGrp"
 	cloudRuleIndexerByAppliedToGrp              = "AppliedToGrp"
 	virtualMachineIndexerByCloudID              = "metadata.annotations.cloud-assigned-id"
-	virtualMachineIndexerByCloudName            = "metadata.annotations.cloud-assigned-name"
 
 	operationCount    = 15
 	cloudSyncInterval = 0xff // 256 Seconds

--- a/pkg/controllers/cloud/networkpolicy_sync.go
+++ b/pkg/controllers/cloud/networkpolicy_sync.go
@@ -28,59 +28,59 @@ import (
 
 // sync synchronizes securityGroup memberships with cloud.
 // Return true if cloud and controller has same membership.
-func (s *securityGroupImpl) syncImpl(csg cloudSecurityGroup, c *securitygroup.SynchronizationContent, membershipOnly bool,
+func (sg *securityGroupImpl) syncImpl(csg cloudSecurityGroup, syncContent *securitygroup.SynchronizationContent, membershipOnly bool,
 	r *NetworkPolicyReconciler) bool {
 	log := r.Log.WithName("CloudSync")
-	if c != nil {
-		s.state = securityGroupStateCreated
-		cMembers := make([]*securitygroup.CloudResource, 0, len(c.Members))
-		for i := range c.Members {
-			cMembers = append(cMembers, &c.Members[i])
+	if syncContent != nil {
+		sg.state = securityGroupStateCreated
+		syncMembers := make([]*securitygroup.CloudResource, 0, len(syncContent.Members))
+		for i := range syncContent.Members {
+			syncMembers = append(syncMembers, &syncContent.Members[i])
 		}
 
-		nMembers := s.members
-		if len(cMembers) > 0 && cMembers[0].Type == securitygroup.CloudResourceTypeNIC {
-			nMembers, _ = r.getNICsOfCloudResources(s.members)
+		internalMembers := sg.members
+		if len(syncMembers) > 0 && syncMembers[0].Type == securitygroup.CloudResourceTypeNIC {
+			internalMembers, _ = r.getNICsOfCloudResources(sg.members)
 		}
-		if compareCloudResources(nMembers, cMembers) {
-			log.V(1).Info("Same SecurityGroup found", "Name", s.id.Name, "State", s.state)
+		if compareCloudResources(internalMembers, syncMembers) {
+			log.V(1).Info("Same SecurityGroup found", "Name", sg.id.Name, "State", sg.state)
 			return true
 		}
-	} else if len(s.members) == 0 {
-		log.V(1).Info("Empty memberships", "Name", s.id.Name)
+	} else if len(sg.members) == 0 {
+		log.V(1).Info("Empty memberships", "Name", sg.id.Name)
 		return true
 	}
 
-	if s.state == securityGroupStateCreated {
-		log.V(1).Info("Update securityGroup", "Name", s.id.Name, "MembershipOnly", membershipOnly, "CloudSecurityGroup", c)
-		_ = s.updateImpl(csg, nil, nil, membershipOnly, r)
-	} else if s.state == securityGroupStateInit {
-		log.V(1).Info("Add securityGroup", "Name", s.id.Name, "MembershipOnly", membershipOnly, "CloudSecurityGroup", c)
-		_ = s.addImpl(csg, membershipOnly, r)
+	if sg.state == securityGroupStateCreated {
+		log.V(1).Info("Update securityGroup", "Name", sg.id.Name, "MembershipOnly", membershipOnly, "CloudSecurityGroup", syncContent)
+		_ = sg.updateImpl(csg, nil, nil, membershipOnly, r)
+	} else if sg.state == securityGroupStateInit {
+		log.V(1).Info("Add securityGroup", "Name", sg.id.Name, "MembershipOnly", membershipOnly, "CloudSecurityGroup", syncContent)
+		_ = sg.addImpl(csg, membershipOnly, r)
 	}
 	return false
 }
 
 // sync synchronizes addressSecurityGroup with cloud.
-func (a *addrSecurityGroup) sync(c *securitygroup.SynchronizationContent,
+func (a *addrSecurityGroup) sync(syncContent *securitygroup.SynchronizationContent,
 	r *NetworkPolicyReconciler) {
 	log := r.Log.WithName("CloudSync")
 	if a.deletePending {
 		log.V(1).Info("AddressSecurityGroup pending delete", "Name", a.id.Name)
 		return
 	}
-	_ = a.syncImpl(a, c, true, r)
+	_ = a.syncImpl(a, syncContent, true, r)
 }
 
 // sync synchronizes appliedToSecurityGroup with cloud.
-func (a *appliedToSecurityGroup) sync(c *securitygroup.SynchronizationContent,
+func (a *appliedToSecurityGroup) sync(syncContent *securitygroup.SynchronizationContent,
 	r *NetworkPolicyReconciler) {
 	log := r.Log.WithName("CloudSync")
 	if a.deletePending {
 		log.V(1).Info("AppliedSecurityGroup pending delete", "Name", a.id.Name)
 		return
 	}
-	if a.syncImpl(a, c, false, r) && len(a.members) > 0 {
+	if a.syncImpl(a, syncContent, false, r) && len(a.members) > 0 {
 		a.hasMembers = true
 	}
 	nps, err := r.networkPolicyIndexer.ByIndex(networkPolicyIndexerByAppliedToGrp, a.id.Name)
@@ -137,7 +137,7 @@ func (a *appliedToSecurityGroup) sync(c *securitygroup.SynchronizationContent,
 		}
 	}
 
-	if c == nil {
+	if syncContent == nil {
 		_ = a.updateAllRules(r)
 		return
 	}
@@ -155,7 +155,7 @@ func (a *appliedToSecurityGroup) sync(c *securitygroup.SynchronizationContent,
 	}
 
 	// Rough compare rules
-	for _, iRule := range c.IngressRules {
+	for _, iRule := range syncContent.IngressRules {
 		proto := 0
 		if iRule.Protocol != nil {
 			proto = *iRule.Protocol
@@ -187,7 +187,7 @@ func (a *appliedToSecurityGroup) sync(c *securitygroup.SynchronizationContent,
 			_ = r.cloudRuleIndexer.Update(rule)
 		}
 	}
-	for _, eRule := range c.EgressRules {
+	for _, eRule := range syncContent.EgressRules {
 		proto := 0
 		if eRule.Protocol != nil {
 			proto = *eRule.Protocol
@@ -233,7 +233,7 @@ func (a *appliedToSecurityGroup) sync(c *securitygroup.SynchronizationContent,
 	for k, i := range items {
 		if i != 0 {
 			log.V(1).Info("Update appliedToSecurityGroup rules", "Name",
-				a.id.CloudResourceID.String(), "CloudSecurityGroup", c, "Item", k, "Diff", i)
+				a.id.CloudResourceID.String(), "CloudSecurityGroup", syncContent, "Item", k, "Diff", i)
 			_ = a.updateAllRules(r)
 			return
 		}
@@ -340,9 +340,9 @@ func (r *NetworkPolicyReconciler) getNICsOfCloudResources(resources []*securityg
 
 	nics := make([]*securitygroup.CloudResource, 0, len(resources))
 	for _, rsc := range resources {
-		name := rsc.Name
+		id := rsc.Name
 		vmList := &v1alpha1.VirtualMachineList{}
-		if err := r.List(context.TODO(), vmList, client.MatchingFields{virtualMachineIndexerByCloudName: name}); err != nil {
+		if err := r.List(context.TODO(), vmList, client.MatchingFields{virtualMachineIndexerByCloudID: id}); err != nil {
 			return resources, err
 		}
 		for _, vm := range vmList.Items {


### PR DESCRIPTION
Issue1:
    Sync content member compare(includes NetworkInterface) always fails.
Fix:
    Name field in CloudResourceID holds the VM ID(resource ID), hence
    use the indexer meant for matching VM ID fix in VM CRs.
    While creating network interface CloudResource object, use
    the right id in CloudResourceID.

Issue2:
    Synchronization content is never received for AT SG.
Fix:
    An example of NSG in Azure is nephe-at-per-vnet-default-archana-test-vnet-1.
    Fix is related to string comaprision of SG name with "per-vnet-default".
    As this is not a direct comparison, use "Contains" instead of "Compare".

Issue3:
    Sync content is not received for AG SG when AT SG with same name exists.
Fix:
    Irrespective of AT group names, fix creates sync content for AG.
    Name collision between AG and AT group can arise when two ANP's
    vm1 AT -> vm2 AG and vm2 AT -> vm1 AG exist.

Issue4:
    Stale sync content received for AG SG which belong to unmanaged VPCs.
Fix:
    While building CloudResource Map for ASG, it is built only for managed VPC,
    however after cloud API call for getting all ASGs is made,
    while processing the result, all nephe created ASGs are taken into
    account even if they do not have any CloudResource member/vpc association.
    Add a check to make sure ASG is associated with managed VPC and
    skip ASGs associated with unmanaged VPCs.

Signed-off-by: Archana Holla <harchana@vmware.com>