### PR TITLE
improve security group operation logging to be consistent

### DIFF
--- a/pkg/cloud-provider/cloudapi/aws/aws_security.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_security.go
@@ -516,8 +516,8 @@ func (ec2Cfg *ec2ServiceConfig) getNepheControllerManagedSecurityGroupsCloudView
 	}
 	managedSgIDToCloudSGObj, unmanagedSgIDToCloudSGObj := getCloudSecurityGroupsByType(cloudSecurityGroups)
 
-	// find all member network-interfaces-ids for managed cloud-security-groups
-	// also find all member network-interface-ids attached to non antrea+ sgs
+	// find all member network-interfaces-ids for managed cloud-security-groups.
+	// also find all member network-interface-ids attached to non nephe created sgs.
 	managedSgIDToMemberCloudResourcesMap := make(map[string][]securitygroup.CloudResource)
 	memberCloudResourcesWithOtherSGsAttachedMap := make(map[string]struct{})
 	for _, networkInterface := range networkInterfaces {

--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -821,7 +821,7 @@ func (a *appliedToSecurityGroup) updateANPRules(r *NetworkPolicyReconciler, np *
 // clearMembers removes all members from a security group.
 func (a *appliedToSecurityGroup) clearMembers(r *NetworkPolicyReconciler) {
 	if a.hasMembers {
-		r.Log.V(1).Info("Clearing AppliedToSecurityGroup members when no rules", "Name", a.id.Name)
+		r.Log.V(1).Info("Clearing AppliedToSecurityGroup members with no rules", "Name", a.id.Name)
 		ch := securitygroup.CloudSecurityGroup.UpdateSecurityGroupMembers(&a.id, nil, false)
 		go func() {
 			err := <-ch
@@ -830,7 +830,6 @@ func (a *appliedToSecurityGroup) clearMembers(r *NetworkPolicyReconciler) {
 		return
 	}
 	// No need to update appliedToSecurityGroup with no members.
-	r.Log.V(1).Info("Ignore AppliedToSecurityGroup rules when members cleared", "Name", a.id.Name)
 	a.hasRules = false
 }
 
@@ -1477,7 +1476,7 @@ func (n *networkPolicy) computeRulesReady(withStatus bool, r *NetworkPolicyRecon
 			}
 			if len(sgs) == 0 {
 				err := fmt.Errorf("internal error")
-				r.Log.Error(err, "Skip computing rules in networkPolicy because addrGroup unknown",
+				r.Log.Error(err, "Skip computing rules in networkPolicy because AddrSecurityGroup unknown",
 					"networkPolicy", n.Name, "AddressGroup", name)
 				return err
 			}

--- a/pkg/controllers/cloud/networkpolicy_controller.go
+++ b/pkg/controllers/cloud/networkpolicy_controller.go
@@ -298,7 +298,7 @@ func (r *NetworkPolicyReconciler) processMemberGrp(name string, eventType watch.
 		if i, ok, _ := indexer.GetByKey(key.String()); ok {
 			sg = i.(cloudSecurityGroup)
 			if compareCloudResources(members, sg.getMembers()) {
-				r.Log.V(1).Info("Ignore add unchanged SecurityGroup to cloud", "key", key)
+				r.Log.V(1).Info("Unchanged SecurityGroup, ignoring add.", "key", key)
 				continue
 			}
 			removed, ok := removedMembers[vpc]
@@ -464,7 +464,7 @@ func (r *NetworkPolicyReconciler) processNetworkPolicy(event watch.Event) error 
 		np = &networkPolicy{}
 		anp.DeepCopyInto(&np.NetworkPolicy)
 		if err := r.networkPolicyIndexer.Add(np); err != nil {
-			return fmt.Errorf("add networkPolicy %v to indexer: %w", npKey, err)
+			return fmt.Errorf("add NetworkPolicy %v to indexer: %w", npKey, err)
 		}
 		isCreate = true
 	} else {
@@ -476,11 +476,11 @@ func (r *NetworkPolicyReconciler) processNetworkPolicy(event watch.Event) error 
 	}
 	if !isCreate && reflect.DeepEqual(anp.Rules, np.Rules) &&
 		reflect.DeepEqual(anp.AppliedToGroups, np.AppliedToGroups) {
-		r.Log.V(1).Info("Ignore update unchanged NetworkPolicy", "Name", anp.Name, "Namespace", anp.Namespace)
+		r.Log.V(1).Info("Unchanged NetworkPolicy, ignoring update.", "Name", anp.Name, "Namespace", anp.Namespace)
 		return nil
 	}
 	if securitygroup.CloudSecurityGroup == nil {
-		r.Log.V(1).Info("Skip NP message no plug-in found")
+		r.Log.V(1).Info("Skip NetworkPolicy message, no plug-in found")
 		return nil
 	}
 	np.update(anp, isCreate, r)

--- a/pkg/controllers/cloud/networkpolicy_sync.go
+++ b/pkg/controllers/cloud/networkpolicy_sync.go
@@ -303,7 +303,7 @@ func (r *NetworkPolicyReconciler) syncWithCloud() {
 		sg := i.(*appliedToSecurityGroup)
 		sg.sync(cloudAppliedToSGs[sg.getID()], r)
 	}
-	// For cloud resource with any non-antrea+ SG, tricking plug-in to remove them by explicitly
+	// For cloud resource with any non nephe created SG, tricking plug-in to remove them by explicitly
 	// updating a single instance of associated security group.
 	for rsc := range rscWithUnknownSGs {
 		i, ok, _ := r.cloudResourceNPTrackerIndexer.GetByKey(rsc.String())


### PR DESCRIPTION
## Description

Currently log messages for security group operations are not consistent and some are not needed, this PR makes them consistent and clearer.

## Changes
1. Make sg operation logging consistent. Verb+SecurityGroup+Action+Condition(if any).
2. Remove unnecessary logs on ag and at no response processing.
3. Improve claim rule and np rule compute log messages.

Signed-off-by: Alexander Liu <alliu@vmware.com>