### PR TITLE
Add endpoint option in cloudprovideraccount CRD

### DIFF
--- a/apis/crd/v1alpha1/cloudprovideraccount_types.go
+++ b/apis/crd/v1alpha1/cloudprovideraccount_types.go
@@ -50,6 +50,8 @@ type CloudProviderAccountAWSConfig struct {
 	SecretRef *SecretReference `json:"secretRef,omitempty"`
 	// Cloud provider account region.
 	Region string `json:"region,omitempty"`
+	// Endpoint URL that overrides the default AWS generated endpoint.
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 type CloudProviderAccountAzureConfig struct {

--- a/config/crd/bases/crd.cloud.antrea.io_cloudprovideraccounts.yaml
+++ b/config/crd/bases/crd.cloud.antrea.io_cloudprovideraccounts.yaml
@@ -41,6 +41,10 @@ spec:
               awsConfig:
                 description: Cloud provider account config.
                 properties:
+                  endpoint:
+                    description: Endpoint URL that overrides the default AWS generated
+                      endpoint.
+                    type: string
                   region:
                     description: Cloud provider account region.
                     type: string

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -177,6 +177,10 @@ spec:
               awsConfig:
                 description: Cloud provider account config.
                 properties:
+                  endpoint:
+                    description: Endpoint URL that overrides the default AWS generated
+                      endpoint.
+                    type: string
                   region:
                     description: Cloud provider account region.
                     type: string

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/apiserver v0.24.2
 	k8s.io/component-base v0.24.2 // indirect
-	k8s.io/klog/v2 v2.60.1
+	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect

--- a/pkg/cloud-provider/cloudapi/aws/aws_account_mgmt.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_account_mgmt.go
@@ -29,7 +29,8 @@ import (
 
 type awsAccountConfig struct {
 	v1alpha1.AwsAccountCredential
-	region string
+	region   string
+	endpoint string
 }
 
 // setAccountCredentials sets account credentials.
@@ -43,6 +44,7 @@ func setAccountCredentials(client client.Client, credentials interface{}) (inter
 	awsConfig := &awsAccountConfig{
 		AwsAccountCredential: *accCred,
 		region:               strings.TrimSpace(awsProviderConfig.Region),
+		endpoint:             strings.TrimSpace(awsProviderConfig.Endpoint),
 	}
 
 	return awsConfig, nil
@@ -72,6 +74,10 @@ func compareAccountCredentials(accountName string, existing interface{}, new int
 	if strings.Compare(existingConfig.region, newConfig.region) != 0 {
 		credsChanged = true
 		awsPluginLogger().Info("account region updated", "account", accountName)
+	}
+	if strings.Compare(existingConfig.endpoint, newConfig.endpoint) != 0 {
+		credsChanged = true
+		awsPluginLogger().Info("endpoint url updated", "account", accountName)
 	}
 	return credsChanged
 }

--- a/pkg/cloud-provider/cloudapi/aws/aws_services.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_services.go
@@ -84,6 +84,7 @@ func (h *awsServicesHelperImpl) newServiceSdkConfigProvider(accConfig *awsAccoun
 
 	awsConfig := &aws.Config{
 		Region:                        &accConfig.region,
+		Endpoint:                      &accConfig.endpoint,
 		Credentials:                   creds,
 		CredentialsChainVerboseErrors: aws.Bool(true),
 	}


### PR DESCRIPTION
Endpoint can be used to set non AWS default URL. Primarily used to set endpoint to mock AWS services like localstack

Signed-off-by: Rahul Jain <rahulj@vmware.com>