### PR TITLE
Propagate VPC poll status to the caller for updating CPA Status field.

### DIFF
--- a/pkg/cloud-provider/cloudapi/aws/aws_ec2.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_ec2.go
@@ -242,7 +242,10 @@ func (ec2Cfg *ec2ServiceConfig) getInstances() ([]*ec2.Instance, error) {
 
 // DoResourceInventory gets inventory from cloud for given cloud account.
 func (ec2Cfg *ec2ServiceConfig) DoResourceInventory() error {
-	vpcs, _ := ec2Cfg.getVpcs()
+	vpcs, e := ec2Cfg.getVpcs()
+	if e != nil {
+		return e
+	}
 
 	instances, e := ec2Cfg.getInstances()
 	if e != nil {

--- a/pkg/cloud-provider/cloudapi/azure/azure_compute.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_compute.go
@@ -218,7 +218,10 @@ func (computeCfg *computeServiceConfig) getComputeResourceFilters() ([]*string, 
 }
 
 func (computeCfg *computeServiceConfig) DoResourceInventory() error {
-	vnets, _ := computeCfg.getVpcs()
+	vnets, err := computeCfg.getVpcs()
+	if err != nil {
+		return err
+	}
 
 	virtualMachines, err := computeCfg.getVirtualMachines()
 	if err == nil {


### PR DESCRIPTION
If fetching vpc list from cloud returns an error, we continue to fetch instances from cloud with the intention that fetching vm instances has a higher priority over fetching vpc list. However, status of vpc poll needs to be taken into consideration and use it for setting "Error" in Status field of CPA CR. This plays a major role especially when CPA is added with incorrect credentials and CES is not yet added.

With this change, "Error" in Status field of CPA CR gets immediately set when fetching vpcs from cloud returns an error.

Signed-off-by: Archana Holla <harchana@vmware.com>