### PR TITLE
update plugin func parameter name to match actual usage

### DIFF
--- a/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
@@ -96,18 +96,18 @@ func (mr *MockCloudInterfaceMockRecorder) AddProviderAccount(client, account int
 }
 
 // CreateSecurityGroup mocks base method.
-func (m *MockCloudInterface) CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error) {
+func (m *MockCloudInterface) CreateSecurityGroup(securityGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecurityGroup", addressGroupIdentifier, membershipOnly)
+	ret := m.ctrl.Call(m, "CreateSecurityGroup", securityGroupIdentifier, membershipOnly)
 	ret0, _ := ret[0].(*string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecurityGroup indicates an expected call of CreateSecurityGroup.
-func (mr *MockCloudInterfaceMockRecorder) CreateSecurityGroup(addressGroupIdentifier, membershipOnly interface{}) *gomock.Call {
+func (mr *MockCloudInterfaceMockRecorder) CreateSecurityGroup(securityGroupIdentifier, membershipOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockCloudInterface)(nil).CreateSecurityGroup), addressGroupIdentifier, membershipOnly)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockCloudInterface)(nil).CreateSecurityGroup), securityGroupIdentifier, membershipOnly)
 }
 
 // DeleteInventoryPoller mocks base method.
@@ -125,17 +125,17 @@ func (mr *MockCloudInterfaceMockRecorder) DeleteInventoryPoller(accountNamespace
 }
 
 // DeleteSecurityGroup mocks base method.
-func (m *MockCloudInterface) DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error {
+func (m *MockCloudInterface) DeleteSecurityGroup(securityGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSecurityGroup", addressGroupIdentifier, membershipOnly)
+	ret := m.ctrl.Call(m, "DeleteSecurityGroup", securityGroupIdentifier, membershipOnly)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSecurityGroup indicates an expected call of DeleteSecurityGroup.
-func (mr *MockCloudInterfaceMockRecorder) DeleteSecurityGroup(addressGroupIdentifier, membershipOnly interface{}) *gomock.Call {
+func (mr *MockCloudInterfaceMockRecorder) DeleteSecurityGroup(securityGroupIdentifier, membershipOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockCloudInterface)(nil).DeleteSecurityGroup), addressGroupIdentifier, membershipOnly)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockCloudInterface)(nil).DeleteSecurityGroup), securityGroupIdentifier, membershipOnly)
 }
 
 // GetAccountStatus mocks base method.
@@ -251,31 +251,31 @@ func (mr *MockCloudInterfaceMockRecorder) RemoveProviderAccount(namespacedName i
 }
 
 // UpdateSecurityGroupMembers mocks base method.
-func (m *MockCloudInterface) UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource, membershipOnly bool) error {
+func (m *MockCloudInterface) UpdateSecurityGroupMembers(securityGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource, membershipOnly bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupMembers", addressGroupIdentifier, computeResourceIdentifier, membershipOnly)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupMembers", securityGroupIdentifier, computeResourceIdentifier, membershipOnly)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupMembers indicates an expected call of UpdateSecurityGroupMembers.
-func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupMembers(addressGroupIdentifier, computeResourceIdentifier, membershipOnly interface{}) *gomock.Call {
+func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupMembers(securityGroupIdentifier, computeResourceIdentifier, membershipOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupMembers", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupMembers), addressGroupIdentifier, computeResourceIdentifier, membershipOnly)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupMembers", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupMembers), securityGroupIdentifier, computeResourceIdentifier, membershipOnly)
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockCloudInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, addRules, rmRules, allRules []*securitygroup.CloudRule) error {
+func (m *MockCloudInterface) UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules, allRules []*securitygroup.CloudRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", addressGroupIdentifier, addRules, rmRules, allRules)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", appliedToGroupIdentifier, addRules, rmRules, allRules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupRules(addressGroupIdentifier, addRules, rmRules, allRules interface{}) *gomock.Call {
+func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupRules(appliedToGroupIdentifier, addRules, rmRules, allRules interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupRules), addressGroupIdentifier, addRules, rmRules, allRules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupRules), appliedToGroupIdentifier, addRules, rmRules, allRules)
 }
 
 // MockAccountMgmtInterface is a mock of AccountMgmtInterface interface.
@@ -488,32 +488,32 @@ func (m *MockSecurityInterface) EXPECT() *MockSecurityInterfaceMockRecorder {
 }
 
 // CreateSecurityGroup mocks base method.
-func (m *MockSecurityInterface) CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error) {
+func (m *MockSecurityInterface) CreateSecurityGroup(securityGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecurityGroup", addressGroupIdentifier, membershipOnly)
+	ret := m.ctrl.Call(m, "CreateSecurityGroup", securityGroupIdentifier, membershipOnly)
 	ret0, _ := ret[0].(*string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecurityGroup indicates an expected call of CreateSecurityGroup.
-func (mr *MockSecurityInterfaceMockRecorder) CreateSecurityGroup(addressGroupIdentifier, membershipOnly interface{}) *gomock.Call {
+func (mr *MockSecurityInterfaceMockRecorder) CreateSecurityGroup(securityGroupIdentifier, membershipOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockSecurityInterface)(nil).CreateSecurityGroup), addressGroupIdentifier, membershipOnly)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockSecurityInterface)(nil).CreateSecurityGroup), securityGroupIdentifier, membershipOnly)
 }
 
 // DeleteSecurityGroup mocks base method.
-func (m *MockSecurityInterface) DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error {
+func (m *MockSecurityInterface) DeleteSecurityGroup(securityGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSecurityGroup", addressGroupIdentifier, membershipOnly)
+	ret := m.ctrl.Call(m, "DeleteSecurityGroup", securityGroupIdentifier, membershipOnly)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSecurityGroup indicates an expected call of DeleteSecurityGroup.
-func (mr *MockSecurityInterfaceMockRecorder) DeleteSecurityGroup(addressGroupIdentifier, membershipOnly interface{}) *gomock.Call {
+func (mr *MockSecurityInterfaceMockRecorder) DeleteSecurityGroup(securityGroupIdentifier, membershipOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockSecurityInterface)(nil).DeleteSecurityGroup), addressGroupIdentifier, membershipOnly)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockSecurityInterface)(nil).DeleteSecurityGroup), securityGroupIdentifier, membershipOnly)
 }
 
 // GetEnforcedSecurity mocks base method.
@@ -531,29 +531,29 @@ func (mr *MockSecurityInterfaceMockRecorder) GetEnforcedSecurity() *gomock.Call 
 }
 
 // UpdateSecurityGroupMembers mocks base method.
-func (m *MockSecurityInterface) UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource, membershipOnly bool) error {
+func (m *MockSecurityInterface) UpdateSecurityGroupMembers(securityGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource, membershipOnly bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupMembers", addressGroupIdentifier, computeResourceIdentifier, membershipOnly)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupMembers", securityGroupIdentifier, computeResourceIdentifier, membershipOnly)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupMembers indicates an expected call of UpdateSecurityGroupMembers.
-func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupMembers(addressGroupIdentifier, computeResourceIdentifier, membershipOnly interface{}) *gomock.Call {
+func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupMembers(securityGroupIdentifier, computeResourceIdentifier, membershipOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupMembers", reflect.TypeOf((*MockSecurityInterface)(nil).UpdateSecurityGroupMembers), addressGroupIdentifier, computeResourceIdentifier, membershipOnly)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupMembers", reflect.TypeOf((*MockSecurityInterface)(nil).UpdateSecurityGroupMembers), securityGroupIdentifier, computeResourceIdentifier, membershipOnly)
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockSecurityInterface) UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, addRules, rmRules, allRules []*securitygroup.CloudRule) error {
+func (m *MockSecurityInterface) UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules, allRules []*securitygroup.CloudRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", addressGroupIdentifier, addRules, rmRules, allRules)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", appliedToGroupIdentifier, addRules, rmRules, allRules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupRules(addressGroupIdentifier, addRules, rmRules, allRules interface{}) *gomock.Call {
+func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupRules(appliedToGroupIdentifier, addRules, rmRules, allRules interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockSecurityInterface)(nil).UpdateSecurityGroupRules), addressGroupIdentifier, addRules, rmRules, allRules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockSecurityInterface)(nil).UpdateSecurityGroupRules), appliedToGroupIdentifier, addRules, rmRules, allRules)
 }

--- a/pkg/cloud-provider/cloudapi/common/cloud.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud.go
@@ -80,24 +80,24 @@ type ComputeInterface interface {
 }
 
 type SecurityInterface interface {
-	// CreateSecurityGroup creates cloud security group corresponding to provided address group, if it does not already exist.
-	// If it exists, returns the existing cloud SG ID
-	CreateSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error)
-	// UpdateSecurityGroupRules updates cloud security group corresponding to provided address group with provided rules.
+	// CreateSecurityGroup creates cloud security group corresponding to provided security group, if it does not already exist.
+	// If it exists, returns the existing cloud SG ID.
+	CreateSecurityGroup(securityGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error)
+	// UpdateSecurityGroupRules updates cloud security group corresponding to provided appliedTo group with provided rules.
 	// addRules and rmRules are the changed rules, allRules are rules from all nps of the security group.
-	UpdateSecurityGroupRules(addressGroupIdentifier *securitygroup.CloudResource, addRules, rmRules,
+	UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules,
 		allRules []*securitygroup.CloudRule) error
-	// UpdateSecurityGroupMembers updates membership of cloud security group corresponding to provided address group. Only
+	// UpdateSecurityGroupMembers updates membership of cloud security group corresponding to provided security group. Only
 	// provided computeResources will remain attached to cloud security group. UpdateSecurityGroupMembers will also make sure that
 	// after membership update, if compute resource is no longer attached to any nephe created cloud security group, then
-	// compute resource will get moved to cloud default security group
-	UpdateSecurityGroupMembers(addressGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource,
+	// compute resource will get moved to cloud default security group.
+	UpdateSecurityGroupMembers(securityGroupIdentifier *securitygroup.CloudResource, computeResourceIdentifier []*securitygroup.CloudResource,
 		membershipOnly bool) error
-	// DeleteSecurityGroup will delete the cloud security group corresponding to provided address group. DeleteSecurityGroup expects that
+	// DeleteSecurityGroup will delete the cloud security group corresponding to provided security group. DeleteSecurityGroup expects that
 	// UpdateSecurityGroupMembers and UpdateSecurityGroupRules is called prior to calling delete. DeleteSecurityGroup as part of delete,
-	// do the best effort to find resources using this address group and detach the cloud security group from those resources.Also if the
+	// do the best effort to find resources using this security group and detach the cloud security group from those resources. Also, if the
 	// compute resource is attached to only this security group, it will be moved to cloud default security group.
-	DeleteSecurityGroup(addressGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error
-	// GetEnforcedSecurity returns the cloud view of enforced security
+	DeleteSecurityGroup(securityGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) error
+	// GetEnforcedSecurity returns the cloud view of enforced security.
 	GetEnforcedSecurity() []securitygroup.SynchronizationContent
 }

--- a/pkg/cloud-provider/plugins.go
+++ b/pkg/cloud-provider/plugins.go
@@ -40,7 +40,7 @@ func init() {
 	registerCloudProvider(cloudcommon.ProviderType(cloudv1alpha1.AzureCloudProvider), azure.Register())
 }
 
-// registerCloudProvider registers a cloudv1alpha1 provider factory by type.  This
+// registerCloudProvider registers a cloudv1alpha1 provider factory by type. This
 // is expected to happen during controller startup.
 func registerCloudProvider(providerType cloudcommon.ProviderType, cloud cloudcommon.CloudInterface) {
 	providersMutex.Lock()

--- a/pkg/cloud-provider/securitygroup/securitygroup.go
+++ b/pkg/cloud-provider/securitygroup/securitygroup.go
@@ -213,6 +213,11 @@ type CloudSecurityGroupAPI interface {
 	// Caller expects to wait on returned channel for status
 	CreateSecurityGroup(name *CloudResource, membershipOnly bool) <-chan error
 
+	// UpdateSecurityGroupRules updates SecurityGroup name's ingress/egress rules in entirety.
+	// SecurityGroup name must already been created. SecurityGroups referred to in ingressRules and
+	// egressRules must have been already created.
+	UpdateSecurityGroupRules(name *CloudResource, addRules, rmRules, allRules []*CloudRule) <-chan error
+
 	// UpdateSecurityGroupMembers updates SecurityGroup name with members.
 	// SecurityGroup name must already have been created.
 	// For appliedSecurityGroup, UpdateSecurityGroupMembers is called only if SG has
@@ -222,11 +227,6 @@ type CloudSecurityGroupAPI interface {
 	// DeleteSecurityGroup deletes SecurityGroup name.
 	// SecurityGroup name must already been created, is empty.
 	DeleteSecurityGroup(name *CloudResource, membershipOnly bool) <-chan error
-
-	// UpdateSecurityGroupRules updates SecurityGroup name's ingress/egress rules in entirety.
-	// SecurityGroup name must already been created. SecurityGroups referred to in ingressRules and
-	// egressRules must have been already created.
-	UpdateSecurityGroupRules(name *CloudResource, addRules, rmRules, allRules []*CloudRule) <-chan error
 
 	// GetSecurityGroupSyncChan returns a channel that networkPolicy controller waits on to retrieve complete SGs
 	// configured by cloud plug-in.


### PR DESCRIPTION
## Description
This PR updates function parameter names in Azure and AWS plugin as well as interface definition. The security group id was incorrectly named as addressGroupIdentifier while actually being used as appliedTo id or both. This PR fixes the misleading names to reflect their actual expected usages.

## Changes
1. Fix function parameter names in AWS and Azure plugin as well as interface definition.
2. Fix function parameter names in security group functions and definition.
3. Add comments and fix comment typos.

Signed-off-by: Alexander Liu <alliu@vmware.com>