### PR TITLE
VPC rest Watch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/apiserver v0.24.2
 	k8s.io/component-base v0.24.2 // indirect
-	k8s.io/klog/v2 v2.60.1 // indirect
+	k8s.io/klog/v2 v2.60.1
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect

--- a/pkg/apiserver/registry/inventory/rest.go
+++ b/pkg/apiserver/registry/inventory/rest.go
@@ -132,7 +132,7 @@ func (r *REST) List(ctx context.Context, options *internalversion.ListOptions) (
 
 	var objs []interface{}
 	if namespace == "" && (accountName != "" || region != "" || name != "") {
-		return nil, errors.NewBadRequest("cannot query filter with all namepsace. Namespace should be specified")
+		return nil, errors.NewBadRequest("cannot query with all namespaces. Namespace should be specified")
 	}
 
 	if namespace == "" {

--- a/pkg/cloud-provider/cloudapi/aws/aws_crd_helpers.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_crd_helpers.go
@@ -22,7 +22,7 @@ import (
 	"antrea.io/nephe/apis/crd/v1alpha1"
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
 	"antrea.io/nephe/pkg/cloud-provider/utils"
-	"antrea.io/nephe/pkg/controllers/inventory"
+	"antrea.io/nephe/pkg/controllers/inventory/common"
 )
 
 const ResourceNameTagKey = "Name"
@@ -98,8 +98,8 @@ func ec2VpcToInternalVpcObject(vpc *ec2.Vpc, namespace string, accountName strin
 		}
 	}
 	labelsMap := map[string]string{
-		inventory.VpcLabelAccountName: accountName,
-		inventory.VpcLabelRegion:      region,
+		common.VpcLabelAccountName: accountName,
+		common.VpcLabelRegion:      region,
 	}
 
 	return utils.GenerateInternalVpcObject(*vpc.VpcId, namespace, labelsMap, strings.ToLower(cloudName),

--- a/pkg/cloud-provider/cloudapi/azure/azure_crd_helpers.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_crd_helpers.go
@@ -23,7 +23,7 @@ import (
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
 	"antrea.io/nephe/pkg/cloud-provider/securitygroup"
 	"antrea.io/nephe/pkg/cloud-provider/utils"
-	"antrea.io/nephe/pkg/controllers/inventory"
+	"antrea.io/nephe/pkg/controllers/inventory/common"
 )
 
 var azureStateMap = map[string]v1alpha1.VMState{
@@ -122,8 +122,8 @@ func ComputeVpcToInternalVpcObject(vnet *network.VirtualNetwork, namespace strin
 		cidrs = append(cidrs, *vnet.AddressSpace.AddressPrefixes...)
 	}
 	labelsMap := map[string]string{
-		inventory.VpcLabelAccountName: accountName,
-		inventory.VpcLabelRegion:      region,
+		common.VpcLabelAccountName: accountName,
+		common.VpcLabelRegion:      region,
 	}
 	return utils.GenerateInternalVpcObject(crdName, namespace, labelsMap, strings.ToLower(*vnet.Name),
 		strings.ToLower(*vnet.ID), tags, v1alpha1.AzureCloudProvider, region, cidrs)

--- a/pkg/controllers/inventory/common/common.go
+++ b/pkg/controllers/inventory/common/common.go
@@ -1,0 +1,25 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+const (
+	VpcIndexerByAccountNameSpacedName = "namespace.accountname"
+	VpcIndexerByVpcNamespacedName     = "namespace.vpcname"
+	VpcIndexerByNamespace             = "vpc.namespace"
+	VpcIndexerByNamespacedRegion      = "namespace.region"
+
+	VpcLabelAccountName = "account-name"
+	VpcLabelRegion      = "region"
+)

--- a/pkg/controllers/inventory/inventory.go
+++ b/pkg/controllers/inventory/inventory.go
@@ -15,65 +15,39 @@
 package inventory
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/watch"
 
+	antreastorage "antrea.io/antrea/pkg/apiserver/storage"
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
+	"antrea.io/nephe/pkg/controllers/inventory/common"
+	"antrea.io/nephe/pkg/controllers/inventory/store"
 	"antrea.io/nephe/pkg/logging"
 )
 
 type Inventory struct {
 	log      logr.Logger
-	vpcCache cache.Indexer
+	vpcStore antreastorage.Interface
 }
-
-const (
-	VpcIndexerByAccountNameSpacedName = "namespace.accountname"
-	VpcIndexerByVpcNamespacedName     = "namespace.vpcname"
-	VpcIndexerByNamespace             = "vpc.namespace"
-	VpcIndexerByNamespacedRegion      = "namespace.region"
-
-	VpcLabelAccountName = "account-name"
-	VpcLabelRegion      = "region"
-)
 
 // InitInventory creates an instance of Inventory struct and initializes inventory with cache indexers.
 func InitInventory() *Inventory {
 	inventory := &Inventory{
 		log: logging.GetLogger("inventory").WithName("Cloud"),
 	}
-	inventory.vpcCache = cache.NewIndexer(
-		func(obj interface{}) (string, error) {
-			vpc := obj.(*runtimev1alpha1.Vpc)
-			return fmt.Sprintf("%v/%v-%v", vpc.Namespace, vpc.Labels[VpcLabelAccountName], vpc.Info.Id), nil
-		},
-		cache.Indexers{
-			VpcIndexerByAccountNameSpacedName: func(obj interface{}) ([]string, error) {
-				vpc := obj.(*runtimev1alpha1.Vpc)
-				return []string{vpc.Namespace + "/" + vpc.Labels[VpcLabelAccountName]}, nil
-			},
-			VpcIndexerByVpcNamespacedName: func(obj interface{}) ([]string, error) {
-				vpc := obj.(*runtimev1alpha1.Vpc)
-				return []string{vpc.Namespace + "/" + vpc.Name}, nil
-			},
-			VpcIndexerByNamespacedRegion: func(obj interface{}) ([]string, error) {
-				vpc := obj.(*runtimev1alpha1.Vpc)
-				return []string{vpc.Namespace + "/" + vpc.Info.Region}, nil
-			},
-			VpcIndexerByNamespace: func(obj interface{}) ([]string, error) {
-				vpc := obj.(*runtimev1alpha1.Vpc)
-				return []string{vpc.Namespace}, nil
-			},
-		})
+	inventory.vpcStore = store.NewVPCInventoryStore()
 	return inventory
 }
 
 // BuildVpcCache using vpc list from cloud, update vpc cache(with vpcs applicable for the current cloud account).
 func (inventory *Inventory) BuildVpcCache(vpcMap map[string]*runtimev1alpha1.Vpc, namespacedName *types.NamespacedName) error {
-	vpcsInCache, _ := inventory.vpcCache.ByIndex(VpcIndexerByAccountNameSpacedName, namespacedName.String())
+	vpcsInCache, _ := inventory.vpcStore.GetByIndex(common.VpcIndexerByAccountNameSpacedName, namespacedName.String())
 
 	// Remove vpcs in vpc cache which are not found in vpc list fetched from cloud.
 	for _, i := range vpcsInCache {
@@ -81,7 +55,8 @@ func (inventory *Inventory) BuildVpcCache(vpcMap map[string]*runtimev1alpha1.Vpc
 		if _, found := vpcMap[vpc.Info.Id]; !found {
 			inventory.log.V(1).Info("Deleting a vpc from vpc cache", "vpc id", vpc.Info.Id, "account",
 				namespacedName.String())
-			if err := inventory.vpcCache.Delete(vpc); err != nil {
+			if err := inventory.vpcStore.Delete(fmt.Sprintf("%v/%v-%v", vpc.Namespace, vpc.Labels[common.VpcLabelAccountName],
+				vpc.Info.Id)); err != nil {
 				inventory.log.Error(err, "failed to delete entry from VpcIndexer", "vpc id", vpc.Info.Id, "account",
 					namespacedName.String())
 			}
@@ -89,7 +64,14 @@ func (inventory *Inventory) BuildVpcCache(vpcMap map[string]*runtimev1alpha1.Vpc
 	}
 
 	for _, v := range vpcMap {
-		err := inventory.vpcCache.Add(v)
+		var err error
+		key := fmt.Sprintf("%v/%v-%v", v.Namespace, v.Labels[common.VpcLabelAccountName], v.Info.Id)
+		if _, found, _ := inventory.vpcStore.Get(key); !found {
+			err = inventory.vpcStore.Create(v)
+		} else {
+			err = inventory.vpcStore.Update(v)
+		}
+
 		if err != nil {
 			return fmt.Errorf("failed to add entry into VpcIndexer, vpc id %s, account %v, error %v",
 				v.Info.Id, *namespacedName, err)
@@ -101,13 +83,14 @@ func (inventory *Inventory) BuildVpcCache(vpcMap map[string]*runtimev1alpha1.Vpc
 
 // DeleteVpcCache deletes all entries from vpc cache.
 func (inventory *Inventory) DeleteVpcCache(namespacedName *types.NamespacedName) error {
-	vpcsInCache, err := inventory.vpcCache.ByIndex(VpcIndexerByAccountNameSpacedName, namespacedName.String())
+	vpcsInCache, err := inventory.vpcStore.GetByIndex(common.VpcIndexerByAccountNameSpacedName, namespacedName.String())
 	if err != nil {
 		return err
 	}
 	for _, i := range vpcsInCache {
 		vpc := i.(*runtimev1alpha1.Vpc)
-		if err := inventory.vpcCache.Delete(vpc); err != nil {
+		if err := inventory.vpcStore.Delete(fmt.Sprintf("%v/%v-%v", vpc.Namespace, vpc.Labels[common.VpcLabelAccountName],
+			vpc.Info.Id)); err != nil {
 			return fmt.Errorf("failed to delete entry from VpcIndexer, indexer %v, error %v", *namespacedName, err)
 		}
 	}
@@ -116,10 +99,16 @@ func (inventory *Inventory) DeleteVpcCache(namespacedName *types.NamespacedName)
 
 // GetVpcsFromIndexer returns vpcs matching the indexedValue for the requested index.
 func (inventory *Inventory) GetVpcsFromIndexer(indexName string, indexedValue string) ([]interface{}, error) {
-	return inventory.vpcCache.ByIndex(indexName, indexedValue)
+	return inventory.vpcStore.GetByIndex(indexName, indexedValue)
 }
 
 // GetAllVpcs returns all vpcs from the indexer.
 func (inventory *Inventory) GetAllVpcs() []interface{} {
-	return inventory.vpcCache.List()
+	return inventory.vpcStore.List()
+}
+
+// Watch returns a Watch interface of VPC.
+func (inventory *Inventory) Watch(ctx context.Context, key string, labelSelector labels.Selector,
+	fieldSelector fields.Selector) (watch.Interface, error) {
+	return inventory.vpcStore.Watch(ctx, key, labelSelector, fieldSelector)
 }

--- a/pkg/controllers/inventory/inventory_test.go
+++ b/pkg/controllers/inventory/inventory_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
+	"antrea.io/nephe/pkg/controllers/inventory/common"
 )
 
 var (
@@ -46,8 +47,8 @@ var _ = Describe("Validate Vpc Cache", func() {
 		vpcList1 := make(map[string]*runtimev1alpha1.Vpc)
 		vpcObj1 := new(runtimev1alpha1.Vpc)
 		labelsMap := map[string]string{
-			VpcLabelAccountName: accountName,
-			VpcLabelRegion:      region,
+			common.VpcLabelAccountName: accountName,
+			common.VpcLabelRegion:      region,
 		}
 		vpcObj1.Name = "obj1"
 		vpcObj1.Namespace = namespace
@@ -70,7 +71,7 @@ var _ = Describe("Validate Vpc Cache", func() {
 		allVpcList := cloudInventory.GetAllVpcs()
 		Expect(len(vpcList1), Equal(len(allVpcList)))
 
-		vpcListByIndex, err := cloudInventory.GetVpcsFromIndexer(VpcIndexerByAccountNameSpacedName, namespacedName.String())
+		vpcListByIndex, err := cloudInventory.GetVpcsFromIndexer(common.VpcIndexerByAccountNameSpacedName, namespacedName.String())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(len(vpcList1), Equal(len(vpcListByIndex)))
 
@@ -89,14 +90,14 @@ var _ = Describe("Validate Vpc Cache", func() {
 		err = cloudInventory.BuildVpcCache(vpcList2, &namespacedName)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		vpcListByIndex, err = cloudInventory.GetVpcsFromIndexer(VpcIndexerByAccountNameSpacedName, namespacedName.String())
+		vpcListByIndex, err = cloudInventory.GetVpcsFromIndexer(common.VpcIndexerByAccountNameSpacedName, namespacedName.String())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(len(vpcList2), Equal(len(vpcListByIndex)))
 
 		// Delete vpc cache.
 		err = cloudInventory.DeleteVpcCache(&namespacedName)
 		Expect(err).ShouldNot(HaveOccurred())
-		_, exist, err := cloudInventory.vpcCache.GetByKey(vpcCacheKey1)
+		_, exist, err := cloudInventory.vpcStore.Get(vpcCacheKey1)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(exist).Should(BeFalse())
 	})

--- a/pkg/controllers/inventory/store/vpc_inventory.go
+++ b/pkg/controllers/inventory/store/vpc_inventory.go
@@ -1,0 +1,168 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	antreastorage "antrea.io/antrea/pkg/apiserver/storage"
+	"antrea.io/antrea/pkg/apiserver/storage/ram"
+	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
+	"antrea.io/nephe/pkg/controllers/inventory/common"
+)
+
+// vpcInventoryEvent implements storage.InternalEvent.
+type vpcInventoryEvent struct {
+	// The current version of the stored VPC.
+	CurrObject *runtimev1alpha1.Vpc
+	// The previous version of the stored VPC.
+	PrevObject *runtimev1alpha1.Vpc
+	// The key of this VPC.
+	Key             string
+	ResourceVersion uint64
+}
+
+// keyAndSpanSelectFunc returns whether the provided selectors matches the key and/or the nodeNames.
+func keyAndSpanSelectFunc(selectors *antreastorage.Selectors, key string, obj interface{}) bool {
+	// If Key is present in selectors, the provided key must match it.
+	if selectors.Key != "" && key != selectors.Key {
+		return false
+	}
+	labelSelector := labels.Everything()
+	if selectors != nil && selectors.Label != nil {
+		labelSelector = selectors.Label
+	}
+	vpc, _ := obj.(*runtimev1alpha1.Vpc)
+	fieldSelector := fields.Everything()
+	if selectors != nil && selectors.Field != nil {
+		fieldSelector = selectors.Field
+	}
+	vpcFields := map[string]string{
+		"metadata.name":      vpc.Name,
+		"metadata.namespace": vpc.Namespace,
+	}
+	return labelSelector.Matches(labels.Set(vpc.Labels)) && fieldSelector.Matches(fields.Set(vpcFields))
+}
+
+// isSelected determines if the previous and the current version of an object should be selected by the given selectors.
+func isSelected(key string, prevObj, currObj interface{}, selectors *antreastorage.Selectors, isInitEvent bool) (bool, bool) {
+	// We have filtered out init events that we are not interested in, so the current object must be selected.
+	if isInitEvent {
+		return false, true
+	}
+	prevObjSelected := !reflect.ValueOf(prevObj).IsNil() && keyAndSpanSelectFunc(selectors, key, prevObj)
+	currObjSelected := !reflect.ValueOf(currObj).IsNil() && keyAndSpanSelectFunc(selectors, key, currObj)
+	return prevObjSelected, currObjSelected
+}
+
+// ToWatchEvent converts the vpcEvent to *watch.Event based on the provided Selectors. It has the following features:
+// 1. Added event will be generated if the Selectors was not interested in the object but is now.
+// 2. Modified event will be generated if the Selectors was and is interested in the object.
+// 3. Deleted event will be generated if the Selectors was interested in the object but is not now.
+func (event *vpcInventoryEvent) ToWatchEvent(selectors *antreastorage.Selectors, isInitEvent bool) *watch.Event {
+	prevObjSelected, currObjSelected := isSelected(event.Key, event.PrevObject, event.CurrObject, selectors, isInitEvent)
+	switch {
+	case !currObjSelected && !prevObjSelected:
+		return nil
+	case currObjSelected && !prevObjSelected:
+		// Watcher was not interested in that object but is now, an added event will be generated.
+		return &watch.Event{Type: watch.Added, Object: event.CurrObject}
+	case currObjSelected && prevObjSelected:
+		// Watcher was not interested in that object but is now, an added event will be generated.
+		return &watch.Event{Type: watch.Modified, Object: event.CurrObject}
+	case !currObjSelected && prevObjSelected:
+		// Watcher was interested in that object but is not interested now, a deleted event will be generated.
+		return &watch.Event{Type: watch.Deleted, Object: event.PrevObject}
+	}
+	return nil
+}
+
+func (event *vpcInventoryEvent) GetResourceVersion() uint64 {
+	return event.ResourceVersion
+}
+
+var _ antreastorage.GenEventFunc = genVPCEvent
+
+// genVPCEvent generates InternalEvent from the given versions of an VPC.
+func genVPCEvent(key string, prevObj, currObj interface{}, rv uint64) (antreastorage.InternalEvent, error) {
+	if reflect.DeepEqual(prevObj, currObj) {
+		return nil, nil
+	}
+
+	event := &vpcInventoryEvent{Key: key, ResourceVersion: rv}
+	if prevObj != nil {
+		event.PrevObject = prevObj.(*runtimev1alpha1.Vpc)
+	}
+
+	if currObj != nil {
+		event.CurrObject = currObj.(*runtimev1alpha1.Vpc)
+	}
+
+	return event, nil
+}
+
+// vpcKeyFunc knows how to get the key of an VPC.
+func vpcKeyFunc(obj interface{}) (string, error) {
+	vpc, ok := obj.(*runtimev1alpha1.Vpc)
+	if !ok {
+		return "", fmt.Errorf("Object is not of type runtime/v1alpha1/Vpc: %v", obj)
+	}
+	return fmt.Sprintf("%v/%v-%v", vpc.Namespace, vpc.Labels[common.VpcLabelAccountName], vpc.Info.Id), nil
+}
+
+// NewVPCInventoryStore creates a store of VPC.
+func NewVPCInventoryStore() antreastorage.Interface {
+	indexers := cache.Indexers{
+		common.VpcIndexerByAccountNameSpacedName: func(obj interface{}) ([]string, error) {
+			vpc := obj.(*runtimev1alpha1.Vpc)
+			return []string{vpc.Namespace + "/" + vpc.Labels[common.VpcLabelAccountName]}, nil
+		},
+		common.VpcIndexerByVpcNamespacedName: func(obj interface{}) ([]string, error) {
+			vpc := obj.(*runtimev1alpha1.Vpc)
+			return []string{vpc.Namespace + "/" + vpc.Name}, nil
+		},
+		common.VpcIndexerByNamespacedRegion: func(obj interface{}) ([]string, error) {
+			vpc := obj.(*runtimev1alpha1.Vpc)
+			return []string{vpc.Namespace + "/" + vpc.Info.Region}, nil
+		},
+		common.VpcIndexerByNamespace: func(obj interface{}) ([]string, error) {
+			vpc := obj.(*runtimev1alpha1.Vpc)
+			return []string{vpc.Namespace}, nil
+		},
+	}
+	return ram.NewStore(vpcKeyFunc, indexers, genVPCEvent, keyAndSpanSelectFunc, func() runtime.Object { return new(runtimev1alpha1.Vpc) })
+}
+
+// GetSelectors extracts label selector, field selector, and key selector from the provided options.
+func GetSelectors(options *internalversion.ListOptions) (string, labels.Selector, fields.Selector) {
+	label := labels.Everything()
+	if options != nil && options.LabelSelector != nil {
+		label = options.LabelSelector
+	}
+	field := fields.Everything()
+	if options != nil && options.FieldSelector != nil {
+		field = options.FieldSelector
+	}
+	key, _ := field.RequiresExactMatch("metadata.name")
+	return key, label, field
+}

--- a/pkg/controllers/inventory/store/vpc_inventory.go
+++ b/pkg/controllers/inventory/store/vpc_inventory.go
@@ -125,7 +125,7 @@ func genVPCEvent(key string, prevObj, currObj interface{}, rv uint64) (antreasto
 func vpcKeyFunc(obj interface{}) (string, error) {
 	vpc, ok := obj.(*runtimev1alpha1.Vpc)
 	if !ok {
-		return "", fmt.Errorf("Object is not of type runtime/v1alpha1/Vpc: %v", obj)
+		return "", fmt.Errorf("object is not of type runtime/v1alpha1/Vpc: %v", obj)
 	}
 	return fmt.Sprintf("%v/%v-%v", vpc.Namespace, vpc.Labels[common.VpcLabelAccountName], vpc.Info.Id), nil
 }


### PR DESCRIPTION
1. Watch() is added to VPC Rest API

2. `store/vpc_inventory` has been added for Watch, and imported `antrea/pkg/apiserver/storage` as storage standard

3. vpcStore has been changed into antreastorage.Interface and been moved to `store/vpc_inventory`