### PR TITLE
Update terraform to deploy VMs with latest version

### DIFF
--- a/hack/terraform/aws/variables.tf
+++ b/hack/terraform/aws/variables.tf
@@ -42,15 +42,15 @@ variable "aws_vm_os_types" {
       name            = "ubuntu-host1"
       login           = "ubuntu"
       init            = "init_script_ubuntu.sh"
-      ami_name_search = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
+      ami_name_search = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
       ami_owner       = "099720109477"
     },
     {
-      name            = "ubuntu-host2"
-      login           = "ubuntu"
-      init            = "init_script_ubuntu.sh"
-      ami_name_search = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
-      ami_owner       = "099720109477"
+      name            = "rhel-host2"
+      login           = "ec2-user"
+      init            = "init_script_rhel.sh"
+      ami_name_search = "RHEL_HA-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2"
+      ami_owner       = "309956199498"
     },
     {
       name            = "amzn-host3"

--- a/hack/terraform/azure/variables.tf
+++ b/hack/terraform/azure/variables.tf
@@ -46,24 +46,24 @@ variable "azure_vm_os_types" {
   }))
   default = [
     {
-      name      = "ubuntu-host"
-      offer     = "UbuntuServer"
-      publisher = "Canonical"
-      sku       = "16.04-LTS"
+      name      = "ubuntu-host1"
+      offer     = "0001-com-ubuntu-server-focal"
+      publisher = "canonical"
+      sku       = "20_04-lts-gen2"
       init      = "init_script_ubuntu.sh"
     },
     {
-      name      = "rhel-host"
+      name      = "rhel-host2"
       offer     = "RHEL"
       publisher = "RedHat"
-      sku       = "8.1-ci"
+      sku       = "91-gen2"
       init      = "init_script_rhel.sh"
     },
     {
-      name      = "centos-host"
+      name      = "centos-host3"
       offer     = "CentOS"
       publisher = "OpenLogic"
-      sku       = "8_1"
+      sku       = "8_5"
       init      = "init_script_centos.sh"
     }
   ]


### PR DESCRIPTION
- deploy ubuntu 20.04, rhel 9.1 and centos 8.5 vms for Azure integration tests.

- deploy ubuntu 20.04, rhel 8.5 and amazon linux vms for AWS integration tests.

- For agented tests only ubunut and rhel vms are supported.