### PR TITLE
Deletes the enable leadership election argument

### DIFF
--- a/config/manager/nephe-controller.yaml
+++ b/config/manager/nephe-controller.yaml
@@ -38,7 +38,6 @@ spec:
       - command:
         - /nephe-controller
         args:
-        - --enable-leader-election
         - --enable-debug-log
         image: "projects.registry.vmware.com/antrea/nephe:latest"
         imagePullPolicy: IfNotPresent

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -721,7 +721,6 @@ spec:
     spec:
       containers:
       - args:
-        - --enable-leader-election
         - --enable-debug-log
         command:
         - /nephe-controller


### PR DESCRIPTION
This deletes the enable leadership election argument in nephe-controller pod.

Signed-off-by: nithishs <nithishs@vmware.com>