### PR TITLE
fix azure stale vmp and add ci tests

### DIFF
--- a/pkg/cloud-provider/utils/crd_generator.go
+++ b/pkg/cloud-provider/utils/crd_generator.go
@@ -103,8 +103,8 @@ func GenerateInternalVpcObject(name string, namespace string, labels map[string]
 	return vpc
 }
 
-// GetCloudResourceCrName gets corresponding cr name from cloud resource id based on cloud type.
-func GetCloudResourceCrName(providerType, name string) string {
+// GetCloudResourceCRName gets corresponding cr name from cloud resource id based on cloud type.
+func GetCloudResourceCRName(providerType, name string) string {
 	switch providerType {
 	case string(cloudv1alpha1.AWSCloudProvider):
 		return name

--- a/pkg/cloud-provider/utils/crd_generator.go
+++ b/pkg/cloud-provider/utils/crd_generator.go
@@ -102,3 +102,15 @@ func GenerateInternalVpcObject(name string, namespace string, labels map[string]
 
 	return vpc
 }
+
+func GetCloudResourceCrdName(providerType, name string) string {
+	switch providerType {
+	case string(cloudv1alpha1.AWSCloudProvider):
+		return name
+	case string(cloudv1alpha1.AzureCloudProvider):
+		tokens := strings.Split(name, "/")
+		return GenerateShortResourceIdentifier(name, tokens[len(tokens)-1])
+	default:
+		return name
+	}
+}

--- a/pkg/cloud-provider/utils/crd_generator.go
+++ b/pkg/cloud-provider/utils/crd_generator.go
@@ -103,7 +103,8 @@ func GenerateInternalVpcObject(name string, namespace string, labels map[string]
 	return vpc
 }
 
-func GetCloudResourceCrdName(providerType, name string) string {
+// GetCloudResourceCrName gets corresponding cr name from cloud resource id based on cloud type.
+func GetCloudResourceCrName(providerType, name string) string {
 	switch providerType {
 	case string(cloudv1alpha1.AWSCloudProvider):
 		return name

--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -1156,13 +1156,14 @@ func (a *appliedToSecurityGroup) notifyNetworkPolicyChange(r *NetworkPolicyRecon
 }
 
 // removeStaleMembers removes sg members that their corresponding CRs no longer exist and cleans up relevant internal resources.
+// we do not make cloud api calls to update members because we do not know if vm is still present in cloud or not.
 func (a *appliedToSecurityGroup) removeStaleMembers(stales []*types.NamespacedName, r *NetworkPolicyReconciler) {
 	if len(a.members) == 0 {
 		return
 	}
 	srcMap := make(map[string]*securitygroup.CloudResource)
 	for _, m := range a.members {
-		name := utils.GetCloudResourceCrdName(m.CloudProvider, m.Name)
+		name := utils.GetCloudResourceCrName(m.CloudProvider, m.Name)
 		srcMap[name] = m
 	}
 	for _, stale := range stales {

--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -32,6 +32,7 @@ import (
 	cloud "antrea.io/nephe/apis/crd/v1alpha1"
 	cloudcommon "antrea.io/nephe/pkg/cloud-provider/cloudapi/common"
 	"antrea.io/nephe/pkg/cloud-provider/securitygroup"
+	"antrea.io/nephe/pkg/cloud-provider/utils"
 	"antrea.io/nephe/pkg/controllers/config"
 	converter "antrea.io/nephe/pkg/converter/target"
 )
@@ -1161,7 +1162,8 @@ func (a *appliedToSecurityGroup) removeStaleMembers(stales []*types.NamespacedNa
 	}
 	srcMap := make(map[string]*securitygroup.CloudResource)
 	for _, m := range a.members {
-		srcMap[m.Name] = m
+		name := utils.GetCloudResourceCrdName(m.CloudProvider, m.Name)
+		srcMap[name] = m
 	}
 	for _, stale := range stales {
 		for k := range srcMap {
@@ -1172,7 +1174,7 @@ func (a *appliedToSecurityGroup) removeStaleMembers(stales []*types.NamespacedNa
 					_ = tracker.update(a, true, r)
 				}
 				// remove member vmp.
-				vmNamespacedName := types.NamespacedName{Name: srcMap[k].Name, Namespace: stale.Namespace}
+				vmNamespacedName := types.NamespacedName{Name: k, Namespace: stale.Namespace}
 				if obj, found, _ := r.virtualMachinePolicyIndexer.GetByKey(vmNamespacedName.String()); found {
 					r.Log.V(1).Info("Delete vmp status", "resource", vmNamespacedName.String())
 					_ = r.virtualMachinePolicyIndexer.Delete(obj)

--- a/pkg/controllers/cloud/networkpolicy_test.go
+++ b/pkg/controllers/cloud/networkpolicy_test.go
@@ -113,26 +113,26 @@ var _ = Describe("NetworkPolicy", func() {
 		vmNameToVirtualMachine = make(map[string]*cloud.VirtualMachine)
 		vmNameToIDMap = make(map[string]string)
 		// ExternalEntity
-		for _, n := range vmNames {
-			vmID := vmNamePrefix + n
+		for _, vmName := range vmNames {
+			vmID := vmNamePrefix + vmName
 			ee := antreatypes.ExternalEntity{}
 			ee.Name = "virtualmachine-" + vmID
 			ee.Namespace = namespace
 			eeOwner := v1.OwnerReference{
 				Kind: reflect.TypeOf(cloud.VirtualMachine{}).Name(),
-				Name: n,
+				Name: vmName,
 			}
 			ee.OwnerReferences = append(ee.OwnerReferences, eeOwner)
 
 			labels := make(map[string]string)
 			// TODO: cleanup dead code
 			labels[config.ExternalEntityLabelKeyKind] = target.GetExternalEntityLabelKind(&cloud.VirtualMachine{})
-			labels[config.ExternalEntityLabelKeyName] = n
+			labels[config.ExternalEntityLabelKeyName] = vmName
 			labels[config.ExternalEntityLabelKeyNamespace] = namespace
 			labels[config.ExternalEntityLabelCloudVPCKey] = vpc
 			ee.Labels = labels
-			vmExternalEntities[n] = &ee
-			vmMembers[n] = &securitygroup.CloudResource{
+			vmExternalEntities[vmName] = &ee
+			vmMembers[vmName] = &securitygroup.CloudResource{
 				Type: securitygroup.CloudResourceTypeVM,
 				CloudResourceID: securitygroup.CloudResourceID{
 					Name: vmID,
@@ -141,15 +141,15 @@ var _ = Describe("NetworkPolicy", func() {
 			}
 
 			vm := cloud.VirtualMachine{}
-			vm.Name = n
+			vm.Name = vmName
 			vm.Namespace = namespace
 			vmAnnotations := make(map[string]string)
 			vmAnnotations[cloudcommon.AnnotationCloudAssignedIDKey] = vmID
 			vmAnnotations[cloudcommon.AnnotationCloudAssignedVPCIDKey] = vpc
 			vmAnnotations[cloudcommon.AnnotationCloudAccountIDKey] = accountID
 			vm.Annotations = vmAnnotations
-			vmNameToVirtualMachine[n] = &vm
-			vmNameToIDMap[n] = vmID
+			vmNameToVirtualMachine[vmName] = &vm
+			vmNameToIDMap[vmName] = vmID
 		}
 
 		// AddressGroups

--- a/pkg/controllers/cloud/networkpolicy_test.go
+++ b/pkg/controllers/cloud/networkpolicy_test.go
@@ -304,7 +304,7 @@ var _ = Describe("NetworkPolicy", func() {
 	getGrpMembers := func(gms []antreanetworking.GroupMember) []*securitygroup.CloudResource {
 		ret := make([]*securitygroup.CloudResource, 0)
 		for _, gm := range gms {
-			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-" + vmNamePrefix); vm != gm.ExternalEntity.Name {
+			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-"+vmNamePrefix); vm != gm.ExternalEntity.Name {
 				ret = append(ret, &securitygroup.CloudResource{
 					Type: securitygroup.CloudResourceTypeVM,
 					CloudResourceID: securitygroup.CloudResourceID{
@@ -322,7 +322,7 @@ var _ = Describe("NetworkPolicy", func() {
 	getGrpExternalEntity := func(gms []antreanetworking.GroupMember) []*antreatypes.ExternalEntity {
 		ret := make([]*antreatypes.ExternalEntity, 0)
 		for _, gm := range gms {
-			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-" + vmNamePrefix); vm != gm.ExternalEntity.Name {
+			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-"+vmNamePrefix); vm != gm.ExternalEntity.Name {
 				// Trim successful
 				ret = append(ret, vmExternalEntities[vm])
 			}
@@ -334,7 +334,7 @@ var _ = Describe("NetworkPolicy", func() {
 	getGrpVPCs := func(gms []antreanetworking.GroupMember) map[string]struct{} {
 		ret := make(map[string]struct{})
 		for _, gm := range gms {
-			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-" + vmNamePrefix); vm != gm.ExternalEntity.Name {
+			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-"+vmNamePrefix); vm != gm.ExternalEntity.Name {
 				ret[vpc] = struct{}{}
 			}
 		}

--- a/pkg/controllers/cloud/networkpolicy_test.go
+++ b/pkg/controllers/cloud/networkpolicy_test.go
@@ -28,7 +28,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
@@ -112,8 +114,9 @@ var _ = Describe("NetworkPolicy", func() {
 		vmNameToIDMap = make(map[string]string)
 		// ExternalEntity
 		for _, n := range vmNames {
+			vmID := vmNamePrefix + n
 			ee := antreatypes.ExternalEntity{}
-			ee.Name = "virtualmachine-" + n
+			ee.Name = "virtualmachine-" + vmID
 			ee.Namespace = namespace
 			eeOwner := v1.OwnerReference{
 				Kind: reflect.TypeOf(cloud.VirtualMachine{}).Name(),
@@ -132,13 +135,12 @@ var _ = Describe("NetworkPolicy", func() {
 			vmMembers[n] = &securitygroup.CloudResource{
 				Type: securitygroup.CloudResourceTypeVM,
 				CloudResourceID: securitygroup.CloudResourceID{
-					Name: vmNamePrefix + n,
+					Name: vmID,
 					Vpc:  vpc,
 				},
 			}
 
 			vm := cloud.VirtualMachine{}
-			vmID := vmNamePrefix + n
 			vm.Name = n
 			vm.Namespace = namespace
 			vmAnnotations := make(map[string]string)
@@ -302,7 +304,7 @@ var _ = Describe("NetworkPolicy", func() {
 	getGrpMembers := func(gms []antreanetworking.GroupMember) []*securitygroup.CloudResource {
 		ret := make([]*securitygroup.CloudResource, 0)
 		for _, gm := range gms {
-			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-"); vm != gm.ExternalEntity.Name {
+			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-" + vmNamePrefix); vm != gm.ExternalEntity.Name {
 				ret = append(ret, &securitygroup.CloudResource{
 					Type: securitygroup.CloudResourceTypeVM,
 					CloudResourceID: securitygroup.CloudResourceID{
@@ -320,7 +322,7 @@ var _ = Describe("NetworkPolicy", func() {
 	getGrpExternalEntity := func(gms []antreanetworking.GroupMember) []*antreatypes.ExternalEntity {
 		ret := make([]*antreatypes.ExternalEntity, 0)
 		for _, gm := range gms {
-			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-"); vm != gm.ExternalEntity.Name {
+			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-" + vmNamePrefix); vm != gm.ExternalEntity.Name {
 				// Trim successful
 				ret = append(ret, vmExternalEntities[vm])
 			}
@@ -332,7 +334,7 @@ var _ = Describe("NetworkPolicy", func() {
 	getGrpVPCs := func(gms []antreanetworking.GroupMember) map[string]struct{} {
 		ret := make(map[string]struct{})
 		for _, gm := range gms {
-			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-"); vm != gm.ExternalEntity.Name {
+			if vm := strings.TrimPrefix(gm.ExternalEntity.Name, "virtualmachine-" + vmNamePrefix); vm != gm.ExternalEntity.Name {
 				ret[vpc] = struct{}{}
 			}
 		}
@@ -585,8 +587,12 @@ var _ = Describe("NetworkPolicy", func() {
 		return chans
 	}
 
-	checkGrpPatchChange := func(grpName string, members []antreanetworking.GroupMember, memberChange bool,
+	checkGrpPatchChange := func(grpName string, members []antreanetworking.GroupMember, staleMember bool,
 		oldMembers []*antreatypes.ExternalEntity, membershipOnly bool) {
+		var retErr error
+		if staleMember {
+			retErr = errors.NewNotFound(schema.GroupResource{}, "")
+		}
 		eelist := make([]*antreatypes.ExternalEntity, 0)
 		if members != nil {
 			eelist = append(eelist, getGrpExternalEntity(members)...)
@@ -597,7 +603,7 @@ var _ = Describe("NetworkPolicy", func() {
 			ref.DeepCopyInto(ee)
 			key := client.ObjectKey{Name: ee.Name, Namespace: ee.Namespace}
 			mockClient.EXPECT().Get(mock.Any(), key, mock.Any()).
-				Return(nil).AnyTimes(). // because unchanged member does not Get.
+				Return(retErr).AnyTimes(). // because unchanged member does not Get.
 				Do(func(_ context.Context, key client.ObjectKey, out *antreatypes.ExternalEntity) {
 					ee.DeepCopyInto(out)
 				})
@@ -613,7 +619,7 @@ var _ = Describe("NetworkPolicy", func() {
 			}
 
 		}
-		if memberChange {
+		if !staleMember {
 			for vpc := range getGrpVPCs(members) {
 				ch := make(chan error)
 				grpID := &securitygroup.CloudResource{
@@ -875,6 +881,11 @@ var _ = Describe("NetworkPolicy", func() {
 		}
 	}
 
+	verifyVmp := func(vmpNum int) {
+		vmpList := reconciler.virtualMachinePolicyIndexer.List()
+		Expect(len(vmpList)).To(Equal(vmpNum))
+	}
+
 	verifyNPStatus := func(trackedVMs map[string]*cloud.VirtualMachine, hasPolicy, hasError bool) {
 		for idx := len(addrGrpNames); idx < len(addrGrpNames)+len(appliedToGrpsNames); idx++ {
 			vm := trackedVMs[vmNamePrefix+vmNames[idx]]
@@ -969,7 +980,7 @@ var _ = Describe("NetworkPolicy", func() {
 		remove := vmExternalEntities[vmNames[0]]
 		addrGrp := addrGrps[0]
 		p1 := patchAddrGrpMember(addrGrp, add, remove, 0)
-		checkGrpPatchChange(addrGrp.Name, addrGrp.GroupMembers, true, []*antreatypes.ExternalEntity{remove}, true)
+		checkGrpPatchChange(addrGrp.Name, addrGrp.GroupMembers, false, []*antreatypes.ExternalEntity{remove}, true)
 		var err error
 		event := watch.Event{Type: watch.Modified, Object: p1}
 		err = reconciler.processAddrGrp(event)
@@ -984,13 +995,30 @@ var _ = Describe("NetworkPolicy", func() {
 		remove := vmExternalEntities[vmNames[2]]
 		appliedToGrp := appliedToGrps[0]
 		p1 := patchAppliedToGrpMember(appliedToGrp, add, remove, 0)
-		checkGrpPatchChange(appliedToGrp.Name, appliedToGrp.GroupMembers, true, []*antreatypes.ExternalEntity{remove}, false)
-		var err error
+		checkGrpPatchChange(appliedToGrp.Name, appliedToGrp.GroupMembers, false, []*antreatypes.ExternalEntity{remove}, false)
 		event := watch.Event{Type: watch.Modified, Object: p1}
-		err = reconciler.processAppliedToGrp(event)
+		err := reconciler.processAppliedToGrp(event)
 		Expect(err).ToNot(HaveOccurred())
 
 		wait()
+	})
+
+	It("Modify appliedToGroup remove stale member", func() {
+		createAndVerifyNP(false)
+		trackedVMs := make(map[string]*cloud.VirtualMachine)
+		verifyNPTracker(trackedVMs, true, false)
+		verifyVmp(len(trackedVMs))
+
+		// modify event remove stale member.
+		remove := vmExternalEntities[vmNames[2]]
+		appliedToGrp := appliedToGrps[0]
+		p1 := patchAppliedToGrpMember(appliedToGrp, nil, remove, 0)
+		checkGrpPatchChange(appliedToGrp.Name, appliedToGrp.GroupMembers, true, []*antreatypes.ExternalEntity{remove}, false)
+
+		event := watch.Event{Type: watch.Modified, Object: p1}
+		err := reconciler.processAppliedToGrp(event)
+		Expect(err).ToNot(HaveOccurred())
+		verifyVmp(len(trackedVMs) - 1)
 	})
 
 	It("Modify networkPolicy address group cloud member", func() {
@@ -1004,10 +1032,9 @@ var _ = Describe("NetworkPolicy", func() {
 
 		anp.Rules[0].From.AddressGroups = append(anp.Rules[0].From.AddressGroups, "ag-patch")
 
-		var err error
 		checkAddrGroup(ag)
 		event := watch.Event{Type: watch.Added, Object: ag}
-		err = reconciler.processAddrGrp(event)
+		err := reconciler.processAddrGrp(event)
 		Expect(err).ToNot(HaveOccurred())
 
 		ingress := ingressRule[0]
@@ -1049,11 +1076,13 @@ var _ = Describe("NetworkPolicy", func() {
 		createAndVerifyNP(false)
 		verifyNPTracker(trackedVMs, true, false)
 		verifyNPStatus(trackedVMs, true, false)
+		verifyVmp(len(trackedVMs))
 		// return delete error
 		sgConfig.sgDeleteError = fmt.Errorf("dummy")
 		deleteAndVerifyNP(false)
 		verifyNPTracker(trackedVMs, false, true)
 		verifyNPStatus(trackedVMs, false, true)
+		verifyVmp(len(trackedVMs))
 		// retry without delete error
 		sgConfig.sgDeleteError = nil
 		verifyDeleteNP(false)
@@ -1061,6 +1090,7 @@ var _ = Describe("NetworkPolicy", func() {
 		wait()
 		verifyNPTracker(trackedVMs, false, false)
 		verifyNPStatus(trackedVMs, false, false)
+		verifyVmp(0)
 	})
 
 	It("Create NetworkPolicy groups after security group garbage collection", func() {

--- a/test/integration/pod_e2e_test.go
+++ b/test/integration/pod_e2e_test.go
@@ -134,7 +134,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Pods", focusAws, focusAzur
 
 		if importing {
 			entityParams := cloudVPC.GetEntitySelectorParameters("test-entity-selector", vmNamespace.Name,
-				reflect.TypeOf(cloud.VirtualMachine{}).Name())
+				reflect.TypeOf(cloud.VirtualMachine{}).Name(), nil)
 			err = utils.ConfigureEntitySelectorAndWait(kubeCtl, k8sClient, entityParams,
 				reflect.TypeOf(cloud.VirtualMachine{}).Name(),
 				len(cloudVPC.GetVMs()), vmNamespace.Name, false)
@@ -163,7 +163,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Pods", focusAws, focusAzur
 
 			if importFirst {
 				entityParams := cloudVPC.GetEntitySelectorParameters("test-entity-selector", vmNamespace.Name,
-					reflect.TypeOf(cloud.VirtualMachine{}).Name())
+					reflect.TypeOf(cloud.VirtualMachine{}).Name(), nil)
 				err := utils.ConfigureEntitySelectorAndWait(kubeCtl, k8sClient, entityParams,
 					reflect.TypeOf(cloud.VirtualMachine{}).Name(),
 					len(cloudVPC.GetVMs()), vmNamespace.Name, false)

--- a/test/integration/vpc_e2e_test.go
+++ b/test/integration/vpc_e2e_test.go
@@ -155,7 +155,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: VPC Inventory", focusAws, focusAzure), func
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Configure CES and verify VM inventory")
-		entityParams := cloudVPC.GetEntitySelectorParameters("test-entity-selector"+namespace.Name, namespace.Name, kind)
+		entityParams := cloudVPC.GetEntitySelectorParameters("test-entity-selector"+namespace.Name, namespace.Name, kind, nil)
 		logf.Log.V(1).Info("Create CES and verify VM inventory is imported", "ces", entityParams.Name)
 		err = utils.ConfigureEntitySelectorAndWait(kubeCtl, k8sClient, entityParams, kind, len(vmIDs), namespace.Name, false)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/templates/entity_selector.go
+++ b/test/templates/entity_selector.go
@@ -18,9 +18,14 @@ type CloudEntitySelectorParameters struct {
 	Name             string
 	Namespace        string
 	CloudAccountName string
-	VPC              string
+	Selector         *SelectorParameters
 	Kind             string
 	Agented          bool
+}
+
+type SelectorParameters struct {
+	VPC string
+	VMs []string
 }
 
 const CloudEntitySelector = `
@@ -32,7 +37,14 @@ metadata:
 spec:
   accountName: {{.CloudAccountName}}
   vmSelector:
+{{- if .Selector.VPC }}
     - vpcMatch:
-        matchID: {{.VPC}}
+        matchID: {{.Selector.VPC}}
+{{ else }}
+    - vmMatch:
+{{- range $vm := .Selector.VMs }}
+        - matchID: {{$vm}}
+{{ end }}
+{{ end }}{{/* .Selector.VPC */}}
       agented: {{.Agented}}
 `

--- a/test/utils/cloud_provider.go
+++ b/test/utils/cloud_provider.go
@@ -40,7 +40,7 @@ type CloudVPC interface {
 	Delete(duration time.Duration) error
 	Reapply(duration time.Duration, withAgent bool) error
 	GetCloudAccountParameters(name, namespace string, cloudCluster bool) k8stemplates.CloudAccountParameters
-	GetEntitySelectorParameters(name, namespace, kind string) k8stemplates.CloudEntitySelectorParameters
+	GetEntitySelectorParameters(name, namespace, kind string, vms []string) k8stemplates.CloudEntitySelectorParameters
 }
 
 func NewCloudVPC(provider v1alpha1.CloudProvider) (CloudVPC, error) {

--- a/test/utils/cloud_provider_aws.go
+++ b/test/utils/cloud_provider_aws.go
@@ -220,14 +220,18 @@ func (p *awsVPC) GetCloudAccountParameters(name, namespace string, cloudCluster 
 	return out
 }
 
-func (p *awsVPC) GetEntitySelectorParameters(name, namespace, kind string) k8stemplates.CloudEntitySelectorParameters {
-	return k8stemplates.CloudEntitySelectorParameters{
+func (p *awsVPC) GetEntitySelectorParameters(name, namespace, kind string, vms []string) k8stemplates.CloudEntitySelectorParameters {
+	out := k8stemplates.CloudEntitySelectorParameters{
 		Name:             name,
 		Namespace:        namespace,
-		VPC:              p.GetVPCID(),
+		Selector:         &k8stemplates.SelectorParameters{VPC: p.GetVPCID()},
 		CloudAccountName: p.currentAccountName,
 		Kind:             kind,
 	}
+	if vms != nil {
+		out.Selector = &k8stemplates.SelectorParameters{VMs: vms}
+	}
+	return out
 }
 
 func (p *awsVPC) VMCmd(vm string, vmCmd []string, timeout time.Duration) (string, error) {

--- a/test/utils/cloud_provider_aws.go
+++ b/test/utils/cloud_provider_aws.go
@@ -220,6 +220,8 @@ func (p *awsVPC) GetCloudAccountParameters(name, namespace string, cloudCluster 
 	return out
 }
 
+// GetEntitySelectorParameters gets the CloudEntitySelector parameters to import given VMs.
+// All VMs in the VPC will be imported if vms is nil.
 func (p *awsVPC) GetEntitySelectorParameters(name, namespace, kind string, vms []string) k8stemplates.CloudEntitySelectorParameters {
 	out := k8stemplates.CloudEntitySelectorParameters{
 		Name:             name,

--- a/test/utils/cloud_provider_azure.go
+++ b/test/utils/cloud_provider_azure.go
@@ -241,6 +241,8 @@ func (p *azureVPC) GetCloudAccountParameters(name, namespace string, _ bool) k8s
 	return out
 }
 
+// GetEntitySelectorParameters gets the CloudEntitySelector parameters to import given VMs.
+// All VMs in the VPC will be imported if vms is nil.
 func (p *azureVPC) GetEntitySelectorParameters(name, namespace, kind string, vms []string) k8stemplates.CloudEntitySelectorParameters {
 	out := k8stemplates.CloudEntitySelectorParameters{
 		Name:             name,

--- a/test/utils/cloud_provider_azure.go
+++ b/test/utils/cloud_provider_azure.go
@@ -241,14 +241,18 @@ func (p *azureVPC) GetCloudAccountParameters(name, namespace string, _ bool) k8s
 	return out
 }
 
-func (p *azureVPC) GetEntitySelectorParameters(name, namespace, kind string) k8stemplates.CloudEntitySelectorParameters {
-	return k8stemplates.CloudEntitySelectorParameters{
+func (p *azureVPC) GetEntitySelectorParameters(name, namespace, kind string, vms []string) k8stemplates.CloudEntitySelectorParameters {
+	out := k8stemplates.CloudEntitySelectorParameters{
 		Name:             name,
 		Namespace:        namespace,
-		VPC:              p.GetVPCID(),
+		Selector:         &k8stemplates.SelectorParameters{VPC: p.GetVPCID()},
 		CloudAccountName: p.currentAccountName,
 		Kind:             kind,
 	}
+	if vms != nil {
+		out.Selector = &k8stemplates.SelectorParameters{VMs: vms}
+	}
+	return out
 }
 
 func (p *azureVPC) VMCmd(vm string, vmCmd []string, timeout time.Duration) (string, error) {

--- a/test/utils/helpers.go
+++ b/test/utils/helpers.go
@@ -135,7 +135,6 @@ func ConfigureK8s(kubeCtl *KubeCtl, params interface{}, yaml string, isDelete bo
 	if err := confParser.Execute(conf, params); err != nil {
 		return fmt.Errorf("parse template failed: %v", err)
 	}
-	// logf.Log.V(1).Info("", "yaml", conf.String())
 	if isDelete {
 		err = kubeCtl.Delete("", conf.Bytes())
 	} else {
@@ -279,18 +278,6 @@ func ConfigureEntitySelectorAndWait(kubeCtl *KubeCtl, k8sClient client.Client, p
 // CheckCloudResourceNetworkPolicies checks NetworkPolicies has been applied to cloud resources.
 func CheckCloudResourceNetworkPolicies(kubeCtl *KubeCtl, k8sClient client.Client, kind, namespace string, ids, anps []string,
 	withAgent bool) error {
-	getVMANPs := func(id string) (map[string]*runtimev1alpha1.NetworkPolicyStatus, error) {
-		v := &runtimev1alpha1.VirtualMachinePolicy{}
-		fetchKey := client.ObjectKey{Name: id, Namespace: namespace}
-		if err := k8sClient.Get(context.TODO(), fetchKey, v); err != nil {
-			if errors.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		return v.Status.NetworkPolicyDetails, nil
-	}
-
 	logf.Log.V(1).Info("Check NetworkPolicy on resources", "resources", ids, "nps", anps)
 
 	if withAgent {
@@ -316,24 +303,27 @@ func CheckCloudResourceNetworkPolicies(kubeCtl *KubeCtl, k8sClient client.Client
 	}
 
 	if err := wait.Poll(time.Second*2, time.Second*300, func() (bool, error) {
-		var getter func(id string) (map[string]*runtimev1alpha1.NetworkPolicyStatus, error)
+		var getter func(k8sClient client.Client, id, namespace string) (*runtimev1alpha1.VirtualMachinePolicy, error)
 		if kind == reflect.TypeOf(v1alpha1.VirtualMachine{}).Name() {
-			getter = getVMANPs
+			getter = GetVirtualMachinePolicy
 		} else {
 			return false, fmt.Errorf("unknown kind %v", kind)
 		}
 
 		for _, id := range ids {
-			npv, err := getter(id)
+			vmp, err := getter(k8sClient, id, namespace)
+			if errors.IsNotFound(err) && len(anps) == 0 {
+				continue
+			}
 			if err != nil {
 				logf.Log.Info("Get resource failed, tolerate", "Resource", id, "Error", err)
 				return false, nil
 			}
-			if len(npv) != len(anps) {
+			if len(vmp.Status.NetworkPolicyDetails) != len(anps) {
 				return false, nil
 			}
 			for _, a := range anps {
-				v, ok := npv[a]
+				v, ok := vmp.Status.NetworkPolicyDetails[a]
 				if !ok {
 					return false, nil
 				}
@@ -349,9 +339,34 @@ func CheckCloudResourceNetworkPolicies(kubeCtl *KubeCtl, k8sClient client.Client
 	return nil
 }
 
+func GetVirtualMachinePolicy(k8sClient client.Client, id, namespace string) (*runtimev1alpha1.VirtualMachinePolicy, error) {
+	v := &runtimev1alpha1.VirtualMachinePolicy{}
+	fetchKey := client.ObjectKey{Name: id, Namespace: namespace}
+	if err := k8sClient.Get(context.TODO(), fetchKey, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func CheckVirtualMachinePolicies(k8sClient client.Client, namespace string, num int) error {
+	vmpList := &runtimev1alpha1.VirtualMachinePolicyList{}
+	listOpts := &client.ListOptions{Namespace: namespace}
+	if err := k8sClient.List(context.TODO(), vmpList, listOpts); err != nil {
+		return err
+	}
+	if len(vmpList.Items) != num {
+		return fmt.Errorf("unexpected vmp count %d, expect %d", len(vmpList.Items), num)
+	}
+	for i := 0; i < num; i++ {
+		if vmpList.Items[i].Status.Realization != runtimev1alpha1.Success {
+			return fmt.Errorf("unexpected vmp status %+v", vmpList.Items[i].Status)
+		}
+	}
+	return nil
+}
+
 // ExecuteCmds excutes cmds on resource srcIDs in parallel, and returns error if oks mismatch.
-func ExecuteCmds(vpc CloudVPC, kubctl *KubeCtl,
-	srcIDs []string, ns string, cmds [][]string, oks []bool, retries int) error {
+func ExecuteCmds(vpc CloudVPC, kubctl *KubeCtl, srcIDs []string, ns string, cmds [][]string, oks []bool, retries int) error {
 	var err error
 	for i := 0; i < retries; i++ {
 		chans := make([]chan error, len(oks))
@@ -437,8 +452,7 @@ func GenerateNameFromText(fullText string, focus []string) string {
 }
 
 // SetAgentConfig configures the cluster, generates agent kubeconfigs and sets terraform env vars.
-func SetAgentConfig(c client.Client, ns *corev1.Namespace, cloudProviders, antreaVersion, kubeconfig, dir string,
-	withWindows bool) error {
+func SetAgentConfig(c client.Client, ns *corev1.Namespace, cloudProviders, antreaVersion, kubeconfig, dir string, withWindows bool) error {
 	err := c.Create(context.TODO(), ns)
 	if err != nil {
 		return fmt.Errorf("failed to create static vm namespace %+v", err)

--- a/test/utils/helpers.go
+++ b/test/utils/helpers.go
@@ -339,6 +339,7 @@ func CheckCloudResourceNetworkPolicies(kubeCtl *KubeCtl, k8sClient client.Client
 	return nil
 }
 
+// GetVirtualMachinePolicy gets vmp corresponding to id and namespace.
 func GetVirtualMachinePolicy(k8sClient client.Client, id, namespace string) (*runtimev1alpha1.VirtualMachinePolicy, error) {
 	v := &runtimev1alpha1.VirtualMachinePolicy{}
 	fetchKey := client.ObjectKey{Name: id, Namespace: namespace}
@@ -348,6 +349,7 @@ func GetVirtualMachinePolicy(k8sClient client.Client, id, namespace string) (*ru
 	return v, nil
 }
 
+// CheckVirtualMachinePolicies checks the number of vmp in a given namespace matches expected num and all in success state.
 func CheckVirtualMachinePolicies(k8sClient client.Client, namespace string, num int) error {
 	vmpList := &runtimev1alpha1.VirtualMachinePolicyList{}
 	listOpts := &client.ListOptions{Namespace: namespace}


### PR DESCRIPTION
## Description
This PR fixes stale vmp issue on Azure when VMs are deleted from the cloud, VM CRs are deleted, or EE CRs are deleted. This PR also adds CI tests to check stale vmp removal.

## Changes
1. Generate correct vm name when removing stale member.
2. CI test to check vmp removal after vm selection changes.

Signed-off-by: Alexander Liu <alliu@vmware.com>