### PR TITLE
Remove IPBlock from AddressGroup

### DIFF
--- a/pkg/controllers/cloud/networkpolicy_pendingitem.go
+++ b/pkg/controllers/cloud/networkpolicy_pendingitem.go
@@ -172,7 +172,7 @@ func (p *pendingGroup) RunPendingItem(id string, context interface{}) bool {
 		members = append(members, v)
 	}
 	name, memberOnly := getGroupIDFromUniqueName(id)
-	err := r.processMemberGrp(name, p.event, memberOnly, members, nil)
+	err := r.processGroup(name, p.event, memberOnly, members, nil)
 	if p.refCnt != nil {
 		return true
 	}

--- a/pkg/controllers/cloud/networkpolicy_sync.go
+++ b/pkg/controllers/cloud/networkpolicy_sync.go
@@ -213,9 +213,6 @@ func (r *NetworkPolicyReconciler) syncWithCloud() {
 	r.syncedWithCloud = true
 	for _, i := range r.addrSGIndexer.List() {
 		sg := i.(*addrSecurityGroup)
-		if sg.isIPBlocks() {
-			continue
-		}
 		sg.sync(cloudAddrSGs[sg.getID()], r)
 	}
 	for _, i := range r.appliedToSGIndexer.List() {

--- a/pkg/controllers/cloud/networkpolicy_test.go
+++ b/pkg/controllers/cloud/networkpolicy_test.go
@@ -747,7 +747,7 @@ var _ = Describe("NetworkPolicy", func() {
 		}
 		for _, grp := range addrGrps {
 			event = watch.Event{Type: watch.Added, Object: grp}
-			err = reconciler.processAddrGrp(event)
+			err = reconciler.processAddressGroup(event)
 			if sgConfig.k8sGetError != nil {
 				Expect(err).To(Equal(sgConfig.k8sGetError))
 			} else {
@@ -756,7 +756,7 @@ var _ = Describe("NetworkPolicy", func() {
 		}
 		for _, grp := range appliedToGrps {
 			event = watch.Event{Type: watch.Added, Object: grp}
-			err = reconciler.processAppliedToGrp(event)
+			err = reconciler.processAppliedToGroup(event)
 			if sgConfig.k8sGetError != nil {
 				Expect(err).To(Equal(sgConfig.k8sGetError))
 			} else {
@@ -803,12 +803,12 @@ var _ = Describe("NetworkPolicy", func() {
 		}
 		for _, grp := range addrGrps {
 			event = watch.Event{Type: watch.Deleted, Object: grp}
-			err = reconciler.processAddrGrp(event)
+			err = reconciler.processAddressGroup(event)
 			Expect(err).ToNot(HaveOccurred())
 		}
 		for _, grp := range appliedToGrps {
 			event = watch.Event{Type: watch.Deleted, Object: grp}
-			err = reconciler.processAppliedToGrp(event)
+			err = reconciler.processAppliedToGroup(event)
 			Expect(err).ToNot(HaveOccurred())
 		}
 		if !outOrder {
@@ -980,7 +980,7 @@ var _ = Describe("NetworkPolicy", func() {
 		checkGrpPatchChange(addrGrp.Name, addrGrp.GroupMembers, false, []*antreatypes.ExternalEntity{remove}, true)
 		var err error
 		event := watch.Event{Type: watch.Modified, Object: p1}
-		err = reconciler.processAddrGrp(event)
+		err = reconciler.processAddressGroup(event)
 		Expect(err).ToNot(HaveOccurred())
 
 		wait()
@@ -994,7 +994,7 @@ var _ = Describe("NetworkPolicy", func() {
 		p1 := patchAppliedToGrpMember(appliedToGrp, add, remove, 0)
 		checkGrpPatchChange(appliedToGrp.Name, appliedToGrp.GroupMembers, false, []*antreatypes.ExternalEntity{remove}, false)
 		event := watch.Event{Type: watch.Modified, Object: p1}
-		err := reconciler.processAppliedToGrp(event)
+		err := reconciler.processAppliedToGroup(event)
 		Expect(err).ToNot(HaveOccurred())
 
 		wait()
@@ -1013,7 +1013,7 @@ var _ = Describe("NetworkPolicy", func() {
 		checkGrpPatchChange(appliedToGrp.Name, appliedToGrp.GroupMembers, true, []*antreatypes.ExternalEntity{remove}, false)
 
 		event := watch.Event{Type: watch.Modified, Object: p1}
-		err := reconciler.processAppliedToGrp(event)
+		err := reconciler.processAppliedToGroup(event)
 		Expect(err).ToNot(HaveOccurred())
 		verifyVmp(len(trackedVMs) - 1)
 	})
@@ -1031,7 +1031,7 @@ var _ = Describe("NetworkPolicy", func() {
 
 		checkAddrGroup(ag)
 		event := watch.Event{Type: watch.Added, Object: ag}
-		err := reconciler.processAddrGrp(event)
+		err := reconciler.processAddressGroup(event)
 		Expect(err).ToNot(HaveOccurred())
 
 		ingress := ingressRule[0]
@@ -1059,7 +1059,7 @@ var _ = Describe("NetworkPolicy", func() {
 		var err error
 		checkAppliedGroup(ag)
 		event := watch.Event{Type: watch.Added, Object: ag}
-		err = reconciler.processAppliedToGrp(event)
+		err = reconciler.processAppliedToGroup(event)
 		Expect(err).ToNot(HaveOccurred())
 		event = watch.Event{Type: watch.Modified, Object: anp}
 		err = reconciler.processNetworkPolicy(event)


### PR DESCRIPTION
IPBlock was used to store non nephe created external entity ip address. The feature is not required, hence removing it.