### PR TITLE
Fix for creating synchronization content for AT SG.

### DIFF
--- a/pkg/cloud-provider/cloudapi/azure/azure_security.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_security.go
@@ -574,7 +574,7 @@ func (computeCfg *computeServiceConfig) processAndBuildATSgView(networkInterface
 		}
 		vnetIDLowerCase := strings.ToLower(*networkInterface.VnetID)
 		nsgIDToVnetIDMap[nsgIDLowerCase] = vnetIDLowerCase
-		if strings.Compare(sgName, strings.ToLower(appliedToSecurityGroupNamePerVnet)) == 0 {
+		if strings.Contains(strings.ToLower(sgName), appliedToSecurityGroupNamePerVnet) {
 			// from tags find nephe AT SG(s) and build membership map
 			newNepheControllerAppliedToSGNameSet := make(map[string]struct{})
 			for key := range networkInterface.Tags[0] {


### PR DESCRIPTION
- An example of NSG in Azure is nephe-at-per-vnet-default-archana-test-vnet-1. Fix is related to string comparison of SG name with "per-vnet-default". As this is not a direct comparison use "Contains" instead of "Compare".

Signed-off-by: Archana Holla <harchana@vmware.com>