### PR TITLE
Update description field in cloud security rule

### DIFF
--- a/pkg/cloud-provider/cloudapi/azure/azure_asg.go
+++ b/pkg/cloud-provider/cloudapi/azure/azure_asg.go
@@ -55,6 +55,7 @@ func createOrGetApplicationSecurityGroup(asgAPIClient azureAsgWrapper, location 
 	return strings.ToLower(*asg.ID), nil
 }
 
+// getNepheControllerCreatedAsgByNameForResourceGroup returns AT and AG ASGs from a resource group.
 func getNepheControllerCreatedAsgByNameForResourceGroup(asgAPIClient azureAsgWrapper,
 	rgName string) (map[string]network.ApplicationSecurityGroup, map[string]network.ApplicationSecurityGroup, error) {
 	applicationSecurityGroups, err := asgAPIClient.listComplete(context.Background(), rgName)


### PR DESCRIPTION
Each cloud security rule created by nephe will have ANP name, ANP namespace and an AppliedToGroup field.

Ignore any rules which don't have a description field or  have an invalid description field.
    
Signed-off-by: Anand Kumar <kumaranand@vmware.com>