### PR TITLE
Upgrade to kubernetes version 1.25 on AKS/EKS

### DIFF
--- a/ci/jenkins/scripts/install-common.sh
+++ b/ci/jenkins/scripts/install-common.sh
@@ -26,7 +26,7 @@ function install_common_packages() {
     curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
     chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl
 
-    sudo apt-get install -y pv bzip2 jq unzip
+    sudo apt-get install -y pv jq unzip
 
     echo "Installing Terraform ${TERRAFORM_VERSION} version"
     curl -Lo ./terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip

--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -23,7 +23,7 @@
 1. Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v2.3.6+.
 2. Install [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.24+.
 3. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html). Recommend v1.2.2.
-4. Install `jq`, `pv`, and `bzip2`.
+4. Install `jq` and `pv`.
 5. Set the below environment variables.
 
    ```bash

--- a/hack/eks
+++ b/hack/eks
@@ -20,7 +20,7 @@ TERRAFORM="terraform"
 KUBECTL="kubectl"
 RUN_PATH="$HOME/tmp/terraform-eks"
 CONFIG_PATH=$(dirname $(readlink -f "$0"))/terraform/eks
-CMD_ARRAY=($AWS_CLI $TERRAFORM $KUBECTL pv bzip2 jq)
+CMD_ARRAY=($AWS_CLI $TERRAFORM $KUBECTL pv jq)
 ENV_ARRAY=(TF_VAR_eks_cluster_iam_role_name TF_VAR_eks_iam_instance_profile_name TF_VAR_aws_key_pair_name)
 CREATE_ONLY=
 
@@ -110,7 +110,7 @@ function load() {
   nodes=$(KUBECONFIG=$RUN_PATH/kubeconfig kubectl get nodes -o json | jq -r '.items[] | .status | .addresses[] | select(.type == "ExternalIP") |.address')
   for node in $(echo $nodes); do
     echo load $image to $node
-    docker save $image | bzip2 | pv | ssh -oStrictHostKeyChecking=no ec2-user@$node 'docker load'
+    docker save $image | pv | ssh -oStrictHostKeyChecking=no ec2-user@$node 'sudo ctr -n=k8s.io images import -'
   done
 }
 

--- a/hack/terraform/aks/main.tf
+++ b/hack/terraform/aks/main.tf
@@ -91,7 +91,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     type = "SystemAssigned"
   }
 
-  kubernetes_version = "1.23.12"
+  kubernetes_version = "1.25.5"
 
   tags = {
     Environment = "nephe"

--- a/hack/terraform/eks/main.tf
+++ b/hack/terraform/eks/main.tf
@@ -100,7 +100,7 @@ module "eks" {
   version         = "~>17.24.0"
   cluster_name    = local.cluster_name
   subnets         = module.vpc.public_subnets
-  cluster_version = "1.23"
+  cluster_version = "1.25"
 
   tags = {
     Terraform   = "true"


### PR DESCRIPTION
EKS nodes no longer use docker as container runtime. It uses containerd as container run time, similar to AKS