### PR TITLE
Optimize ExternalEntity patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.19.1
+	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.2
@@ -129,8 +130,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 )
-
-require golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 
 // antrea dependency.
 replace (

--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,8 @@ require (
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 )
 
+require golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
+
 // antrea dependency.
 replace (
 	// Variadic arguments are not supported in 1.6 and controller-runtime module

--- a/go.sum
+++ b/go.sum
@@ -619,6 +619,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb h1:PaBZQdo+iSDyHT053FjUCgZQ/9uqVwPOcl7KSWhKn6w=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/converter/source/converter_source_suite_test.go
+++ b/pkg/converter/source/converter_source_suite_test.go
@@ -34,10 +34,11 @@ import (
 )
 
 var (
-	mockCtrl                    *mock.Controller
-	mockClient                  *controllerruntimeclient.MockClient
-	scheme                      = runtime.NewScheme()
-	networkInterfaceIPAddresses = []string{"1.1.1.1", "2.2.2.2"}
+	mockCtrl                         *mock.Controller
+	mockClient                       *controllerruntimeclient.MockClient
+	scheme                           = runtime.NewScheme()
+	networkInterfaceIPAddresses      = []string{"1.1.1.1", "2.2.2.2"}
+	networkInterfaceIPAddressesPatch = []string{"3.3.3.3"}
 	// Used by ExternalNode.
 	networkInterfaceNames      = []string{"nic0"}
 	testNamespace              = "test-namespace"
@@ -48,8 +49,9 @@ var (
 		"VirtualMachine": &source.VirtualMachineSource{},
 	}
 
-	externalEntitySources map[string]target.ExternalEntitySource
-	externalNodeSources   map[string]target.ExternalNodeSource
+	externalEntitySources      map[string]target.ExternalEntitySource
+	externalEntitySourcesPatch map[string]target.ExternalEntitySource
+	externalNodeSources        map[string]target.ExternalNodeSource
 )
 
 var _ = BeforeSuite(func() {
@@ -64,6 +66,7 @@ func commonInitTest() {
 	mockCtrl = mock.NewController(GinkgoT())
 	mockClient = controllerruntimeclient.NewMockClient(mockCtrl)
 	externalEntitySources = testing2.SetupExternalEntitySources(networkInterfaceIPAddresses, testNamespace)
+	externalEntitySourcesPatch = testing2.SetupExternalEntitySources(networkInterfaceIPAddressesPatch, testNamespace)
 	externalNodeSources = testing2.SetupExternalNodeSources(networkInterfaceIPAddresses, testNamespace)
 }
 

--- a/pkg/converter/source/converter_source_suite_test.go
+++ b/pkg/converter/source/converter_source_suite_test.go
@@ -52,6 +52,7 @@ var (
 	externalEntitySources      map[string]target.ExternalEntitySource
 	externalEntitySourcesPatch map[string]target.ExternalEntitySource
 	externalNodeSources        map[string]target.ExternalNodeSource
+	externalNodeSourcesPatch   map[string]target.ExternalNodeSource
 )
 
 var _ = BeforeSuite(func() {
@@ -68,6 +69,7 @@ func commonInitTest() {
 	externalEntitySources = testing2.SetupExternalEntitySources(networkInterfaceIPAddresses, testNamespace)
 	externalEntitySourcesPatch = testing2.SetupExternalEntitySources(networkInterfaceIPAddressesPatch, testNamespace)
 	externalNodeSources = testing2.SetupExternalNodeSources(networkInterfaceIPAddresses, testNamespace)
+	externalNodeSourcesPatch = testing2.SetupExternalNodeSources(networkInterfaceIPAddressesPatch, testNamespace)
 }
 
 // Testing converting source crd to target crd

--- a/pkg/converter/source/virtualmachine_converter.go
+++ b/pkg/converter/source/virtualmachine_converter.go
@@ -167,8 +167,11 @@ func (v VMConverter) processEvent(vm *VirtualMachineSource, failedUpdates map[st
 			err = v.Client.Patch(ctx, patch, base)
 		} else {
 			base := client.MergeFrom(externEntity.DeepCopy())
-			patch := target.PatchExternalEntityFrom(vm, externEntity, v.Client)
-			err = v.Client.Patch(ctx, patch, base)
+			patch, changed := target.PatchExternalEntityFrom(vm, externEntity, v.Client)
+
+			if changed {
+				err = v.Client.Patch(ctx, patch, base)
+			}
 		}
 		if err != nil {
 			v.Log.Error(err, fmt.Sprintf("unable to patch %s", resource), "Key", fetchKey)

--- a/pkg/converter/source/virtualmachine_converter.go
+++ b/pkg/converter/source/virtualmachine_converter.go
@@ -163,14 +163,19 @@ func (v VMConverter) processEvent(vm *VirtualMachineSource, failedUpdates map[st
 	if !isNotFound {
 		if isExternalnode {
 			base := client.MergeFrom(externNode.DeepCopy())
-			patch := target.PatchExternalNodeFrom(vm, externNode, v.Client)
-			err = v.Client.Patch(ctx, patch, base)
+			patch, changed := target.PatchExternalNodeFrom(vm, externNode, v.Client)
+			if changed {
+				err = v.Client.Patch(ctx, patch, base)
+			} else {
+				return
+			}
 		} else {
 			base := client.MergeFrom(externEntity.DeepCopy())
 			patch, changed := target.PatchExternalEntityFrom(vm, externEntity, v.Client)
-
 			if changed {
 				err = v.Client.Patch(ctx, patch, base)
+			} else {
+				return
 			}
 		}
 		if err != nil {

--- a/pkg/converter/target/externalentity.go
+++ b/pkg/converter/target/externalentity.go
@@ -92,43 +92,40 @@ func populateExternalEntityFrom(source ExternalEntitySource, externalEntity *ant
 		changed = true
 	}
 	sourcePorts := source.GetEndPointPort(cl)
-	sort.Slice(externalEntity.Spec.Ports, func(i, j int) bool {
-		if externalEntity.Spec.Ports[i].Name != externalEntity.Spec.Ports[j].Name {
-			return strings.Compare(externalEntity.Spec.Ports[i].Name, externalEntity.Spec.Ports[j].Name) < 0
-		}
-		if externalEntity.Spec.Ports[i].Port != externalEntity.Spec.Ports[j].Port {
-			return externalEntity.Spec.Ports[i].Port < externalEntity.Spec.Ports[j].Port
-		}
-		return strings.Compare(string(externalEntity.Spec.Ports[i].Protocol), string(externalEntity.Spec.Ports[j].Protocol)) < 0
-	})
-	sort.Slice(sourcePorts, func(i, j int) bool {
-		if sourcePorts[i].Name != sourcePorts[j].Name {
-			return strings.Compare(sourcePorts[i].Name, sourcePorts[j].Name) < 0
-		}
-		if sourcePorts[i].Port != sourcePorts[j].Port {
-			return sourcePorts[i].Port < sourcePorts[j].Port
-		}
-		return strings.Compare(string(sourcePorts[i].Protocol), string(sourcePorts[j].Protocol)) < 0
-	})
+	sortNamedPort(externalEntity.Spec.Ports)
+	sortNamedPort(sourcePorts)
 	if !reflect.DeepEqual(externalEntity.Spec.Ports, sourcePorts) {
 		externalEntity.Spec.Ports = sourcePorts
 		changed = true
 	}
-	sort.Slice(externalEntity.Spec.Endpoints, func(i, j int) bool {
-		if externalEntity.Spec.Endpoints[i].Name != externalEntity.Spec.Endpoints[j].Name {
-			return strings.Compare(externalEntity.Spec.Endpoints[i].Name, externalEntity.Spec.Endpoints[j].Name) < 0
+
+	sortEndpoint(externalEntity.Spec.Endpoints)
+	sortEndpoint(endpoints)
+	if !reflect.DeepEqual(externalEntity.Spec.Endpoints, endpoints) {
+		externalEntity.Spec.Endpoints = endpoints
+		changed = true
+	}
+
+	return changed
+}
+
+func sortNamedPort(ports []antreatypes.NamedPort) {
+	sort.Slice(ports, func(i, j int) bool {
+		if ports[i].Name != ports[j].Name {
+			return strings.Compare(ports[i].Name, ports[j].Name) < 0
 		}
-		return strings.Compare(externalEntity.Spec.Endpoints[i].IP, externalEntity.Spec.Endpoints[j].IP) < 0
+		if ports[i].Port != ports[j].Port {
+			return ports[i].Port < ports[j].Port
+		}
+		return strings.Compare(string(ports[i].Protocol), string(ports[j].Protocol)) < 0
 	})
+}
+
+func sortEndpoint(endpoints []antreatypes.Endpoint) {
 	sort.Slice(endpoints, func(i, j int) bool {
 		if endpoints[i].Name != endpoints[j].Name {
 			return strings.Compare(endpoints[i].Name, endpoints[j].Name) < 0
 		}
 		return strings.Compare(endpoints[i].IP, endpoints[j].IP) < 0
 	})
-	if !reflect.DeepEqual(externalEntity.Spec.Endpoints, endpoints) {
-		externalEntity.Spec.Endpoints = endpoints
-		changed = true
-	}
-	return changed
 }

--- a/pkg/converter/target/externalnode.go
+++ b/pkg/converter/target/externalnode.go
@@ -86,21 +86,20 @@ func populateExternalNodeFrom(source ExternalNodeSource, externalNode *antreav1a
 			IPs:  ips,
 		})
 	}
-	sort.Slice(externalNode.Spec.Interfaces, func(i, j int) bool {
-		if externalNode.Spec.Interfaces[i].Name == externalNode.Spec.Interfaces[j].Name {
-			return slices.Compare(externalNode.Spec.Interfaces[i].IPs, externalNode.Spec.Interfaces[j].IPs) < 0
-		}
-		return strings.Compare(externalNode.Spec.Interfaces[i].Name, externalNode.Spec.Interfaces[j].Name) < 0
-	})
+	sortNetworkInterface(externalNode.Spec.Interfaces)
+	sortNetworkInterface(networkInterface)
+	if !reflect.DeepEqual(externalNode.Spec.Interfaces, networkInterface) {
+		externalNode.Spec.Interfaces = networkInterface
+		changed = true
+	}
+	return changed
+}
+
+func sortNetworkInterface(networkInterface []antreav1alpha1.NetworkInterface) {
 	sort.Slice(networkInterface, func(i, j int) bool {
 		if networkInterface[i].Name == networkInterface[j].Name {
 			return slices.Compare(networkInterface[i].IPs, networkInterface[j].IPs) < 0
 		}
 		return strings.Compare(networkInterface[i].Name, networkInterface[j].Name) < 0
 	})
-	if !reflect.DeepEqual(externalNode.Spec.Interfaces, networkInterface) {
-		externalNode.Spec.Interfaces = networkInterface
-		changed = true
-	}
-	return changed
 }


### PR DESCRIPTION
Close #109
1. Optimize ExternalEntity patch for not agented and agented.
2. Sort the elements in ExternalEntity to compare if there is an update
3. Update the unit-test
4. Add sorting funcions for sorting NerworkInterface, Endpoint and NamedPort Slices.
