### PR TITLE
Pin K8s to 1.23.12 for AKS

### DIFF
--- a/hack/terraform/aks/main.tf
+++ b/hack/terraform/aks/main.tf
@@ -90,6 +90,9 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   identity {
     type = "SystemAssigned"
   }
+
+  kubernetes_version = "1.23.12"
+
   tags = {
     Environment = "nephe"
   }


### PR DESCRIPTION
K8s 1.24 version introduced breaking change on how Service Accounts (SA) are handled. Pinning the K8s version till Antrea updates SA for VM agent support.

Signed-off-by: Rahul Jain <rahulj@vmware.com>