### PR TITLE
Remove deprecated actions in github workflow

### DIFF
--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -17,7 +17,7 @@ jobs:
         TAG: ${{ github.ref }}
       run: |
         version=${TAG:10}
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
   build:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -20,30 +20,9 @@ jobs:
       run: |
         mkdir assets
         VERSION="${TAG:10}" ./hack/release/prepare-assets.sh ./assets
-    - name: Upload nephe.yml
-      uses: actions/upload-release-asset@v1
+    - name: Upload all assets
+      uses: alexellis/upload-assets@0.4.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./assets/nephe.yml
-        asset_name: nephe.yml
-        asset_content_type: application/octet-stream
-    - name: Upload install-vm-agent-wrapper.sh
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./assets/install-vm-agent-wrapper.sh
-        asset_name: install-vm-agent-wrapper.sh
-        asset_content_type: application/octet-stream
-    - name: Upload install-vm-agent-wrapper.ps1
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./assets/install-vm-agent-wrapper.ps1
-        asset_name: install-vm-agent-wrapper.ps1
-        asset_content_type: application/octet-stream
+        asset_paths: '["./assets/*"]'

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -22,7 +22,7 @@ jobs:
           echo "$version is a release candidate or a pre-release"
           exit 0
         fi
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
   pr-update-changelog:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
Use alexellis/upload-assets instead of actions/upload-release-asset, which is no longer maintained.

Remove deprecated set-output command.