### PR TITLE
Add checksum annotation on helm deployment yaml

### DIFF
--- a/build/charts/nephe/templates/controller/deployment.yaml
+++ b/build/charts/nephe/templates/controller/deployment.yaml
@@ -12,6 +12,10 @@ spec:
       control-plane: nephe-controller
   template:
     metadata:
+      annotations:
+        # Automatically restart Pod if the ConfigMap changes
+        # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         control-plane: nephe-controller
     spec:


### PR DESCRIPTION
With checksum annotation we can handle pod restart if config map changes between helm charts