### PR TITLE
Add Managed VPC flag in VPC Info

### DIFF
--- a/apis/runtime/v1alpha1/vpc_types.go
+++ b/apis/runtime/v1alpha1/vpc_types.go
@@ -27,6 +27,7 @@ type VpcStatus struct {
 	Region   string                 `json:"region,omitempty"`
 	Tags     map[string]string      `json:"tags,omitempty"`
 	Cidrs    []string               `json:"cidrs,omitempty"`
+	Managed  bool                   `json:"managed,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -195,22 +195,22 @@ kubectl get vpc -A
 
 ```text
 # Output
-NAMESPACE   NAME                    CLOUD PROVIDER   REGION
-sample-ns   vpc-0f54c9f1b395038ab   AWS              us-west-1
-sample-ns   vpc-04269a331ab6cd649   AWS              us-west-1
-sample-ns   vpc-047156bebab1083c9   AWS              us-west-1
+NAMESPACE   NAME                    CLOUD PROVIDER   REGION      MANAGED
+sample-ns   vpc-0d6bb6a4a880bd9ad   AWS              us-west-1   true
+sample-ns   vpc-04269a331ab6cd649   AWS              us-west-1   false
+sample-ns   vpc-047156bebab1083c9   AWS              us-west-1   false
 ```
 
 Use describe on VPC object to get `Id` or `Name` field and use it in vpcMatch
 section of `CloudEntitySelector` configuration.
 
 ```bash
-kubectl describe vpc vpc-0f54c9f1b395038ab -n sample-ns
+kubectl describe vpc vpc-0d6bb6a4a880bd9ad -n sample-ns
 ```
 
 ```text
 # Output
-Name:         vpc-0f54c9f1b395038ab
+Name:         vpc-0d6bb6a4a880bd9ad
 Namespace:    sample-ns
 Labels:       account-name=cloudprovideraccount-aws-sample
               region=us-west-1
@@ -223,7 +223,7 @@ Spec:
   Cidrs:
     10.0.0.0/16
   Cloud Provider:  AWS
-  Id:              vpc-0f54c9f1b395038ab
+  Id:              vpc-0d6bb6a4a880bd9ad
   Name:            test-us-west1-vpc
   Region:          us-west-1
   Tags:

--- a/pkg/apiserver/registry/inventory/rest.go
+++ b/pkg/apiserver/registry/inventory/rest.go
@@ -177,6 +177,7 @@ func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOpti
 			{Name: "NAME", Type: "string", Description: "Name"},
 			{Name: "CLOUD PROVIDER", Type: "string", Description: "Cloud Provider"},
 			{Name: "REGION", Type: "string", Description: "Region"},
+			{Name: "MANAGED", Type: "bool", Description: "Managed VPC"},
 		},
 	}
 	if m, err := meta.ListAccessor(obj); err == nil {
@@ -192,7 +193,7 @@ func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOpti
 	table.Rows, err = metatable.MetaToTableRow(obj,
 		func(obj runtime.Object, _ metav1.Object, _, _ string) ([]interface{}, error) {
 			vpc := obj.(*runtimev1alpha1.Vpc)
-			return []interface{}{vpc.Name, vpc.Status.Provider, vpc.Status.Region}, nil
+			return []interface{}{vpc.Name, vpc.Status.Provider, vpc.Status.Region, vpc.Status.Managed}, nil
 		})
 	return table, err
 }

--- a/pkg/apiserver/registry/inventory/vpc_test.go
+++ b/pkg/apiserver/registry/inventory/vpc_test.go
@@ -51,7 +51,8 @@ var _ = Describe("VPC", func() {
 			Tags: map[string]string{
 				"no.delete": "true",
 			},
-			Cidrs: []string{"192.168.1.1/24"},
+			Cidrs:   []string{"192.168.1.1/24"},
+			Managed: true,
 		},
 	}
 	cacheTest2 := &runtimev1alpha1.Vpc{
@@ -65,7 +66,8 @@ var _ = Describe("VPC", func() {
 			Tags: map[string]string{
 				"no.delete": "true",
 			},
-			Cidrs: []string{"192.168.1.1/24"},
+			Cidrs:   []string{"192.168.1.1/24"},
+			Managed: false,
 		},
 	}
 	cacheTest3 := &runtimev1alpha1.Vpc{
@@ -83,8 +85,9 @@ var _ = Describe("VPC", func() {
 			Tags: map[string]string{
 				"no.delete": "true",
 			},
-			Region: "region",
-			Cidrs:  []string{"192.168.1.1/24"},
+			Region:  "region",
+			Cidrs:   []string{"192.168.1.1/24"},
+			Managed: true,
 		},
 	}
 
@@ -133,7 +136,8 @@ var _ = Describe("VPC", func() {
 						Tags: map[string]string{
 							"no.delete": "true",
 						},
-						Cidrs: []string{"192.168.1.1/24"},
+						Cidrs:   []string{"192.168.1.1/24"},
+						Managed: true,
 					},
 				},
 				{
@@ -151,8 +155,9 @@ var _ = Describe("VPC", func() {
 						Tags: map[string]string{
 							"no.delete": "true",
 						},
-						Region: "region",
-						Cidrs:  []string{"192.168.1.1/24"},
+						Region:  "region",
+						Cidrs:   []string{"192.168.1.1/24"},
+						Managed: true,
 					},
 				},
 			},
@@ -174,8 +179,9 @@ var _ = Describe("VPC", func() {
 						Tags: map[string]string{
 							"no.delete": "true",
 						},
-						Region: "region",
-						Cidrs:  []string{"192.168.1.1/24"},
+						Region:  "region",
+						Cidrs:   []string{"192.168.1.1/24"},
+						Managed: true,
 					},
 				},
 			},
@@ -274,10 +280,11 @@ var _ = Describe("VPC", func() {
 			{Name: "NAME", Type: "string", Description: "Name"},
 			{Name: "CLOUD PROVIDER", Type: "string", Description: "Cloud Provider"},
 			{Name: "REGION", Type: "string", Description: "Region"},
+			{Name: "MANAGED", Type: "bool", Description: "Managed VPC"},
 		},
 		Rows: []metav1.TableRow{
 			{
-				Cells: []interface{}{"targetId4", v1alpha1.AWSCloudProvider, "us-west-2"},
+				Cells: []interface{}{"targetId4", v1alpha1.AWSCloudProvider, "us-west-2", false},
 			},
 		},
 	}

--- a/pkg/cloud-provider/cloudapi/aws/aws_crd_helpers.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_crd_helpers.go
@@ -80,7 +80,7 @@ func ec2InstanceToVirtualMachineCRD(instance *ec2.Instance, namespace string, ac
 }
 
 // ec2VpcToInternalVpcObject converts ec2 vpc object to vpc runtime object.
-func ec2VpcToInternalVpcObject(vpc *ec2.Vpc, namespace string, accountName string, region string) *runtimev1alpha1.Vpc {
+func ec2VpcToInternalVpcObject(vpc *ec2.Vpc, namespace string, accountName string, region string, managed bool) *runtimev1alpha1.Vpc {
 	cloudName := ""
 	tags := make(map[string]string, 0)
 	if len(vpc.Tags) != 0 {
@@ -103,5 +103,5 @@ func ec2VpcToInternalVpcObject(vpc *ec2.Vpc, namespace string, accountName strin
 	}
 
 	return utils.GenerateInternalVpcObject(*vpc.VpcId, namespace, labelsMap, strings.ToLower(cloudName),
-		strings.ToLower(*vpc.VpcId), tags, v1alpha1.AWSCloudProvider, region, cidrs)
+		strings.ToLower(*vpc.VpcId), tags, v1alpha1.AWSCloudProvider, region, cidrs, managed)
 }

--- a/pkg/cloud-provider/cloudapi/aws/aws_security.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_security.go
@@ -498,7 +498,7 @@ func buildEc2SgsToAttachForCaseMemberOnlySgWithNoATSgAttached(networkInterfaceNe
 }
 
 func (ec2Cfg *ec2ServiceConfig) getNepheControllerManagedSecurityGroupsCloudView() []securitygroup.SynchronizationContent {
-	vpcIDs := ec2Cfg.getCachedVpcIDs()
+	vpcIDs := ec2Cfg.getManagedVpcIDs()
 	if len(vpcIDs) == 0 {
 		return []securitygroup.SynchronizationContent{}
 	}

--- a/pkg/cloud-provider/cloudapi/azure/azure_crd_helpers.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_crd_helpers.go
@@ -109,7 +109,7 @@ func computeInstanceToVirtualMachineCRD(instance *virtualMachineTable, namespace
 
 // ComputeVpcToInternalVpcObject converts vnet object from cloud format(network.VirtualNetwork) to vpc runtime object.
 func ComputeVpcToInternalVpcObject(vnet *network.VirtualNetwork, namespace string, accountName string,
-	region string) *runtimev1alpha1.Vpc {
+	region string, managed bool) *runtimev1alpha1.Vpc {
 	crdName := utils.GenerateShortResourceIdentifier(*vnet.ID, *vnet.Name)
 	tags := make(map[string]string, 0)
 	if len(vnet.Tags) != 0 {
@@ -126,5 +126,5 @@ func ComputeVpcToInternalVpcObject(vnet *network.VirtualNetwork, namespace strin
 		common.VpcLabelRegion:      region,
 	}
 	return utils.GenerateInternalVpcObject(crdName, namespace, labelsMap, strings.ToLower(*vnet.Name),
-		strings.ToLower(*vnet.ID), tags, v1alpha1.AzureCloudProvider, region, cidrs)
+		strings.ToLower(*vnet.ID), tags, v1alpha1.AzureCloudProvider, region, cidrs, managed)
 }

--- a/pkg/cloud-provider/cloudapi/azure/azure_security.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_security.go
@@ -808,7 +808,7 @@ func (c *azureCloud) UpdateSecurityGroupRules(appliedToGroupIdentifier *security
 	}
 
 	vnetPeerPairs := computeService.getVnetPeers(vnetID)
-	vnetCachedIDs := computeService.getCachedVnetIDs()
+	vnetCachedIDs := computeService.getManagedVnetIDs()
 	vnetVMs, _ := computeService.getVirtualMachines()
 	// ruleIP := vnetVMs[len(vnetVMs)-1].NetworkInterfaces[0].PrivateIps[0]
 	// AT sg name per vnet is fixed and predefined. Get azure nsg name for it.
@@ -975,7 +975,7 @@ func (c *azureCloud) GetEnforcedSecurity() []securitygroup.SynchronizationConten
 }
 
 func (computeCfg *computeServiceConfig) getNepheControllerManagedSecurityGroupsCloudView() []securitygroup.SynchronizationContent {
-	vnetIDs := computeCfg.getCachedVnetIDs()
+	vnetIDs := computeCfg.getManagedVnetIDs()
 	if len(vnetIDs) == 0 {
 		return []securitygroup.SynchronizationContent{}
 	}
@@ -1004,7 +1004,7 @@ func (computeCfg *computeServiceConfig) getNepheControllerManagedSecurityGroupsC
 
 func (computeCfg *computeServiceConfig) ifPeerProcessing(vnetID string) bool {
 	vnetPeerPairs := computeCfg.getVnetPeers(vnetID)
-	vnetCachedIDs := computeCfg.getCachedVnetIDs()
+	vnetCachedIDs := computeCfg.getManagedVnetIDs()
 	for _, vnetPeerPair := range vnetPeerPairs {
 		vnetPeerID, _, _ := vnetPeerPair[0], vnetPeerPair[1], vnetPeerPair[2]
 		if _, ok := vnetCachedIDs[vnetPeerID]; ok {

--- a/pkg/cloud-provider/utils/crd_generator.go
+++ b/pkg/cloud-provider/utils/crd_generator.go
@@ -79,7 +79,8 @@ func GenerateShortResourceIdentifier(id string, prefixToAdd string) string {
 
 // GenerateInternalVpcObject generates runtimev1alpha1 vpc object using the input parameters.
 func GenerateInternalVpcObject(name string, namespace string, labels map[string]string, cloudName string,
-	cloudId string, tags map[string]string, cloudProvider cloudv1alpha1.CloudProvider, region string, cidrs []string) *runtimev1alpha1.Vpc {
+	cloudId string, tags map[string]string, cloudProvider cloudv1alpha1.CloudProvider,
+	region string, cidrs []string, managed bool) *runtimev1alpha1.Vpc {
 	status := &runtimev1alpha1.VpcStatus{
 		Name:     cloudName,
 		Id:       cloudId,
@@ -87,6 +88,7 @@ func GenerateInternalVpcObject(name string, namespace string, labels map[string]
 		Region:   region,
 		Tags:     tags,
 		Cidrs:    cidrs,
+		Managed:  managed,
 	}
 
 	vpc := &runtimev1alpha1.Vpc{


### PR DESCRIPTION
Managed VPCs/VNETs are those which include one ore more managed VMs. Added a flag in VPC info struct to indicate if the VPC is managed or not.
Also updated get vpc output and doc.

Signed-off-by: Rahul Jain <rahulj@vmware.com>