### PR TITLE
Implement account poller restart.

### DIFF
--- a/pkg/cloud-provider/cloudapi/aws/aws_cloudinterface_impl.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_cloudinterface_impl.go
@@ -105,14 +105,14 @@ func (c *awsCloud) GetAccountStatus(accNamespacedName *types.NamespacedName) (*c
 	return c.cloudCommon.GetStatus(accNamespacedName)
 }
 
-// AddInventoryPoller adds poller for polling cloud inventory.
-func (c *awsCloud) AddInventoryPoller(accountNamespacedName *types.NamespacedName) error {
-	return c.cloudCommon.AddInventoryPoller(accountNamespacedName)
+// DoInventoryPoll calls cloud API to get vm and vpc resources.
+func (c *awsCloud) DoInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+	return c.cloudCommon.DoInventoryPoll(accountNamespacedName)
 }
 
-// DeleteInventoryPoller deletes an existing poller created for polling cloud inventory.
-func (c *awsCloud) DeleteInventoryPoller(accountNamespacedName *types.NamespacedName) error {
-	return c.cloudCommon.DeleteInventoryPoller(accountNamespacedName)
+// DeleteInventoryPoll resets cloud snapshot to nil.
+func (c *awsCloud) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+	return c.cloudCommon.DeleteInventoryPoll(accountNamespacedName)
 }
 
 // GetVpcInventory pulls cloud vpc inventory from internal snapshot.

--- a/pkg/cloud-provider/cloudapi/aws/aws_cloudinterface_impl.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_cloudinterface_impl.go
@@ -105,14 +105,14 @@ func (c *awsCloud) GetAccountStatus(accNamespacedName *types.NamespacedName) (*c
 	return c.cloudCommon.GetStatus(accNamespacedName)
 }
 
-// DoInventoryPoll calls cloud API to get vm and vpc resources.
+// DoInventoryPoll calls cloud API to get cloud resources.
 func (c *awsCloud) DoInventoryPoll(accountNamespacedName *types.NamespacedName) error {
 	return c.cloudCommon.DoInventoryPoll(accountNamespacedName)
 }
 
-// DeleteInventoryPoll resets cloud snapshot to nil.
-func (c *awsCloud) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
-	return c.cloudCommon.DeleteInventoryPoll(accountNamespacedName)
+// DeleteInventoryPollCache resets cloud snapshot to nil.
+func (c *awsCloud) DeleteInventoryPollCache(accountNamespacedName *types.NamespacedName) error {
+	return c.cloudCommon.DeleteInventoryPollCache(accountNamespacedName)
 }
 
 // GetVpcInventory pulls cloud vpc inventory from internal snapshot.

--- a/pkg/cloud-provider/cloudapi/aws/aws_security_test.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_security_test.go
@@ -130,6 +130,9 @@ var _ = Describe("AWS Cloud Security", func() {
 		err = cloudInterface.AddAccountResourceSelector(testAccountNamespacedName, selector)
 		Expect(err).Should(BeNil())
 
+		err = cloudInterface.DoInventoryPoll(testAccountNamespacedName)
+		Expect(err).Should(BeNil())
+
 		cloudResourcePrefix := config.DefaultCloudResourcePrefix
 		securitygroup.SetCloudResourcePrefix(&(cloudResourcePrefix))
 

--- a/pkg/cloud-provider/cloudapi/aws/aws_test.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_test.go
@@ -222,7 +222,7 @@ var _ = Describe("AWS cloud", func() {
 				errPolAdd := c.DoInventoryPoll(&testAccountNamespacedName)
 				Expect(errPolAdd).Should(BeNil())
 
-				errPolDel := c.DeleteInventoryPoll(&testAccountNamespacedName)
+				errPolDel := c.DeleteInventoryPollCache(&testAccountNamespacedName)
 				Expect(errPolDel).Should(BeNil())
 
 				mockawsEC2.EXPECT().pagedDescribeInstancesWrapper(gomock.Any()).Return(getEc2InstanceObject(instanceIds), nil).Times(0)

--- a/pkg/cloud-provider/cloudapi/aws/aws_test.go
+++ b/pkg/cloud-provider/cloudapi/aws/aws_test.go
@@ -148,7 +148,7 @@ var _ = Describe("AWS cloud", func() {
 				Expect(found).To(BeTrue())
 				Expect(accCfg).To(Not(BeNil()))
 
-				errPolAdd := c.AddInventoryPoller(&testAccountNamespacedName)
+				errPolAdd := c.DoInventoryPoll(&testAccountNamespacedName)
 				Expect(errPolAdd).Should(BeNil())
 
 				err = checkVpcPollResult(c, testAccountNamespacedName, vpcIDs)
@@ -183,7 +183,7 @@ var _ = Describe("AWS cloud", func() {
 				Expect(found).To(BeTrue())
 				Expect(accCfg).To(Not(BeNil()))
 
-				errPolAdd := c.AddInventoryPoller(&testAccountNamespacedName)
+				errPolAdd := c.DoInventoryPoll(&testAccountNamespacedName)
 				Expect(errPolAdd).Should(BeNil())
 
 				vpcMap, err := c.GetVpcInventory(&testAccountNamespacedName)
@@ -219,10 +219,10 @@ var _ = Describe("AWS cloud", func() {
 				Expect(found).To(BeTrue())
 				Expect(accCfg).To(Not(BeNil()))
 
-				errPolAdd := c.AddInventoryPoller(&testAccountNamespacedName)
+				errPolAdd := c.DoInventoryPoll(&testAccountNamespacedName)
 				Expect(errPolAdd).Should(BeNil())
 
-				errPolDel := c.DeleteInventoryPoller(&testAccountNamespacedName)
+				errPolDel := c.DeleteInventoryPoll(&testAccountNamespacedName)
 				Expect(errPolDel).Should(BeNil())
 
 				mockawsEC2.EXPECT().pagedDescribeInstancesWrapper(gomock.Any()).Return(getEc2InstanceObject(instanceIds), nil).Times(0)
@@ -262,6 +262,9 @@ var _ = Describe("AWS cloud", func() {
 				errSelAdd := c.AddAccountResourceSelector(&testAccountNamespacedName, selector)
 				Expect(errSelAdd).Should(BeNil())
 
+				err = c.DoInventoryPoll(&testAccountNamespacedName)
+				Expect(err).Should(BeNil())
+
 				err = checkAccountAddSuccessCondition(c, testAccountNamespacedName, instanceIds)
 				Expect(err).Should(BeNil())
 			})
@@ -295,6 +298,9 @@ var _ = Describe("AWS cloud", func() {
 				errSelAdd := c.AddAccountResourceSelector(&testAccountNamespacedName, selector)
 				Expect(errSelAdd).Should(BeNil())
 
+				err = c.DoInventoryPoll(&testAccountNamespacedName)
+				Expect(err).Should(BeNil())
+
 				err = checkAccountAddSuccessCondition(c, testAccountNamespacedName, instanceIds)
 				Expect(err).Should(BeNil())
 			})
@@ -315,6 +321,9 @@ var _ = Describe("AWS cloud", func() {
 
 				errSelAdd := c.AddAccountResourceSelector(&testAccountNamespacedName, selector)
 				Expect(errSelAdd).Should(BeNil())
+
+				err = c.DoInventoryPoll(&testAccountNamespacedName)
+				Expect(err).Should(BeNil())
 
 				err = checkAccountAddSuccessCondition(c, testAccountNamespacedName, instanceIds)
 				Expect(err).Should(BeNil())

--- a/pkg/cloud-provider/cloudapi/azure/azure_cloudinterface_impl.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_cloudinterface_impl.go
@@ -105,14 +105,14 @@ func (c *azureCloud) GetAccountStatus(accNamespacedName *types.NamespacedName) (
 	return c.cloudCommon.GetStatus(accNamespacedName)
 }
 
-// DoInventoryPoll calls cloud API to get vm and vpc resources.
+// DoInventoryPoll calls cloud API to get cloud resources.
 func (c *azureCloud) DoInventoryPoll(accountNamespacedName *types.NamespacedName) error {
 	return c.cloudCommon.DoInventoryPoll(accountNamespacedName)
 }
 
-// DeleteInventoryPoll resets cloud snapshot to nil.
-func (c *azureCloud) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
-	return c.cloudCommon.DeleteInventoryPoll(accountNamespacedName)
+// DeleteInventoryPollCache resets cloud snapshot to nil.
+func (c *azureCloud) DeleteInventoryPollCache(accountNamespacedName *types.NamespacedName) error {
+	return c.cloudCommon.DeleteInventoryPollCache(accountNamespacedName)
 }
 
 // GetVpcInventory pulls cloud vpc inventory from internal snapshot.

--- a/pkg/cloud-provider/cloudapi/azure/azure_cloudinterface_impl.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_cloudinterface_impl.go
@@ -105,14 +105,14 @@ func (c *azureCloud) GetAccountStatus(accNamespacedName *types.NamespacedName) (
 	return c.cloudCommon.GetStatus(accNamespacedName)
 }
 
-// AddInventoryPoller adds poller for polling cloud inventory.
-func (c *azureCloud) AddInventoryPoller(accountNamespacedName *types.NamespacedName) error {
-	return c.cloudCommon.AddInventoryPoller(accountNamespacedName)
+// DoInventoryPoll calls cloud API to get vm and vpc resources.
+func (c *azureCloud) DoInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+	return c.cloudCommon.DoInventoryPoll(accountNamespacedName)
 }
 
-// DeleteInventoryPoller deletes an existing poller created for polling cloud inventory.
-func (c *azureCloud) DeleteInventoryPoller(accountNamespacedName *types.NamespacedName) error {
-	return c.cloudCommon.DeleteInventoryPoller(accountNamespacedName)
+// DeleteInventoryPoll resets cloud snapshot to nil.
+func (c *azureCloud) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+	return c.cloudCommon.DeleteInventoryPoll(accountNamespacedName)
 }
 
 // GetVpcInventory pulls cloud vpc inventory from internal snapshot.

--- a/pkg/cloud-provider/cloudapi/azure/azure_test.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Azure", func() {
 				Expect(found).To(BeTrue())
 				Expect(accCfg).To(Not(BeNil()))
 
-				errPolAdd := c.AddInventoryPoller(testAccountNamespacedName)
+				errPolAdd := c.DoInventoryPoll(testAccountNamespacedName)
 				Expect(errPolAdd).Should(BeNil())
 
 				vnetMap, err := c.GetVpcInventory(testAccountNamespacedName)
@@ -213,9 +213,9 @@ var _ = Describe("Azure", func() {
 				Expect(found).To(BeTrue())
 				Expect(accCfg).To(Not(BeNil()))
 
-				errPolAdd := c.AddInventoryPoller(testAccountNamespacedName)
+				errPolAdd := c.DoInventoryPoll(testAccountNamespacedName)
 				Expect(errPolAdd).Should(BeNil())
-				errPolDel := c.DeleteInventoryPoller(testAccountNamespacedName)
+				errPolDel := c.DeleteInventoryPoll(testAccountNamespacedName)
 				Expect(errPolDel).Should(BeNil())
 				mockazureVirtualNetworksWrapper.EXPECT().listAllComplete(gomock.Any()).Return(createVnetObject(vnetIDs), nil).MinTimes(0)
 			})

--- a/pkg/cloud-provider/cloudapi/azure/azure_test.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Azure", func() {
 
 				errPolAdd := c.DoInventoryPoll(testAccountNamespacedName)
 				Expect(errPolAdd).Should(BeNil())
-				errPolDel := c.DeleteInventoryPoll(testAccountNamespacedName)
+				errPolDel := c.DeleteInventoryPollCache(testAccountNamespacedName)
 				Expect(errPolDel).Should(BeNil())
 				mockazureVirtualNetworksWrapper.EXPECT().listAllComplete(gomock.Any()).Return(createVnetObject(vnetIDs), nil).MinTimes(0)
 			})

--- a/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
@@ -96,18 +96,18 @@ func (mr *MockCloudInterfaceMockRecorder) CreateSecurityGroup(securityGroupIdent
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockCloudInterface)(nil).CreateSecurityGroup), securityGroupIdentifier, membershipOnly)
 }
 
-// DeleteInventoryPoll mocks base method.
-func (m *MockCloudInterface) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+// DeleteInventoryPollCache mocks base method.
+func (m *MockCloudInterface) DeleteInventoryPollCache(accountNamespacedName *types.NamespacedName) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteInventoryPoll", accountNamespacedName)
+	ret := m.ctrl.Call(m, "DeleteInventoryPollCache", accountNamespacedName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteInventoryPoll indicates an expected call of DeleteInventoryPoll.
-func (mr *MockCloudInterfaceMockRecorder) DeleteInventoryPoll(accountNamespacedName interface{}) *gomock.Call {
+// DeleteInventoryPollCache indicates an expected call of DeleteInventoryPollCache.
+func (mr *MockCloudInterfaceMockRecorder) DeleteInventoryPollCache(accountNamespacedName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryPoll", reflect.TypeOf((*MockCloudInterface)(nil).DeleteInventoryPoll), accountNamespacedName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryPollCache", reflect.TypeOf((*MockCloudInterface)(nil).DeleteInventoryPollCache), accountNamespacedName)
 }
 
 // DeleteSecurityGroup mocks base method.
@@ -329,18 +329,18 @@ func (mr *MockAccountMgmtInterfaceMockRecorder) AddProviderAccount(client, accou
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProviderAccount", reflect.TypeOf((*MockAccountMgmtInterface)(nil).AddProviderAccount), client, account)
 }
 
-// DeleteInventoryPoll mocks base method.
-func (m *MockAccountMgmtInterface) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+// DeleteInventoryPollCache mocks base method.
+func (m *MockAccountMgmtInterface) DeleteInventoryPollCache(accountNamespacedName *types.NamespacedName) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteInventoryPoll", accountNamespacedName)
+	ret := m.ctrl.Call(m, "DeleteInventoryPollCache", accountNamespacedName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteInventoryPoll indicates an expected call of DeleteInventoryPoll.
-func (mr *MockAccountMgmtInterfaceMockRecorder) DeleteInventoryPoll(accountNamespacedName interface{}) *gomock.Call {
+// DeleteInventoryPollCache indicates an expected call of DeleteInventoryPollCache.
+func (mr *MockAccountMgmtInterfaceMockRecorder) DeleteInventoryPollCache(accountNamespacedName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryPoll", reflect.TypeOf((*MockAccountMgmtInterface)(nil).DeleteInventoryPoll), accountNamespacedName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryPollCache", reflect.TypeOf((*MockAccountMgmtInterface)(nil).DeleteInventoryPollCache), accountNamespacedName)
 }
 
 // DoInventoryPoll mocks base method.

--- a/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud-mock_test.go
@@ -67,20 +67,6 @@ func (mr *MockCloudInterfaceMockRecorder) AddAccountResourceSelector(accNamespac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAccountResourceSelector", reflect.TypeOf((*MockCloudInterface)(nil).AddAccountResourceSelector), accNamespacedName, selector)
 }
 
-// AddInventoryPoller mocks base method.
-func (m *MockCloudInterface) AddInventoryPoller(accountNamespacedName *types.NamespacedName) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddInventoryPoller", accountNamespacedName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddInventoryPoller indicates an expected call of AddInventoryPoller.
-func (mr *MockCloudInterfaceMockRecorder) AddInventoryPoller(accountNamespacedName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInventoryPoller", reflect.TypeOf((*MockCloudInterface)(nil).AddInventoryPoller), accountNamespacedName)
-}
-
 // AddProviderAccount mocks base method.
 func (m *MockCloudInterface) AddProviderAccount(client client.Client, account *v1alpha1.CloudProviderAccount) error {
 	m.ctrl.T.Helper()
@@ -110,18 +96,18 @@ func (mr *MockCloudInterfaceMockRecorder) CreateSecurityGroup(securityGroupIdent
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockCloudInterface)(nil).CreateSecurityGroup), securityGroupIdentifier, membershipOnly)
 }
 
-// DeleteInventoryPoller mocks base method.
-func (m *MockCloudInterface) DeleteInventoryPoller(accountNamespacedName *types.NamespacedName) error {
+// DeleteInventoryPoll mocks base method.
+func (m *MockCloudInterface) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteInventoryPoller", accountNamespacedName)
+	ret := m.ctrl.Call(m, "DeleteInventoryPoll", accountNamespacedName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteInventoryPoller indicates an expected call of DeleteInventoryPoller.
-func (mr *MockCloudInterfaceMockRecorder) DeleteInventoryPoller(accountNamespacedName interface{}) *gomock.Call {
+// DeleteInventoryPoll indicates an expected call of DeleteInventoryPoll.
+func (mr *MockCloudInterfaceMockRecorder) DeleteInventoryPoll(accountNamespacedName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryPoller", reflect.TypeOf((*MockCloudInterface)(nil).DeleteInventoryPoller), accountNamespacedName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryPoll", reflect.TypeOf((*MockCloudInterface)(nil).DeleteInventoryPoll), accountNamespacedName)
 }
 
 // DeleteSecurityGroup mocks base method.
@@ -136,6 +122,20 @@ func (m *MockCloudInterface) DeleteSecurityGroup(securityGroupIdentifier *securi
 func (mr *MockCloudInterfaceMockRecorder) DeleteSecurityGroup(securityGroupIdentifier, membershipOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockCloudInterface)(nil).DeleteSecurityGroup), securityGroupIdentifier, membershipOnly)
+}
+
+// DoInventoryPoll mocks base method.
+func (m *MockCloudInterface) DoInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DoInventoryPoll", accountNamespacedName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DoInventoryPoll indicates an expected call of DoInventoryPoll.
+func (mr *MockCloudInterfaceMockRecorder) DoInventoryPoll(accountNamespacedName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoInventoryPoll", reflect.TypeOf((*MockCloudInterface)(nil).DoInventoryPoll), accountNamespacedName)
 }
 
 // GetAccountStatus mocks base method.
@@ -315,20 +315,6 @@ func (mr *MockAccountMgmtInterfaceMockRecorder) AddAccountResourceSelector(accNa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAccountResourceSelector", reflect.TypeOf((*MockAccountMgmtInterface)(nil).AddAccountResourceSelector), accNamespacedName, selector)
 }
 
-// AddInventoryPoller mocks base method.
-func (m *MockAccountMgmtInterface) AddInventoryPoller(accountNamespacedName *types.NamespacedName) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddInventoryPoller", accountNamespacedName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddInventoryPoller indicates an expected call of AddInventoryPoller.
-func (mr *MockAccountMgmtInterfaceMockRecorder) AddInventoryPoller(accountNamespacedName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInventoryPoller", reflect.TypeOf((*MockAccountMgmtInterface)(nil).AddInventoryPoller), accountNamespacedName)
-}
-
 // AddProviderAccount mocks base method.
 func (m *MockAccountMgmtInterface) AddProviderAccount(client client.Client, account *v1alpha1.CloudProviderAccount) error {
 	m.ctrl.T.Helper()
@@ -343,18 +329,32 @@ func (mr *MockAccountMgmtInterfaceMockRecorder) AddProviderAccount(client, accou
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProviderAccount", reflect.TypeOf((*MockAccountMgmtInterface)(nil).AddProviderAccount), client, account)
 }
 
-// DeleteInventoryPoller mocks base method.
-func (m *MockAccountMgmtInterface) DeleteInventoryPoller(accountNamespacedName *types.NamespacedName) error {
+// DeleteInventoryPoll mocks base method.
+func (m *MockAccountMgmtInterface) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteInventoryPoller", accountNamespacedName)
+	ret := m.ctrl.Call(m, "DeleteInventoryPoll", accountNamespacedName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteInventoryPoller indicates an expected call of DeleteInventoryPoller.
-func (mr *MockAccountMgmtInterfaceMockRecorder) DeleteInventoryPoller(accountNamespacedName interface{}) *gomock.Call {
+// DeleteInventoryPoll indicates an expected call of DeleteInventoryPoll.
+func (mr *MockAccountMgmtInterfaceMockRecorder) DeleteInventoryPoll(accountNamespacedName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryPoller", reflect.TypeOf((*MockAccountMgmtInterface)(nil).DeleteInventoryPoller), accountNamespacedName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryPoll", reflect.TypeOf((*MockAccountMgmtInterface)(nil).DeleteInventoryPoll), accountNamespacedName)
+}
+
+// DoInventoryPoll mocks base method.
+func (m *MockAccountMgmtInterface) DoInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DoInventoryPoll", accountNamespacedName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DoInventoryPoll indicates an expected call of DoInventoryPoll.
+func (mr *MockAccountMgmtInterfaceMockRecorder) DoInventoryPoll(accountNamespacedName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoInventoryPoll", reflect.TypeOf((*MockAccountMgmtInterface)(nil).DoInventoryPoll), accountNamespacedName)
 }
 
 // GetAccountStatus mocks base method.

--- a/pkg/cloud-provider/cloudapi/common/cloud.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud.go
@@ -65,10 +65,10 @@ type AccountMgmtInterface interface {
 	RemoveAccountResourcesSelector(accNamespacedName *types.NamespacedName, selector string)
 	// GetAccountStatus gets accounts status.
 	GetAccountStatus(accNamespacedName *types.NamespacedName) (*cloudv1alpha1.CloudProviderAccountStatus, error)
-	// DoInventoryPoll calls cloud API to get vm and vpc resources.
+	// DoInventoryPoll calls cloud API to get cloud resources.
 	DoInventoryPoll(accountNamespacedName *types.NamespacedName) error
-	// DeleteInventoryPoll resets cloud snapshot to nil.
-	DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error
+	// DeleteInventoryPollCache resets cloud snapshot to nil.
+	DeleteInventoryPollCache(accountNamespacedName *types.NamespacedName) error
 	// GetVpcInventory gets vpc inventory from internal stored snapshot.
 	GetVpcInventory(accountNamespacedName *types.NamespacedName) (map[string]*runtimev1alpha1.Vpc, error)
 }

--- a/pkg/cloud-provider/cloudapi/common/cloud.go
+++ b/pkg/cloud-provider/cloudapi/common/cloud.go
@@ -65,10 +65,10 @@ type AccountMgmtInterface interface {
 	RemoveAccountResourcesSelector(accNamespacedName *types.NamespacedName, selector string)
 	// GetAccountStatus gets accounts status.
 	GetAccountStatus(accNamespacedName *types.NamespacedName) (*cloudv1alpha1.CloudProviderAccountStatus, error)
-	// AddInventoryPoller kicks start a periodic cloud inventory polling.
-	AddInventoryPoller(accountNamespacedName *types.NamespacedName) error
-	// DeleteInventoryPoller stops cloud inventory polling.
-	DeleteInventoryPoller(accountNamespacedName *types.NamespacedName) error
+	// DoInventoryPoll calls cloud API to get vm and vpc resources.
+	DoInventoryPoll(accountNamespacedName *types.NamespacedName) error
+	// DeleteInventoryPoll resets cloud snapshot to nil.
+	DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error
 	// GetVpcInventory gets vpc inventory from internal stored snapshot.
 	GetVpcInventory(accountNamespacedName *types.NamespacedName) (map[string]*runtimev1alpha1.Vpc, error)
 }

--- a/pkg/cloud-provider/cloudapi/internal/accounts_common.go
+++ b/pkg/cloud-provider/cloudapi/internal/accounts_common.go
@@ -33,7 +33,7 @@ type CloudAccountInterface interface {
 	GetStatus() *cloudv1alpha1.CloudProviderAccountStatus
 
 	performInventorySync() error
-	resetInventorySync()
+	resetInventorySyncCache()
 }
 
 type cloudAccountConfig struct {
@@ -218,7 +218,7 @@ func (accCfg *cloudAccountConfig) GetStatus() *cloudv1alpha1.CloudProviderAccoun
 	return accCfg.Status
 }
 
-func (accCfg *cloudAccountConfig) resetInventorySync() {
+func (accCfg *cloudAccountConfig) resetInventorySyncCache() {
 	for _, serviceConfig := range accCfg.serviceConfigs {
 		serviceConfig.resetCachedState()
 	}

--- a/pkg/cloud-provider/cloudapi/internal/accounts_common.go
+++ b/pkg/cloud-provider/cloudapi/internal/accounts_common.go
@@ -17,11 +17,9 @@ package internal
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cloudv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
@@ -34,19 +32,17 @@ type CloudAccountInterface interface {
 	GetServiceConfigByName(name CloudServiceName) (CloudServiceInterface, error)
 	GetStatus() *cloudv1alpha1.CloudProviderAccountStatus
 
-	startPeriodicInventorySync() error
-	stopPeriodicInventorySync()
+	performInventorySync() error
+	resetInventorySync()
 }
 
 type cloudAccountConfig struct {
-	mutex                 sync.Mutex
-	namespacedName        *types.NamespacedName
-	credentials           interface{}
-	serviceConfigs        map[CloudServiceName]*CloudServiceCommon
-	inventoryPollInterval time.Duration
-	inventoryChannel      chan struct{}
-	logger                func() logging.Logger
-	Status                *cloudv1alpha1.CloudProviderAccountStatus
+	mutex          sync.Mutex
+	namespacedName *types.NamespacedName
+	credentials    interface{}
+	serviceConfigs map[CloudServiceName]*CloudServiceCommon
+	logger         func() logging.Logger
+	Status         *cloudv1alpha1.CloudProviderAccountStatus
 }
 
 type CloudCredentialValidatorFunc func(client client.Client, credentials interface{}) (interface{}, error)
@@ -55,7 +51,7 @@ type CloudServiceConfigCreatorFunc func(namespacedName *types.NamespacedName, cl
 	helper interface{}) ([]CloudServiceInterface, error)
 
 func (c *cloudCommon) newCloudAccountConfig(client client.Client, namespacedName *types.NamespacedName, credentials interface{},
-	pollInterval time.Duration, loggerFunc func() logging.Logger) (CloudAccountInterface, error) {
+	loggerFunc func() logging.Logger) (CloudAccountInterface, error) {
 	credentialsValidatorFunc := c.commonHelper.SetAccountCredentialsFunc()
 	if credentialsValidatorFunc == nil {
 		return nil, fmt.Errorf("registered cloud-credentials validator function cannot be nil")
@@ -86,12 +82,11 @@ func (c *cloudCommon) newCloudAccountConfig(client client.Client, namespacedName
 
 	status := &cloudv1alpha1.CloudProviderAccountStatus{}
 	return &cloudAccountConfig{
-		logger:                loggerFunc,
-		namespacedName:        namespacedName,
-		inventoryPollInterval: pollInterval,
-		serviceConfigs:        serviceConfigMap,
-		credentials:           cloudConvertedCredential,
-		Status:                status,
+		logger:         loggerFunc,
+		namespacedName: namespacedName,
+		serviceConfigs: serviceConfigMap,
+		credentials:    cloudConvertedCredential,
+		Status:         status,
 	}, nil
 }
 
@@ -181,8 +176,9 @@ func (accCfg *cloudAccountConfig) performInventorySync() error {
 
 			err := serviceCfg.doResourceInventory()
 			if err != nil {
-				// set the error status to be used later in `cloudprovideraccount` CR.
+				// set the error status to be used later in `CloudProviderAccount` CR.
 				accCfg.Status.Error = err.Error()
+				ch <- err
 			}
 			inventoryStats := serviceCfg.getInventoryStats()
 			inventoryStats.UpdateInventoryPollStats(err)
@@ -195,7 +191,6 @@ func (accCfg *cloudAccountConfig) performInventorySync() error {
 			err = multierr.Append(err, e)
 		}
 	}
-
 	return err
 }
 
@@ -223,35 +218,7 @@ func (accCfg *cloudAccountConfig) GetStatus() *cloudv1alpha1.CloudProviderAccoun
 	return accCfg.Status
 }
 
-func (accCfg *cloudAccountConfig) startPeriodicInventorySync() error {
-	err := accCfg.performInventorySync()
-	if err != nil {
-		return err
-	}
-
-	accCfg.mutex.Lock()
-	defer accCfg.mutex.Unlock()
-
-	if accCfg.inventoryChannel == nil {
-		ch := make(chan struct{})
-		condFunc := func() (bool, error) {
-			_ = accCfg.performInventorySync()
-			return false, nil
-		}
-		// nolint:errcheck
-		go wait.PollUntil(accCfg.inventoryPollInterval, condFunc, ch)
-		accCfg.inventoryChannel = ch
-	}
-
-	return err
-}
-
-func (accCfg *cloudAccountConfig) stopPeriodicInventorySync() {
-	if accCfg.inventoryChannel != nil {
-		close(accCfg.inventoryChannel)
-		accCfg.inventoryChannel = nil
-	}
-
+func (accCfg *cloudAccountConfig) resetInventorySync() {
 	for _, serviceConfig := range accCfg.serviceConfigs {
 		serviceConfig.resetCachedState()
 	}

--- a/pkg/cloud-provider/cloudapi/internal/cloud_common.go
+++ b/pkg/cloud-provider/cloudapi/internal/cloud_common.go
@@ -58,7 +58,7 @@ type CloudCommonInterface interface {
 
 	DoInventoryPoll(accountNamespacedName *types.NamespacedName) error
 
-	DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error
+	DeleteInventoryPollCache(accountNamespacedName *types.NamespacedName) error
 
 	GetVpcInventory(accountNamespacedName *types.NamespacedName) (map[string]*runtimev1alpha1.Vpc, error)
 }
@@ -237,14 +237,14 @@ func (c *cloudCommon) DoInventoryPoll(accountNamespacedName *types.NamespacedNam
 	return nil
 }
 
-// DeleteInventoryPoll resets cloud snapshot to nil.
-func (c *cloudCommon) DeleteInventoryPoll(accountNamespacedName *types.NamespacedName) error {
+// DeleteInventoryPollCache resets cloud snapshot to nil.
+func (c *cloudCommon) DeleteInventoryPollCache(accountNamespacedName *types.NamespacedName) error {
 	accCfg, found := c.GetCloudAccountByName(accountNamespacedName)
 	if !found {
 		return fmt.Errorf("unable to find cloud account %v", *accountNamespacedName)
 	}
 
-	accCfg.resetInventorySync()
+	accCfg.resetInventorySyncCache()
 	return nil
 }
 

--- a/pkg/controllers/cloud/account_poller_test.go
+++ b/pkg/controllers/cloud/account_poller_test.go
@@ -156,5 +156,34 @@ var _ = Describe("Account poller", func() {
 			Expect(accPoller).To(Not(BeNil()))
 			Expect(exists).To(BeTrue())
 		})
+		It("Account poller restart", func() {
+			_ = fakeClient.Create(context.Background(), secret)
+			_ = fakeClient.Create(context.Background(), account)
+
+			accountCloudType, err := utils.GetAccountProviderType(account)
+			Expect(err).ShouldNot(HaveOccurred())
+			accPoller, exists := reconciler.Poller.addAccountPoller(accountCloudType, &testAccountNamespacedName, account, reconciler)
+			Expect(accPoller).To(Not(BeNil()))
+			Expect(exists).To(BeFalse())
+
+			err = reconciler.Poller.RestartAccountPoller(&testAccountNamespacedName)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Account poller not available during restart", func() {
+			_ = fakeClient.Create(context.Background(), secret)
+			_ = fakeClient.Create(context.Background(), account)
+
+			accountCloudType, err := utils.GetAccountProviderType(account)
+			Expect(err).ShouldNot(HaveOccurred())
+			accPoller, exists := reconciler.Poller.addAccountPoller(accountCloudType, &testAccountNamespacedName, account, reconciler)
+			Expect(accPoller).To(Not(BeNil()))
+			Expect(exists).To(BeFalse())
+
+			err = reconciler.Poller.removeAccountPoller(&testAccountNamespacedName)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = reconciler.Poller.RestartAccountPoller(&testAccountNamespacedName)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring(errorMsgAccountPollerNotFound))
+		})
 	})
 })

--- a/pkg/controllers/cloud/account_poller_test.go
+++ b/pkg/controllers/cloud/account_poller_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Account poller", func() {
 			Expect(accPoller).To(Not(BeNil()))
 			Expect(exists).To(BeFalse())
 
-			err = reconciler.Poller.RestartAccountPoller(&testAccountNamespacedName)
+			err = reconciler.Poller.restartAccountPoller(&testAccountNamespacedName)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("Account poller not available during restart", func() {
@@ -181,7 +181,7 @@ var _ = Describe("Account poller", func() {
 
 			err = reconciler.Poller.removeAccountPoller(&testAccountNamespacedName)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = reconciler.Poller.RestartAccountPoller(&testAccountNamespacedName)
+			err = reconciler.Poller.restartAccountPoller(&testAccountNamespacedName)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(errorMsgAccountPollerNotFound))
 		})

--- a/pkg/controllers/cloud/cloudentityselector_controller.go
+++ b/pkg/controllers/cloud/cloudentityselector_controller.go
@@ -136,6 +136,7 @@ func (r *CloudEntitySelectorReconciler) updatePendingSyncCountAndStatus() {
 func (r *CloudEntitySelectorReconciler) processCreateOrUpdate(selector *cloudv1alpha1.CloudEntitySelector,
 	selectorNamespacedName *types.NamespacedName) error {
 	r.Log.Info("Received request", "selector", selectorNamespacedName, "operation", "create/update")
+
 	accountNamespacedName := &types.NamespacedName{
 		Namespace: selector.Namespace,
 		Name:      selector.Spec.AccountName,
@@ -151,24 +152,32 @@ func (r *CloudEntitySelectorReconciler) processCreateOrUpdate(selector *cloudv1a
 	}
 
 	r.selectorToAccountMap[*selectorNamespacedName] = *accountNamespacedName
+
+	callCESDelete := false
+	defer func() {
+		if callCESDelete {
+			_ = r.processDelete(selectorNamespacedName)
+		}
+	}()
+
 	err = cloudInterface.AddAccountResourceSelector(accountNamespacedName, selector)
 	if err != nil {
 		r.Log.Info(errorMsgSelectorAddFail, "selector", selectorNamespacedName, "error", err)
-		_ = r.processDelete(selectorNamespacedName)
+		callCESDelete = true
 		return fmt.Errorf("%s %s, err: %v", errorMsgSelectorAddFail, selectorNamespacedName.Name, err)
 	}
 
 	err = r.Poller.updateAccountPoller(accountNamespacedName, selector)
 	if err != nil {
 		r.Log.Info(errorMsgSelectorAddFail, "selector", selectorNamespacedName, "error", err)
-		_ = r.processDelete(selectorNamespacedName)
+		callCESDelete = true
 		return err
 	}
 
-	err = r.Poller.RestartAccountPoller(accountNamespacedName)
+	err = r.Poller.restartAccountPoller(accountNamespacedName)
 	if err != nil {
 		r.Log.Info(errorMsgSelectorAddFail, "selector", selectorNamespacedName, "error", err)
-		_ = r.processDelete(selectorNamespacedName)
+		callCESDelete = true
 		return err
 	}
 
@@ -177,6 +186,7 @@ func (r *CloudEntitySelectorReconciler) processCreateOrUpdate(selector *cloudv1a
 
 func (r *CloudEntitySelectorReconciler) processDelete(selectorNamespacedName *types.NamespacedName) error {
 	r.Log.Info("Received request", "selector", selectorNamespacedName, "operation", "delete")
+
 	accountNamespacedName, found := r.selectorToAccountMap[*selectorNamespacedName]
 	if !found {
 		return fmt.Errorf("%s %s", errorMsgSelectorAccountMapNotFound, selectorNamespacedName.String())
@@ -195,6 +205,10 @@ func (r *CloudEntitySelectorReconciler) processDelete(selectorNamespacedName *ty
 	}
 
 	cloudInterface.RemoveAccountResourcesSelector(&tempAccountNamespacedName, selectorNamespacedName.Name)
+
+	if err := r.Poller.restartAccountPoller(&tempAccountNamespacedName); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/controllers/cloud/cloudprovideraccount_controller.go
+++ b/pkg/controllers/cloud/cloudprovideraccount_controller.go
@@ -144,15 +144,10 @@ func (r *CloudProviderAccountReconciler) processCreate(namespacedName *types.Nam
 		return fmt.Errorf("%s, err: %v", errorMsgAccountAddFail, err)
 	}
 
-	accPoller, preExists := r.Poller.addAccountPoller(accountCloudType, namespacedName, account, r)
+	accPoller, exists := r.Poller.addAccountPoller(accountCloudType, namespacedName, account, r)
 
-	if !preExists {
-		err = cloudInterface.AddInventoryPoller(namespacedName)
-		if err != nil {
-			_ = r.Poller.removeAccountPoller(namespacedName)
-			return err
-		}
-		go wait.Until(accPoller.doAccountPoller, time.Duration(accPoller.pollIntvInSeconds)*time.Second, accPoller.ch)
+	if !exists {
+		go wait.Until(accPoller.doAccountPolling, time.Duration(accPoller.pollIntvInSeconds)*time.Second, accPoller.ch)
 	} else {
 		err = r.Poller.RestartAccountPoller(namespacedName)
 		if err != nil {
@@ -181,7 +176,8 @@ func (r *CloudProviderAccountReconciler) processDelete(namespacedName *types.Nam
 	if err != nil {
 		return err
 	}
-	err = cloudInterface.DeleteInventoryPoller(namespacedName)
+
+	err = cloudInterface.DeleteInventoryPoll(namespacedName)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/cloud/cloudprovideraccount_controller.go
+++ b/pkg/controllers/cloud/cloudprovideraccount_controller.go
@@ -153,6 +153,11 @@ func (r *CloudProviderAccountReconciler) processCreate(namespacedName *types.Nam
 			return err
 		}
 		go wait.Until(accPoller.doAccountPoller, time.Duration(accPoller.pollIntvInSeconds)*time.Second, accPoller.ch)
+	} else {
+		err = r.Poller.RestartAccountPoller(namespacedName)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -164,6 +169,7 @@ func (r *CloudProviderAccountReconciler) processDelete(namespacedName *types.Nam
 	if err != nil {
 		return err
 	}
+	r.Log.V(1).Info("removed account poller", "account", namespacedName.String())
 
 	err = r.Inventory.DeleteVpcCache(namespacedName)
 	if err != nil {

--- a/test/integration/cloudresource_e2e_test.go
+++ b/test/integration/cloudresource_e2e_test.go
@@ -753,18 +753,18 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Cloud Resources", focusAws
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		// change ces to only select a subset of VMs.
+		By("Change CES selector to import only a subset of VMs")
 		entityParams := cloudVPC.GetEntitySelectorParameters("test-entity-selector"+namespace.Name, namespace.Name, kind, ids[:vmCount])
 		err = utils.ConfigureEntitySelectorAndWait(kubeCtl, k8sClient, entityParams, kind, vmCount, namespace.Name, false)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Check vmp after vm change")
+		By("Check VMPs after importing subset of VMs")
 		err = utils.CheckVirtualMachinePolicies(k8sClient, namespace.Name, vmCount)
 		Expect(err).ToNot(HaveOccurred())
 
-		// change ces back for cleanup check.
+		By("Revert CES selector to import all VMS")
 		entityParams = cloudVPC.GetEntitySelectorParameters("test-entity-selector"+namespace.Name, namespace.Name, kind, nil)
-		err = utils.ConfigureEntitySelectorAndWait(kubeCtl, k8sClient, entityParams, kind, vmCount, namespace.Name, false)
+		err = utils.ConfigureEntitySelectorAndWait(kubeCtl, k8sClient, entityParams, kind, len(cloudVPC.GetVMs()), namespace.Name, false)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/test/utils/helpers.go
+++ b/test/utils/helpers.go
@@ -270,7 +270,7 @@ func ConfigureEntitySelectorAndWait(kubeCtl *KubeCtl, k8sClient client.Client, p
 		}
 		return false, fmt.Errorf("unknown kind %v", kind)
 	}); err != nil {
-		return fmt.Errorf("failed to get cloud resources %s(%d) in namespace %s: %w", kind, num, namespace, err)
+		return fmt.Errorf("failed to get cloud resources %s, expected count %d, namespace %s: %w", kind, num, namespace, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Account poller is created as part of CPA add. It is scheduled to run every poll interval(configurable in CPA CR).
On CES add/CES update/CPA update, it is a good idea to restart the goroutine in order to import fresh set of cloud inventory matching the new configuration without waiting for next execution of goroutine.

Using lock based mechanism to control the execution of goroutine, making sure at any point of time there is only one account poller goroutine running for an account.