### PR TITLE
Add upgrade e2e test with helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,17 @@ $(CONTROLLER_GEN):
 # Run integration-tests
 integration-test-aws:
 	ginkgo -v --timeout=90m --fail-fast --focus=".*test-aws.*" test/integration/ -- \
-	    -manifest-path=../../config/nephe.yml -preserve-setup-on-fail=true -cloud-provider=AWS
+	-manifest-path=../../config/nephe.yml -preserve-setup-on-fail=true -cloud-provider=AWS
 
 integration-test-azure:
 	ginkgo -v --timeout=90m --fail-fast --focus=".*test-azure.*" test/integration/ -- \
-        -manifest-path=../../config/nephe.yml -preserve-setup-on-fail=true -cloud-provider=Azure
+	-manifest-path=../../config/nephe.yml -preserve-setup-on-fail=true -cloud-provider=Azure
+
+# Upgrade tests
+upgrade-test-aws:
+	ginkgo -v --timeout=90m --fail-fast --focus=".*test-aws.*" test/upgrade/ -- \
+	-from-version=0.5.0 -to-version="latest" -chart-dir="../../build/charts/nephe" -preserve-setup-on-fail=false -cloud-provider=AWS
+
+upgrade-test-azure:
+	ginkgo -v --timeout=90m --fail-fast --focus=".*test-azure.*" test/upgrade/ -- \
+	-from-version=0.5.0 -to-version="latest" -chart-dir="../../build/charts/nephe" -preserve-setup-on-fail=true -cloud-provider=Azure

--- a/ci/jenkins/nephe-ci.sh
+++ b/ci/jenkins/nephe-ci.sh
@@ -235,4 +235,15 @@ case $testType in
                                                    --azure-tenant-id ${AZURE_TENANT_ID} --azure-secret ${AZURE_PASSWORD} --owner ${owner} --with-agent \
                                                    --with-agent-windows"
     ;;
+    aws-upgrade)
+    echo "Run upgrade tests on Kind cluster with AWS VMs"
+    ssh -i id_rsa ubuntu@${ip_addr} "cd ~/nephe; ./ci/jenkins/scripts/test-aws.sh --aws-access-key-id ${AWS_ACCESS_KEY_ID} --aws-secret-key ${AWS_ACCESS_KEY_SECRET} \
+                                                   --aws-service-user-role-arn ${AWS_SERVICE_USER_ROLE_ARN} --aws-service-user ${AWS_SERVICE_USER_NAME} --owner ${owner} \
+                                                   --upgrade"
+    ;;
+    azure-upgrade)
+    echo "Run upgrade tests on Kind cluster with Azure VMs"
+    ssh -i id_rsa ubuntu@${ip_addr} "cd ~/nephe; ./ci/jenkins/scripts/test-azure.sh --azure-subscription-id ${AZURE_SUBSCRIPTION_ID} --azure-app-id ${AZURE_APP_ID} \
+                                                   --azure-tenant-id ${AZURE_TENANT_ID} --azure-secret ${AZURE_PASSWORD} --owner ${owner} --upgrade"
+    ;;
  esac

--- a/ci/jenkins/scripts/install-common.sh
+++ b/ci/jenkins/scripts/install-common.sh
@@ -39,6 +39,13 @@ function install_common_packages() {
     sudo rm -rf /usr/local/go && sudo tar -zxf go${GO_VERSION}.linux-amd64.tar.gz -C /usr/local/
     rm go${GO_VERSION}.linux-amd64.tar.gz
     export PATH=$PATH:/usr/local/go/bin
+
+    echo "Installing Helm"
+    curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+    sudo apt-get install apt-transport-https --yes
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+    sudo apt-get update
+    sudo apt-get install helm
 }
 
 function install_kind() {

--- a/hack/build-bin.sh
+++ b/hack/build-bin.sh
@@ -19,3 +19,5 @@ echo "GOBIN=$(pwd)/bin CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go i
 GOBIN=$(pwd)/bin CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go install -ldflags="-s -w" antrea.io/nephe/cmd/...
 echo "CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go test -c antrea.io/nephe/test/integration/ -ldflags="-s -w" -o ./ci/bin/integration.test"
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go test -c antrea.io/nephe/test/integration/ -ldflags="-s -w" -o ./ci/bin/integration.test
+echo "CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go test -c antrea.io/nephe/test/upgrade/ -ldflags="-s -w" -o ./ci/bin/upgrade.test"
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go test -c antrea.io/nephe/test/upgrade/ -ldflags="-s -w" -o ./ci/bin/upgrade.test

--- a/test/upgrade/networkpolicy_e2e_test.go
+++ b/test/upgrade/networkpolicy_e2e_test.go
@@ -1,0 +1,304 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path"
+	"reflect"
+	"time"
+
+	k8stemplates "antrea.io/nephe/test/templates"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
+	"antrea.io/nephe/test/utils"
+)
+
+var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy upgrade test", focusAws, focusAzure), func() {
+	const (
+		apachePort = "8080"
+	)
+	var (
+		namespace      *v1.Namespace
+		accountParams  k8stemplates.CloudAccountParameters
+		anpParams      k8stemplates.ANPParameters
+		anpSetupParams k8stemplates.ANPParameters
+	)
+
+	BeforeEach(func() {
+		if preserveSetupOnFail {
+			preserveSetup = true
+		}
+		// Apply Helm Chart.
+		logf.Log.Info("Installing Helm Chart", "version", fromVersion)
+		err := utils.InstallHelmChart(k8sClient, fromVersion)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		var err error
+		bundleCollected := false
+		result := CurrentSpecReport()
+		if result.Failed() {
+			if len(supportBundleDir) > 0 {
+				logf.Log.Info("Collect support bundles for test failure.")
+				fileName := utils.GenerateNameFromText(result.FullText(), testFocus)
+				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, false, false)
+				bundleCollected = true
+			}
+			if preserveSetupOnFail {
+				logf.Log.V(1).Info("Preserve setup on failure")
+				return
+			}
+		}
+
+		defer func() {
+			if !bundleCollected && err != nil && len(supportBundleDir) > 0 {
+				logf.Log.Info("Collect support bundles for clean-up failure.")
+				fileName := utils.GenerateNameFromText(result.FullText(), testFocus)
+				utils.CollectSupportBundle(kubeCtl, path.Join(supportBundleDir, fileName), cloudVPC, false, false)
+			}
+
+			// Don't delete the chart if preserveSetup is true.
+			if preserveSetup == false {
+				logf.Log.Info("Deleting Helm Chart")
+				err = utils.DeleteHelmChart()
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}()
+
+		// Explicitly remove ANP before delete namespace.
+		err = utils.ConfigureK8s(kubeCtl, anpSetupParams, k8stemplates.CloudAntreaNetworkPolicy, true)
+		Expect(err).ToNot(HaveOccurred())
+		err = utils.ConfigureK8s(kubeCtl, anpParams, k8stemplates.CloudAntreaNetworkPolicy, true)
+		Expect(err).ToNot(HaveOccurred())
+		err = utils.CheckCloudResourceNetworkPolicies(kubeCtl, k8sClient, reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name(), namespace.Name,
+			cloudVPC.GetVMs(), nil, false)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Remove account and secret.
+		err = utils.AddOrRemoveCloudAccount(kubeCtl, accountParams, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Namespace deletion will remove cloud accounts.
+		err = k8sClient.Delete(context.TODO(), namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		time.Sleep(time.Second * 60)
+
+		// Check for Controller restart
+		err = utils.CheckRestart(kubeCtl)
+		Expect(err).ToNot(HaveOccurred(), "controller restart detected.")
+
+		preserveSetup = false
+	})
+
+	setup := func(kind string, num int, allowedPorts []string, denyEgress bool) {
+		namespace = &v1.Namespace{}
+		nss := []*v1.Namespace{namespace}
+		for _, ns := range nss {
+			if ns == nil {
+				continue
+			}
+			var err error
+			if len(ns.Status.Phase) == 0 {
+				// Create ns if not already present.
+				ns.Name = "test-cloud-e2e-" + fmt.Sprintf("%x", rand.Int())
+				ns.Labels = map[string]string{"name": ns.Name}
+				err = k8sClient.Create(context.TODO(), ns)
+				Expect(err).ToNot(HaveOccurred())
+				logf.Log.V(1).Info("Created namespace", "ns", ns.Name)
+			}
+			accountParams = cloudVPC.GetCloudAccountParameters("test-cloud-account"+ns.Name, ns.Name, false)
+			err = utils.AddOrRemoveCloudAccount(kubeCtl, accountParams, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			entityParams := cloudVPC.GetEntitySelectorParameters("test-entity-selector"+ns.Name, ns.Name, kind, nil)
+			entityParams.Agented = false
+			err = utils.ConfigureEntitySelectorAndWait(kubeCtl, k8sClient, entityParams, kind, num, ns.Name, false)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		anpParams = k8stemplates.ANPParameters{
+			Name:      "test-cloud-anp",
+			Namespace: namespace.Name,
+		}
+
+		// Setup policies for all VMs
+		anpSetupParams = k8stemplates.ANPParameters{
+			Name:      "test-cloud-setup-anp",
+			Namespace: namespace.Name,
+		}
+		vmKind := reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()
+		anpSetupParams.AppliedTo = utils.ConfigANPApplyTo(vmKind, "", "", "", "")
+		anpSetupParams.From = utils.ConfigANPToFrom("", "", "", "", "",
+			"0.0.0.0/0", "", allowedPorts, false)
+		if denyEgress {
+			anpSetupParams.To = utils.ConfigANPToFrom("", "", "", "", "", "", "", nil, denyEgress)
+		} else {
+			anpSetupParams.To = utils.ConfigANPToFrom("", "", "", "", "", "0.0.0.0/0", "", nil, false)
+
+		}
+		err := utils.ConfigureK8s(kubeCtl, anpSetupParams, k8stemplates.CloudAntreaNetworkPolicy, false)
+		Expect(err).ToNot(HaveOccurred())
+		err = utils.CheckCloudResourceNetworkPolicies(
+			kubeCtl, k8sClient, vmKind, namespace.Name, cloudVPC.GetVMs(), []string{anpSetupParams.Name}, false,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		oks := make([]bool, len(cloudVPC.GetVMs()))
+		for i := range oks {
+			oks[i] = true
+		}
+		err = utils.ExecuteCmds(cloudVPC, nil, cloudVPC.GetVMs(), "", [][]string{{"ls"}}, oks, 30)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	verifyAppliedTo := func(kind string, ids, ips []string, srcVM, srcIP string, applied []bool) {
+		// Apply ANP and check configuration.
+		err := utils.ConfigureK8s(kubeCtl, anpParams, k8stemplates.CloudAntreaNetworkPolicy, false)
+		Expect(err).ToNot(HaveOccurred())
+		for i, ok := range applied {
+			var np []string
+			if kind == reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name() {
+				np = append(np, anpSetupParams.Name)
+			}
+			if ok {
+				np = append(np, anpParams.Name)
+			}
+			err = utils.CheckCloudResourceNetworkPolicies(kubeCtl, k8sClient, kind, namespace.Name, []string{ids[i]}, np, false)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		appliedIPs := make([]string, 0)
+		notAppliedIPs := make([]string, 0)
+		oks := make([]bool, 0)
+		for i, a := range applied {
+			if ips[i] == srcIP {
+				continue
+			}
+			if a {
+				appliedIPs = append(appliedIPs, ips[i])
+				oks = append(oks, true)
+			} else {
+				notAppliedIPs = append(notAppliedIPs, ips[i])
+			}
+		}
+		if len(appliedIPs) > 0 {
+			err = utils.ExecuteCurlCmds(cloudVPC, nil, []string{srcVM}, "", appliedIPs, apachePort, oks, 30)
+			Expect(err).ToNot(HaveOccurred())
+		}
+		if len(notAppliedIPs) > 0 {
+			oks = make([]bool, len(notAppliedIPs))
+			err = utils.ExecuteCurlCmds(cloudVPC, nil, []string{srcVM}, "", notAppliedIPs, apachePort, oks, 30)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
+	testAppliedTo := func(kind string) {
+		ids := cloudVPC.GetVMs()
+		ips := cloudVPC.GetVMPrivateIPs()
+		setup(kind, len(ids), []string{"22"}, false)
+
+		srcVM := cloudVPC.GetVMs()[0]
+		srcIP := cloudVPC.GetVMPrivateIPs()[0]
+		dstNsName := namespace.Name
+
+		appliedIdx := len(ids) - 1
+		anpParams.From = utils.ConfigANPToFrom(kind, "", "", "", "", "", dstNsName, []string{apachePort}, false)
+
+		By(fmt.Sprintf("Applied NetworkPolicy to %v by kind label selector", kind))
+		applied := make([]bool, len(ids))
+		for i := range applied {
+			applied[i] = true
+		}
+		anpParams.AppliedTo = utils.ConfigANPApplyTo(kind, "", "", "", "")
+		verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
+
+		By(fmt.Sprintf("Applied NetworkPolicy to %v by name label selector", kind))
+		applied = make([]bool, len(ids))
+		applied[appliedIdx] = true
+		anpParams.AppliedTo = utils.ConfigANPApplyTo(kind, ids[appliedIdx], "", "", "")
+		verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
+
+		By(fmt.Sprintf("Applied NetworkPolicy to %v by VPC label selector", kind))
+		for i := range applied {
+			applied[i] = true
+		}
+		anpParams.AppliedTo = utils.ConfigANPApplyTo(kind, "", cloudVPC.GetCRDVPCID(), "", "")
+		verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
+
+		By(fmt.Sprintf("Applied NetworkPolicy to %v by tag label selector", kind))
+		applied = make([]bool, len(ids))
+		applied[appliedIdx] = true
+		key := "Name"
+		if value, found := cloudVPC.GetTags()[appliedIdx][key]; found {
+			anpParams.AppliedTo = utils.ConfigANPApplyTo(kind, "", "", key, value)
+			verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
+		}
+	}
+
+	DescribeTable("AppliedTo Before Upgrade",
+		func(kind string) {
+			testAppliedTo(kind)
+		},
+		Entry("VM In Same Namespace",
+			reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()),
+	)
+
+	DescribeTable("AppliedTo After Upgrade",
+		func(kind string) {
+			By(fmt.Sprintf("Upgrading Helm Chart to %s.", toVersion))
+			err := utils.UpgradeHelmChart(k8sClient, toVersion, chartDir)
+			Expect(err).ToNot(HaveOccurred())
+			By("Test AppliedTo after upgrade.")
+			testAppliedTo(kind)
+		},
+		Entry("VM In Same Namespace",
+			reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()),
+	)
+
+	DescribeTable("AppliedTo Upgrade with ANPs configured",
+		func(kind string) {
+			ids := cloudVPC.GetVMs()
+			ips := cloudVPC.GetVMPrivateIPs()
+			setup(kind, len(ids), []string{"22"}, false)
+
+			srcVM := cloudVPC.GetVMs()[0]
+			srcIP := cloudVPC.GetVMPrivateIPs()[0]
+			dstNsName := namespace.Name
+			anpParams.From = utils.ConfigANPToFrom(kind, "", "", "", "", "", dstNsName, []string{apachePort}, false)
+
+			By(fmt.Sprintf("Applied NetworkPolicy to %v by kind label selector", kind))
+			applied := make([]bool, len(ids))
+			for i := range applied {
+				applied[i] = true
+			}
+			anpParams.AppliedTo = utils.ConfigANPApplyTo(kind, "", "", "", "")
+			verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
+
+			By(fmt.Sprintf("Upgrading Helm Chart to %s.", toVersion))
+			err := utils.UpgradeHelmChart(k8sClient, toVersion, chartDir)
+			Expect(err).ToNot(HaveOccurred())
+			verifyAppliedTo(kind, ids, ips, srcVM, srcIP, applied)
+		},
+		Entry("VM In Same Namespace",
+			reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()),
+	)
+})

--- a/test/upgrade/upgrade_suite_test.go
+++ b/test/upgrade/upgrade_suite_test.go
@@ -1,0 +1,152 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"flag"
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	antreav1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	antreav1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	crdv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
+	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
+	"antrea.io/nephe/pkg/logging"
+	"antrea.io/nephe/test/utils"
+)
+
+const (
+	focusAws   = "test-aws"
+	focusAzure = "test-azure"
+)
+
+var (
+	kubeCtl       *utils.KubeCtl
+	k8sClient     client.Client
+	cloudVPC      utils.CloudVPC
+	scheme        = runtime.NewScheme()
+	testFocus     = []string{focusAws, focusAzure}
+	preserveSetup = false
+
+	// flags.
+	preserveSetupOnFail bool
+	supportBundleDir    string
+	kubeconfig          string
+	cloudProvider       string
+	fromVersion         string
+	toVersion           string
+	chartDir            string
+)
+
+func init() {
+	flag.StringVar(&fromVersion, "from-version", "", "Helm upgrade version from.")
+	flag.StringVar(&toVersion, "to-version", "latest", "Helm upgrade version to.")
+	flag.BoolVar(&preserveSetupOnFail, "preserve-setup-on-fail", false, "Preserve the setup if a test failed.")
+	flag.StringVar(&supportBundleDir, "support-bundle-dir", "", "Support bundles are saved in this dir when specified.")
+	flag.StringVar(&cloudProvider, "cloud-provider", string(runtimev1alpha1.AzureCloudProvider),
+		"Cloud Provider. Default is Azure.")
+	flag.StringVar(&chartDir, "chart-dir", "../../build/charts/nephe", "Helm chart directory.")
+	rand.Seed(time.Now().Unix())
+}
+
+func TestUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Upgrade Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), logging.UseDevMode()))
+
+	// required fields.
+	Expect(fromVersion).ToNot(BeEmpty())
+
+	var err error
+	By("Bootstrapping the test environment")
+	err = clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = crdv1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = antreav1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = antreav1alpha2.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = runtimev1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// setup kubeCtl.
+	kubeconfig = flag.Lookup("kubeconfig").Value.(flag.Getter).Get().(string)
+	kubeCtl, err = utils.NewKubeCtl(kubeconfig)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(kubeCtl).ToNot(BeNil())
+
+	// set k8sClient.
+	k8sClient, err = utils.NewK8sClient(scheme, "")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	By("Check cert-manager is ready, may wait longer for docker pull")
+	// Increase the timeout for now to get past CI/CD timeout at this point to see what is causing it.
+	err = utils.RestartOrWaitDeployment(k8sClient, "cert-manager", "cert-manager", time.Second*240, false)
+	Expect(err).ToNot(HaveOccurred())
+	err = utils.RestartOrWaitDeployment(k8sClient, "cert-manager-cainjector", "cert-manager", time.Second*120, false)
+	Expect(err).ToNot(HaveOccurred())
+	err = utils.RestartOrWaitDeployment(k8sClient, "cert-manager-webhook", "cert-manager", time.Second*120, false)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Check antrea controller is ready, may wait longer for docker pull")
+	err = utils.RestartOrWaitDeployment(k8sClient, "antrea-controller", "kube-system", time.Second*120, false)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Check nephe controller is not running")
+	err = utils.CheckDeploymentConfigured(k8sClient, "nephe-controller", "nephe-system")
+	Expect(err).To(HaveOccurred())
+
+	By("Check VM VPCs are ready")
+	cloudVPC, err = utils.NewCloudVPC(runtimev1alpha1.CloudProvider(cloudProvider))
+	Expect(err).ToNot(HaveOccurred())
+	if !cloudVPC.IsConfigured() {
+		err := cloudVPC.Reapply(time.Second*600, false)
+		Expect(err).ToNot(HaveOccurred())
+		logf.Log.Info("VM VPCs created", "Provider", cloudProvider, "VPCID", cloudVPC.GetVPCID())
+	}
+
+})
+
+var _ = AfterSuite(func() {
+	if preserveSetup == true || kubeCtl == nil {
+		return
+	}
+
+	// Delete VPC.
+	if cloudVPC != nil {
+		logf.Log.Info("Initiating VM VPC deletion", "Provider", cloudProvider, "VPCID", cloudVPC.GetVPCID())
+		err := cloudVPC.Delete(time.Second * 600)
+		Expect(err).ToNot(HaveOccurred())
+
+	}
+})

--- a/test/utils/networkpolicy_helper.go
+++ b/test/utils/networkpolicy_helper.go
@@ -1,0 +1,74 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+
+	"antrea.io/nephe/pkg/labels"
+	k8stemplates "antrea.io/nephe/test/templates"
+)
+
+// ConfigANPApplyTo helper function to configure appliedTo in Antrea NetworkPolicy.
+func ConfigANPApplyTo(kind, instanceName, vpc, tagKey, tagVal string) *k8stemplates.EntitySelectorParameters {
+	ret := &k8stemplates.EntitySelectorParameters{}
+	if len(kind) > 0 {
+		ret.Kind = labels.ExternalEntityLabelKeyKind + ": " + strings.ToLower(kind)
+	}
+	if len(vpc) > 0 {
+		ret.VPC = labels.ExternalEntityLabelKeyOwnerVmVpc + ": " + strings.ToLower(vpc)
+	}
+	if len(instanceName) > 0 {
+		ret.CloudInstanceName = labels.ExternalEntityLabelKeyOwnerVm + ": " + strings.ToLower(instanceName)
+	}
+	if len(tagKey) > 0 {
+		tagKey = labels.LabelPrefixNephe + labels.ExternalEntityLabelKeyTagPrefix + tagKey
+		ret.Tags = map[string]string{tagKey: tagVal}
+	}
+	return ret
+}
+
+// ConfigANPToFrom helper function to configure to and from fields in Antrea NetworkPolicy.
+func ConfigANPToFrom(kind, instanceName, vpc, tagKey, tagVal, ipBlock, nsName string, ports []string,
+	denyAll bool) *k8stemplates.ToFromParameters {
+	ret := &k8stemplates.ToFromParameters{
+		DenyAll: denyAll,
+	}
+	if len(ipBlock) > 0 {
+		ret.IPBlock = ipBlock
+	}
+	if len(kind) > 0 {
+		ret.Entity = &k8stemplates.EntitySelectorParameters{
+			Kind: labels.ExternalEntityLabelKeyKind + ": " + strings.ToLower(kind),
+		}
+		if len(vpc) > 0 {
+			ret.Entity.VPC = labels.ExternalEntityLabelKeyOwnerVmVpc + ": " + strings.ToLower(vpc)
+		}
+		if len(instanceName) > 0 {
+			ret.Entity.CloudInstanceName = labels.ExternalEntityLabelKeyOwnerVm + ": " + strings.ToLower(instanceName)
+		}
+		if len(tagKey) > 0 {
+			tagKey = labels.LabelPrefixNephe + labels.ExternalEntityLabelKeyTagPrefix + tagKey
+			ret.Entity.Tags = map[string]string{tagKey: tagVal}
+		}
+	}
+
+	for _, p := range ports {
+		ret.Ports = append(ret.Ports, &k8stemplates.PortParameters{Protocol: string(v1.ProtocolTCP), Port: p})
+	}
+	return ret
+}


### PR DESCRIPTION
## Description
Add upgrade e2e tests with helm version v0.5.

## Changes
Added network policy e2e upgrade tests. Base version is pinned to v0.5 and it will test upgrade with latest main branch. Tests also includes an option to test between release builds too.