### PR TITLE
Increased retry count to a higher value

### DIFF
--- a/test/integration/pod_e2e_test.go
+++ b/test/integration/pod_e2e_test.go
@@ -142,7 +142,8 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Pods", focusAws, focusAzur
 		}
 
 		Expect(len(cloudVPC.GetVMIPs())).To(Equal(len(oks)))
-		err = utils.ExecuteCurlCmds(nil, kubeCtl, []string{pod}, namespace.Name, cloudVPC.GetVMIPs(), "80", oks, 2)
+		// Increased retry count to allow command execution total timeout to 120 seconds.
+		err = utils.ExecuteCurlCmds(nil, kubeCtl, []string{pod}, namespace.Name, cloudVPC.GetVMIPs(), "80", oks, 24)
 		Expect(err).ToNot(HaveOccurred())
 	}
 


### PR DESCRIPTION
We need to take into consideration, azure might take additional time to clean up previous Antrea NetworkPolicies.  Increasing the count by 24, which essentially mean total timeout of 120 seconds (24 * 5sec retry interval).