### PR TITLE
Fix log and error messages

### DIFF
--- a/cmd/nephe-controller/main.go
+++ b/cmd/nephe-controller/main.go
@@ -132,28 +132,28 @@ func main() {
 	// Register webhook for secret.
 	mgr.GetWebhookServer().Register("/validate-v1-secret",
 		&webhook.Admission{Handler: &nephewebhook.SecretValidator{Client: mgr.GetClient(),
-			Log: logging.GetLogger("webhook").WithName("secret")}})
+			Log: logging.GetLogger("webhook").WithName("Secret")}})
 
 	// Register webhook for CloudProviderAccount Mutator.
 	mgr.GetWebhookServer().Register("/mutate-crd-cloud-antrea-io-v1alpha1-cloudprovideraccount",
 		&webhook.Admission{Handler: &nephewebhook.CPAMutator{Client: mgr.GetClient(),
-			Log: logging.GetLogger("webhook").WithName("cloudprovideraccount-resource")}})
+			Log: logging.GetLogger("webhook").WithName("CloudProviderAccount")}})
 
 	// Register webhook for CloudProviderAccount Validator.
 	mgr.GetWebhookServer().Register("/validate-crd-cloud-antrea-io-v1alpha1-cloudprovideraccount",
 		&webhook.Admission{Handler: &nephewebhook.CPAValidator{Client: mgr.GetClient(),
-			Log: logging.GetLogger("webhook").WithName("cloudprovideraccount-resource")}})
+			Log: logging.GetLogger("webhook").WithName("CloudProviderAccount")}})
 
 	// Register webhook for CloudEntitySelector Mutator.
 	mgr.GetWebhookServer().Register("/mutate-crd-cloud-antrea-io-v1alpha1-cloudentityselector",
 		&webhook.Admission{Handler: &nephewebhook.CESMutator{Client: mgr.GetClient(),
 			Sh:  mgr.GetScheme(),
-			Log: logging.GetLogger("webhook").WithName("cloudentityselector-resource")}})
+			Log: logging.GetLogger("webhook").WithName("CloudEntitySelector")}})
 
 	// Register webhook for CloudEntitySelector Validator.
 	mgr.GetWebhookServer().Register("/validate-crd-cloud-antrea-io-v1alpha1-cloudentityselector",
 		&webhook.Admission{Handler: &nephewebhook.CESValidator{Client: mgr.GetClient(),
-			Log: logging.GetLogger("webhook").WithName("cloudentityselector-resource")}})
+			Log: logging.GetLogger("webhook").WithName("CloudEntitySelector")}})
 
 	if err = (&apiserver.NepheControllerAPIServer{}).SetupWithManager(mgr,
 		npController.GetVirtualMachinePolicyIndexer(), cloudInventory, logging.GetLogger("apiServer")); err != nil {

--- a/pkg/cloud-provider/cloudapi/internal/cloud_common.go
+++ b/pkg/cloud-provider/cloudapi/internal/cloud_common.go
@@ -160,7 +160,7 @@ func (c *cloudCommon) GetCloudAccountComputeResourceCRDs(accountNamespacedName *
 	error) {
 	accCfg, found := c.GetCloudAccountByName(accountNamespacedName)
 	if !found {
-		return nil, fmt.Errorf("unable to find cloud account:%v", *accountNamespacedName)
+		return nil, fmt.Errorf("unable to find cloud account %v", *accountNamespacedName)
 	}
 	namespace := accCfg.GetNamespacedName().Namespace
 
@@ -205,7 +205,7 @@ func (c *cloudCommon) AddSelector(accountNamespacedName *types.NamespacedName, s
 	// Invoke this function to force inventory scan for vms soon after CES add.
 	err := accCfg.startPeriodicInventorySync()
 	if err != nil {
-		return fmt.Errorf("inventory sync failed [ account : %v, err: %v ]", *accountNamespacedName, err)
+		return fmt.Errorf("failed to sync inventory, account: %v, err: %v", *accountNamespacedName, err)
 	}
 
 	return nil
@@ -241,7 +241,7 @@ func (c *cloudCommon) AddInventoryPoller(accountNamespacedName *types.Namespaced
 
 	err := accCfg.startPeriodicInventorySync()
 	if err != nil {
-		return fmt.Errorf("inventory sync failed [ account : %v, err: %v ]", *accountNamespacedName, err)
+		return fmt.Errorf("failed to sync inventory, account: %v, err: %v", *accountNamespacedName, err)
 	}
 
 	return nil
@@ -262,7 +262,7 @@ func (c *cloudCommon) DeleteInventoryPoller(accountNamespacedName *types.Namespa
 func (c *cloudCommon) GetVpcInventory(accountNamespacedName *types.NamespacedName) (map[string]*runtimev1alpha1.Vpc, error) {
 	accCfg, found := c.GetCloudAccountByName(accountNamespacedName)
 	if !found {
-		return nil, fmt.Errorf("unable to find cloud account:%v", *accountNamespacedName)
+		return nil, fmt.Errorf("unable to find cloud account %v", *accountNamespacedName)
 	}
 
 	serviceConfigs := accCfg.GetServiceConfigs()

--- a/pkg/cloud-provider/plugins.go
+++ b/pkg/cloud-provider/plugins.go
@@ -46,17 +46,17 @@ func registerCloudProvider(providerType cloudcommon.ProviderType, cloud cloudcom
 	providersMutex.Lock()
 	defer providersMutex.Unlock()
 	if _, found := providers[providerType]; found {
-		corePluginLogger().V(0).Info("cloudv1alpha1 provider already exists",
+		corePluginLogger().V(0).Info("crd.v1alpha1 cloud provider already exists",
 			"type", providerType)
 		return
 	}
 	providers[providerType] = cloud
 
-	corePluginLogger().V(1).Info("registered cloudv1alpha1 provider successfully",
+	corePluginLogger().V(1).Info("registered crd.v1alpha1 cloud provider successfully",
 		"type", providerType)
 }
 
-// GetCloudInterface returns an instance of the cloudv1alpha1 provider type, or nil if
+// GetCloudInterface returns an instance of the crd.v1alpha1 cloud Provider type, or nil if
 // the type is unknown.  The error return is only used if the named provider
 // was known but failed to initialize.
 func GetCloudInterface(providerType cloudcommon.ProviderType) (cloudcommon.CloudInterface, error) {
@@ -64,7 +64,7 @@ func GetCloudInterface(providerType cloudcommon.ProviderType) (cloudcommon.Cloud
 	defer providersMutex.Unlock()
 	cloud, found := providers[providerType]
 	if !found {
-		return nil, fmt.Errorf("unsupported cloudv1alpha1 provider %q", providerType)
+		return nil, fmt.Errorf("unsupported crd.v1alpha1 cloud provider %q", providerType)
 	}
 	return cloud, nil
 }

--- a/pkg/controllers/cloud/cloudprovideraccount_controller.go
+++ b/pkg/controllers/cloud/cloudprovideraccount_controller.go
@@ -129,9 +129,10 @@ func (r *CloudProviderAccountReconciler) updatePendingSyncCountAndStatus() {
 
 func (r *CloudProviderAccountReconciler) processCreate(namespacedName *types.NamespacedName,
 	account *cloudv1alpha1.CloudProviderAccount) error {
+	r.Log.Info("Received request", "account", namespacedName, "operation", "create/update")
 	accountCloudType, err := utils.GetAccountProviderType(account)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s, err: %v", errorMsgAccountAddFail, err)
 	}
 	cloudType := r.addAccountProviderType(namespacedName, accountCloudType)
 	cloudInterface, err := cloudprovider.GetCloudInterface(cloudType)
@@ -140,7 +141,7 @@ func (r *CloudProviderAccountReconciler) processCreate(namespacedName *types.Nam
 	}
 	err = cloudInterface.AddProviderAccount(r.Client, account)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s, err: %v", errorMsgAccountAddFail, err)
 	}
 
 	accPoller, preExists := r.Poller.addAccountPoller(accountCloudType, namespacedName, account, r)
@@ -158,7 +159,7 @@ func (r *CloudProviderAccountReconciler) processCreate(namespacedName *types.Nam
 }
 
 func (r *CloudProviderAccountReconciler) processDelete(namespacedName *types.NamespacedName) error {
-	r.Log.V(1).Info("remove account poller", "account", namespacedName.String())
+	r.Log.Info("Received request", "account", namespacedName, "operation", "delete")
 	err := r.Poller.removeAccountPoller(namespacedName)
 	if err != nil {
 		return err

--- a/pkg/controllers/cloud/common.go
+++ b/pkg/controllers/cloud/common.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	// Error messages
+	errorMsgAccountAddFail             = "failed to add account"
 	errorMsgSelectorAddFail            = "selector add failed, poller is not created for account"
 	errorMsgSelectorAccountMapNotFound = "failed to find account for selector"
 	errorMsgAccountPollerNotFound      = "account poller not found"

--- a/pkg/controllers/cloud/networkpolicy_pendingitem.go
+++ b/pkg/controllers/cloud/networkpolicy_pendingitem.go
@@ -89,7 +89,7 @@ func (q *PendingItemQueue) Update(id string, checkRun bool, updates ...interface
 	i, ok := q.items[id]
 	if !ok {
 		err := fmt.Errorf("not found")
-		log.Error(err, "Update", "Name", id)
+		log.Error(err, "update", "Name", id)
 		return err
 	}
 	i.UpdatePendingItem(id, q.context, updates...)
@@ -118,7 +118,7 @@ func (q *PendingItemQueue) GetRetryCount(id string) int {
 	i, ok := q.items[id]
 	if !ok {
 		err := fmt.Errorf("not found")
-		log.Error(err, "GetRetryCount", "Name", id)
+		log.Error(err, "failed to GetRetryCount", "Name", id)
 		return -1
 	}
 	if i.opCnt == nil {

--- a/pkg/controllers/cloud/networkpolicy_sync.go
+++ b/pkg/controllers/cloud/networkpolicy_sync.go
@@ -93,7 +93,7 @@ func (a *appliedToSecurityGroup) sync(syncContent *securitygroup.Synchronization
 	}
 	nps, err := r.networkPolicyIndexer.ByIndex(networkPolicyIndexerByAppliedToGrp, a.id.Name)
 	if err != nil {
-		log.Error(err, "Get networkPolicy by indexer", "Index", networkPolicyIndexerByAppliedToGrp, "Key", a.id.Name)
+		log.Error(err, "get networkPolicy by indexer", "Index", networkPolicyIndexerByAppliedToGrp, "Key", a.id.Name)
 		return
 	}
 	items := make(map[string]int)
@@ -265,6 +265,7 @@ func (r *NetworkPolicyReconciler) syncWithCloud() {
 	if r.bookmarkCnt < npSyncReadyBookMarkCnt {
 		return
 	}
+	log.V(1).Info("Started synchronizing cloud security groups with controller")
 	ch := securitygroup.CloudSecurityGroup.GetSecurityGroupSyncChan()
 	cloudAddrSGs := make(map[securitygroup.CloudResourceID]*securitygroup.SynchronizationContent)
 	cloudAppliedToSGs := make(map[securitygroup.CloudResourceID]*securitygroup.SynchronizationContent)
@@ -279,6 +280,7 @@ func (r *NetworkPolicyReconciler) syncWithCloud() {
 		}
 		// Removes unknown sg.
 		if _, ok, _ := indexer.GetByKey(content.Resource.CloudResourceID.String()); !ok {
+			log.V(0).Info("Delete SecurityGroup not found in cache", "Name", content.Resource.Name, "MembershipOnly", content.MembershipOnly)
 			state := securityGroupStateCreated
 			_ = sgNew(&content.Resource, []*securitygroup.CloudResource{}, &state).delete(r)
 			continue
@@ -321,6 +323,7 @@ func (r *NetworkPolicyReconciler) syncWithCloud() {
 			break
 		}
 	}
+	log.V(1).Info("Done synchronizing cloud security groups with controller")
 }
 
 // processBookMark process bookmark event and return true.

--- a/pkg/controllers/cloud/virtualmachine_controller.go
+++ b/pkg/controllers/cloud/virtualmachine_controller.go
@@ -56,14 +56,16 @@ func (r *VirtualMachineReconciler) Reconcile(_ context.Context, req ctrl.Request
 	virtualMachine := cloudv1alpha1.VirtualMachine{}
 	if err := r.Get(context.TODO(), req.NamespacedName, &virtualMachine); err != nil {
 		if !errors.IsNotFound(err) {
-			r.Log.V(0).Info("Error getting VM crd", "vm", req.NamespacedName)
+			r.Log.Error(err, "failed to get VM crd", "vm", req.NamespacedName)
 			return ctrl.Result{}, err
 		}
 		// Fall through if owner is deleted.
-		r.Log.V(1).Info("Is delete", "vm", req.NamespacedName)
+		r.Log.Info("Received request", "vm", req.NamespacedName, "operation", "delete")
 		accessor, _ := meta.Accessor(&virtualMachine)
 		accessor.SetName(req.Name)
 		accessor.SetNamespace(req.Namespace)
+	} else {
+		r.Log.Info("Received request", "vm", req.NamespacedName, "operation", "create/update")
 	}
 
 	r.converter.Ch <- virtualMachine

--- a/pkg/controllers/inventory/inventory.go
+++ b/pkg/controllers/inventory/inventory.go
@@ -72,8 +72,8 @@ func (inventory *Inventory) BuildVpcCache(vpcMap map[string]*runtimev1alpha1.Vpc
 			err = inventory.vpcStore.Update(v)
 		}
 		if err != nil {
-			return fmt.Errorf("failed to add vpc into vpc cache, vpc id %s, account %v, error %v",
-				v.Status.Id, *namespacedName, err)
+			return fmt.Errorf("failed to add vpc into vpc cache, vpc id: %s, error: %v",
+				v.Status.Id, err)
 		}
 	}
 

--- a/test/integration/crd_rw_test.go
+++ b/test/integration/crd_rw_test.go
@@ -152,9 +152,11 @@ var _ = Describe(fmt.Sprintf("%s,%s: Basic CRD Read-Write", focusAws, focusAzure
 		logf.Log.Info("Delete", "account", account.Name)
 		err := k8sClient.Delete(context.TODO(), account)
 		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(1 * time.Second)
 		logf.Log.Info("Delete", "secret", secret.Name)
 		err = k8sClient.Delete(context.TODO(), secret)
 		Expect(err).ToNot(HaveOccurred())
+		time.Sleep(1 * time.Second)
 	}
 
 	table.DescribeTable("Modifying CRDs",
@@ -173,6 +175,8 @@ var _ = Describe(fmt.Sprintf("%s,%s: Basic CRD Read-Write", focusAws, focusAzure
 			By("Can be added")
 			err := k8sClient.Create(context.TODO(), crd)
 			Expect(err).ToNot(HaveOccurred())
+			// Sleep for a second, so that CR is processed by the reconciler.
+			time.Sleep(1 * time.Second)
 
 			By("Can be retrieved")
 			key := client.ObjectKeyFromObject(crd)
@@ -182,6 +186,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: Basic CRD Read-Write", focusAws, focusAzure
 			By("Can be deleted")
 			err = k8sClient.Delete(context.TODO(), crd)
 			Expect(err).ToNot(HaveOccurred())
+			time.Sleep(1 * time.Second)
 
 			if deleteAccount != nil {
 				deleteAccount()


### PR DESCRIPTION
Info logs should always start with capital letter.
Error logs should always start with small letter.
    
Also add sleep in crd integration test, to allow CR create/delete operation to be processed by the reconciler
Also handle some error cases in the account poller effectively.
    
Signed-off-by: Anand Kumar <kumaranand@vmware.com>