### PR TITLE
Sync with cloud feature hardening - 2.

### DIFF
--- a/pkg/cloud-provider/cloudapi/azure/azure_nsg_rules.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_nsg_rules.go
@@ -445,13 +445,17 @@ func convertToAzureAddressPrefix(ruleIPs []*net.IPNet) (*string, *[]string) {
 	return addressPrefix, addressPrefixes
 }
 
-// convertToInternalRulesByAppliedToSGName converts azure rules to securitygroup.IngressRule and securitygroup.EgressRule and split
-// them by security group names.
+// convertToInternalRulesByAppliedToSGName converts azure rules to securitygroup.IngressRule and securitygroup.EgressRule
+// and split them by security group names.
 func convertToInternalRulesByAppliedToSGName(azureSecurityRules *[]network.SecurityRule,
 	vnetID string) (map[string][]securitygroup.IngressRule, map[string][]securitygroup.EgressRule) {
 	nepheControllerATSgNameToIngressRules := make(map[string][]securitygroup.IngressRule)
 	nepheControllerATSgNameToEgressRules := make(map[string][]securitygroup.EgressRule)
 	for _, azureSecurityRule := range *azureSecurityRules {
+		// skip any rules not created by nephe
+		if azureSecurityRule.Description == nil {
+			continue
+		}
 		desc, ok := securitygroup.ExtractCloudDescription(azureSecurityRule.Description)
 		if !ok {
 			// Ignore rules that don't have a valid description field.


### PR DESCRIPTION
Fixes:
- Add empty string check for sg rule description field while creating sync content.
- Stale AT SG doesn't get deleted during sync as sync doesn't identify it as an ASG associated with NSG. It is due to the usage of ASGs in "tags" field of NSG for retrieving ASGs from cloud. User added stale ASG can't be present in tags. Fix is to use ASGs attached to network interfaces instead of getting ASGs from "tags". AT SGs are added as "tags" in a NSG for user visibility purpose.
- SG deletion logic uses RG name from Vnet of CloudResource. If SG belongs to a different RG then it SG doesn't get deleted. Hence, while creating sync content make sure that only SGs with RGs same as Vnet are included.

Signed-off-by: Archana Holla <harchana@vmware.com>