### PR TITLE
Send rule realization update even if ANP didnt change

### DIFF
--- a/pkg/controllers/cloud/networkpolicy_controller.go
+++ b/pkg/controllers/cloud/networkpolicy_controller.go
@@ -477,6 +477,9 @@ func (r *NetworkPolicyReconciler) processNetworkPolicy(event watch.Event) error 
 	if !isCreate && reflect.DeepEqual(anp.Rules, np.Rules) &&
 		reflect.DeepEqual(anp.AppliedToGroups, np.AppliedToGroups) {
 		r.Log.V(1).Info("Unchanged NetworkPolicy, ignoring update.", "Name", anp.Name, "Namespace", anp.Namespace)
+		// Send rule realization status if even no rule diff is found. This is because in case of
+		// antrea controller restart, it will send all ANPs again and there won't be any diff.
+		r.sendRuleRealizationStatus(anp, nil)
 		return nil
 	}
 	if securitygroup.CloudSecurityGroup == nil {


### PR DESCRIPTION
If an ANP is configured with Allow -> Reject -> Allow actions, nephe was not sending rule realization update as it didnt find any diff in the rules. As Reject action is failed early before internal cache in nephe is updated. Fix is to send ANP realization update even if no change in ANP rules are detected.
This will handle antrea controller restart case too, in which when all ANPs are replayed by antrea controller, nephe will not detect any change and no rule status update will happen.

Signed-off-by: Rahul Jain <rahulj@vmware.com>