### PR TITLE
Restrict any CPA CR operation until CES is synced.

### DIFF
--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -800,6 +800,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - cloudentityselectors
   sideEffects: None
@@ -822,6 +823,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - cloudprovideraccounts
   sideEffects: None

--- a/config/webhook/manifests-new.yaml
+++ b/config/webhook/manifests-new.yaml
@@ -67,6 +67,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+          - DELETE
         resources:
           - cloudentityselectors
     sideEffects: None
@@ -87,6 +88,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+          - DELETE
         resources:
           - cloudprovideraccounts
     sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -71,6 +71,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - cloudentityselectors
   sideEffects: None
@@ -92,6 +93,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - cloudprovideraccounts
   sideEffects: None

--- a/pkg/apiserver/webhook/cloudentityselector_webhook.go
+++ b/pkg/apiserver/webhook/cloudentityselector_webhook.go
@@ -130,7 +130,7 @@ func (v *CESMutator) InjectDecoder(d *admission.Decoder) error {
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // nolint:lll
-// +kubebuilder:webhook:verbs=create;update,path=/validate-crd-cloud-antrea-io-v1alpha1-cloudentityselector,mutating=false,failurePolicy=fail,groups=crd.cloud.antrea.io,resources=cloudentityselectors,versions=v1alpha1,name=vcloudentityselector.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update;delete,path=/validate-crd-cloud-antrea-io-v1alpha1-cloudentityselector,mutating=false,failurePolicy=fail,groups=crd.cloud.antrea.io,resources=cloudentityselectors,versions=v1alpha1,name=vcloudentityselector.kb.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 // CESValidator is used to validate CES object.
 type CESValidator struct {


### PR DESCRIPTION
Since CPA object is a parent of CES object, any operation on the CPA object should not be allowed until CES controller has reconciled all the pending objects (i.e. synced).

Also enable webhook validation for CPA and CES objects on DELETE operation.