### PR TITLE
fix vmp stuck in-progress when anp has no rules

### DIFF
--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -1593,8 +1593,11 @@ func (n *networkPolicy) markDirty(r *NetworkPolicyReconciler) {
 
 // getStatus returns status of networkPolicy.
 func (n *networkPolicy) getStatus(r *NetworkPolicyReconciler) error {
-	if n.ingressRules == nil && n.egressRules == nil {
-		return &InProgress{}
+	if n.rulesReady {
+		return nil
 	}
-	return n.computeRulesReady(true, r)
+	if err := n.computeRulesReady(true, r); err != nil {
+		return err
+	}
+	return &InProgress{}
 }


### PR DESCRIPTION
## Description
This PR fixes the bug where VMP is stuck in `in-progress` state if an ANP with no rules is applied.

## Changes
1. Rework the np status logic.