### PR TITLE
early exit on update rules when no rules to update

### DIFF
--- a/pkg/controllers/cloud/networkpolicy_pendingitem.go
+++ b/pkg/controllers/cloud/networkpolicy_pendingitem.go
@@ -245,20 +245,6 @@ func (p *pendingGroup) RunOrDeletePendingItem(id string, context interface{}) (r
 func (p *pendingGroup) ClearPendingState() {}
 
 func (s *securityGroupImpl) runPendingItemImpl(c cloudSecurityGroup, memberOnly bool, r *NetworkPolicyReconciler) bool {
-	if s.retryOp == nil {
-		// retry operation successful. Reconcile current group with
-		// plug-ing
-		if s.state != securityGroupStateGarbageCollectState {
-			if ag, ok := c.(*appliedToSecurityGroup); ok {
-				ag.hasMembers = false
-				_ = ag.updateAllRules(r)
-			} else {
-				_ = s.updateImpl(c, nil, nil, memberOnly, r)
-			}
-		}
-		return true
-	}
-
 	op := *s.retryOp
 	s.retryOp = nil
 	var err error
@@ -285,7 +271,7 @@ func (s *securityGroupImpl) RunOrDeletePendingItem(id string, context interface{
 	r := context.(*NetworkPolicyReconciler)
 	log := r.Log.WithName("RetryingSecurityGroup")
 	if s.retryOp == nil {
-		run = true
+		run = false
 		delete = true
 	} else if s.retryInProgress {
 		run = false

--- a/pkg/controllers/cloud/networkpolicy_sync.go
+++ b/pkg/controllers/cloud/networkpolicy_sync.go
@@ -249,10 +249,10 @@ func (a *appliedToSecurityGroup) sync(syncContent *securitygroup.Synchronization
 
 	// rule machines
 	if len(nps) > 0 {
-		if !a.hasRules {
+		if !a.ruleReady {
 			a.markDirty(r, false)
 		}
-		a.hasRules = true
+		a.ruleReady = true
 	}
 }
 

--- a/pkg/controllers/cloud/networkpolicy_test.go
+++ b/pkg/controllers/cloud/networkpolicy_test.go
@@ -1165,7 +1165,7 @@ var _ = Describe("NetworkPolicy", func() {
 				},
 				{
 					sgRuleNoOrder:     true,
-					addrSgMemberTimes: 2,
+					addrSgMemberTimes: 1,
 					appSgMemberTimes:  1,
 					appSgRuleTimes:    2,
 					sgCreateTimes:     1,
@@ -1186,8 +1186,8 @@ var _ = Describe("NetworkPolicy", func() {
 				},
 				{
 					sgRuleNoOrder:     true,
-					addrSgMemberTimes: 2,
-					appSgMemberTimes:  2,
+					addrSgMemberTimes: 1,
+					appSgMemberTimes:  1,
 					appSgRuleTimes:    1,
 					sgDeleteTimes:     1,
 				},
@@ -1336,7 +1336,7 @@ var _ = Describe("NetworkPolicy", func() {
 			cloudReturnSameSG: {
 				addrSgMemberTimes: 0,
 				appSgMemberTimes:  0,
-				appSgRuleTimes:    1,
+				appSgRuleTimes:    0,
 				sgCreateTimes:     0,
 			},
 			cloudReturnNoSG: {
@@ -1348,7 +1348,7 @@ var _ = Describe("NetworkPolicy", func() {
 			cloudReturnDiffMemberSG: {
 				addrSgMemberTimes: 1,
 				appSgMemberTimes:  0,
-				appSgRuleTimes:    1,
+				appSgRuleTimes:    0,
 				sgCreateTimes:     0,
 			},
 			cloudReturnDiffRuleSG: {
@@ -1360,7 +1360,7 @@ var _ = Describe("NetworkPolicy", func() {
 			cloudReturnExtraSG: {
 				addrSgMemberTimes: 0,
 				appSgMemberTimes:  0,
-				appSgRuleTimes:    1,
+				appSgRuleTimes:    0,
 				sgCreateTimes:     0,
 			},
 		}


### PR DESCRIPTION
## Description
The current update rules routine proceeds to the cloud plugin level regardless of whether there are any actual updates. With this pull request, a check has been added to exit the routine early when there are no rules that require updating.

## Changes
1. Adds a check to exit updateANPRules func early when no rules to update.
2. Fixed a bug where security group deletion doesn't clean up remaining sg rules in cloudRule indexer.
3. Removed reconcile logic on security group retry success since it serves no purpose and leads to race condition.

Closes #124 