### PR TITLE
fix vmp applied before all cloud operation complete

### DIFF
--- a/pkg/controllers/cloud/networkpolicy.go
+++ b/pkg/controllers/cloud/networkpolicy.go
@@ -1089,7 +1089,7 @@ func (a *appliedToSecurityGroup) getStatus() error {
 	if a.status != nil {
 		return a.status
 	}
-	if a.state == securityGroupStateCreated && a.ruleReady {
+	if a.state == securityGroupStateCreated && a.ruleReady && a.hasMembers {
 		return nil
 	}
 	return &InProgress{}


### PR DESCRIPTION
## Description
Currently, when an ANP is being applied, the vmp changes to the `applied` state after the update rule operation is completed, but before the update member operation is finished. This behavior can be misleading, as the `applied` state should only appear after all cloud operations have completed successfully.

## Changes
1. The AppliedTo sg will now return an `in-progress` status before both `ruleReady` and `hasMember` are set to true. Previously, it only returned an `in-progress` status before `ruleReady` was true.

Closes #174 