### PR TITLE
VPC test patch for list order error

### DIFF
--- a/pkg/apiserver/registry/inventory/vpc_suite_test.go
+++ b/pkg/apiserver/registry/inventory/vpc_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package inventory_test
+package inventory
 
 import (
 	"testing"

--- a/pkg/apiserver/registry/inventory/vpc_test.go
+++ b/pkg/apiserver/registry/inventory/vpc_test.go
@@ -15,6 +15,8 @@
 package inventory_test
 
 import (
+	"sort"
+
 	logger "github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -212,6 +214,10 @@ var _ = Describe("VPC", func() {
 			for i, vpcListOption := range vpcLabelSelectorListOptions {
 				rest := NewREST(cloudInventory, l)
 				actualObj, err := rest.List(request.NewDefaultContext(), vpcListOption)
+				items := actualObj.(*runtimev1alpha1.VpcList).Items
+				sort.SliceStable(items, func(i, j int) bool {
+					return items[i].Name < items[j].Name
+				})
 				Expect(err).Should(BeNil())
 				Expect(actualObj).To(Equal(expectedPolicyLists[i]))
 			}

--- a/pkg/apiserver/registry/inventory/vpc_test.go
+++ b/pkg/apiserver/registry/inventory/vpc_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package inventory_test
+package inventory
 
 import (
 	"sort"
@@ -31,7 +31,6 @@ import (
 
 	"antrea.io/nephe/apis/crd/v1alpha1"
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
-	. "antrea.io/nephe/pkg/apiserver/registry/inventory"
 	"antrea.io/nephe/pkg/controllers/inventory"
 )
 
@@ -210,7 +209,6 @@ var _ = Describe("VPC", func() {
 			Expect(err).Should(BeNil())
 		}
 		It("Should return the list result of rest by labels", func() {
-			Skip("Disabling the test")
 			for i, vpcListOption := range vpcLabelSelectorListOptions {
 				rest := NewREST(cloudInventory, l)
 				actualObj, err := rest.List(request.NewDefaultContext(), vpcListOption)


### PR DESCRIPTION
There is a intermittent error for vpc unit test(about 7%) because of the Items of VPC list will have different orders, added the sort function of this part