### PR TITLE
fix vmp in progress on nephe controller restart

### DIFF
--- a/pkg/controllers/cloud/networkpolicy_cloudresource.go
+++ b/pkg/controllers/cloud/networkpolicy_cloudresource.go
@@ -135,6 +135,7 @@ func (r *NetworkPolicyReconciler) newCloudResourceNPTracker(rsc *securitygroup.C
 		prevAppliedToSGs: make(map[string]*appliedToSecurityGroup),
 		cloudResource:    *rsc,
 	}
+	tracker.unmarkDirty()
 	if err := r.cloudResourceNPTrackerIndexer.Add(tracker); err != nil {
 		log.Error(err, "Add to cloudResourceNPTracker indexer")
 		return nil
@@ -153,6 +154,9 @@ func (r *NetworkPolicyReconciler) getCloudResourceNPTracker(rsc *securitygroup.C
 
 func (r *NetworkPolicyReconciler) processCloudResourceNPTrackers() {
 	log := r.Log.WithName("NPTracker")
+	if !r.syncedWithCloud {
+		return
+	}
 	for _, i := range r.cloudResourceNPTrackerIndexer.List() {
 		tracker := i.(*cloudResourceNPTracker)
 		if !tracker.isDirty() {


### PR DESCRIPTION
## Description
When the Nephe controller is restarted with ANPs applied, the vmp briefly enters the 'in-progress' state for less than a second before returning to the 'applied' state. This behavior can be misleading, as the ANP is still applied on the cloud and Nephe is simply resyncing the state. This PR fixes this issue by postponing the vmp updates until the initial cloud sync is completed.

## Changes
1. Do not update the vmp status until initial cloud sync is completed.

Closes #177