### PR TITLE
parse cloud rule descriptions and support user created rules

### DIFF
--- a/docs/networkpolicy.md
+++ b/docs/networkpolicy.md
@@ -110,6 +110,17 @@ contains Ingress and Egress rules.
 - SecurityGroups - a list of securityGroups to which outgoing traffic is
   permitted.
 
+Nephe supports creating user custom rules in NSGs created by Nephe, and these
+custom rules will be preserved regardless of NetworkPolicy configuration.
+However, there are certain limitations on user rules:
+
+- Nephe does not actively maintain user rules. Therefore, changes to
+  NetworkPolicies can result in changes to NSG members and the deletion of NSGs,
+  which may result in changes or deletion of user rules.
+- Nephe uses rule descriptions to track information, so users should not modify
+  Nephe rule descriptions and should not create custom rules with descriptions
+  in the same format.
+
 ## Implementation
 
 The `Nephe Controller` creates two types of network security groups (NSGs) to

--- a/pkg/cloudprovider/cloudapi/azure/azure_security_test.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_security_test.go
@@ -40,28 +40,29 @@ import (
 
 var _ = Describe("Azure Cloud Security", func() {
 	var (
-		testAccountNamespacedName               = &types.NamespacedName{Namespace: "namespace01", Name: "account01"}
-		testAccountNamespacedNameNotExist       = &types.NamespacedName{Namespace: "notexist01", Name: "notexist01"}
-		testAnpNamespace                        = &types.NamespacedName{Namespace: "test-anp-ns", Name: "test-anp"}
-		testSubID                               = "SubID"
-		credentials                             = "credentials"
-		testClientID                            = "ClientID"
-		testClientKey                           = "ClientKey"
-		testTenantID                            = "TenantID"
-		testRegion                              = "eastus"
-		testRG                                  = "testRG"
-		nsgID                                   = "nephe-ag-nsgID"
-		atAsgID                                 = "nephe-at-atapplicationsgID"
-		atAsgName                               = "atapplicationsgID"
-		agAsgID                                 = "nephe-ag-agapplicationsgID"
-		testPriority                      int32 = 100
-		testSourcePortRange                     = "*"
-		testDestinationPortRange                = "*"
-		testPrivateIP                           = "0.0.0.0"
-		testProtocol                            = 6
-		testFromPort                            = 22
-		testToPort                              = 23
-		testCidrStr                             = "192.168.1.1/24"
+		testAccountNamespacedName         = &types.NamespacedName{Namespace: "namespace01", Name: "account01"}
+		testAccountNamespacedNameNotExist = &types.NamespacedName{Namespace: "notexist01", Name: "notexist01"}
+		testAnpNamespace                  = &types.NamespacedName{Namespace: "test-anp-ns", Name: "test-anp"}
+		testSubID                         = "SubID"
+		credentials                       = "credentials"
+		testClientID                      = "ClientID"
+		testClientKey                     = "ClientKey"
+		testTenantID                      = "TenantID"
+		testRegion                        = "eastus"
+		testRG                            = "testRG"
+		nsgID                             = "nephe-ag-nsgID"
+		atAsgID                           = "nephe-at-atapplicationsgID"
+		atAsgName                         = "atapplicationsgID"
+		agAsgID                           = "nephe-ag-agapplicationsgID"
+		testPriority                      = int32(100)
+		testDirection                     = network.SecurityRuleDirectionInbound
+		testSourcePortRange               = "*"
+		testDestinationPortRange          = "*"
+		testPrivateIP                     = "0.0.0.0"
+		testProtocol                      = 6
+		testFromPort                      = 22
+		testToPort                        = 23
+		testCidrStr                       = "192.168.1.1/24"
 
 		testVnet01   = "testVnet01"
 		testVnetID01 = fmt.Sprintf("/subscriptions/%v/resourceGroups/%v/providers/Microsoft.Network/virtualNetworks/%v",
@@ -191,6 +192,7 @@ var _ = Describe("Azure Cloud Security", func() {
 					Priority:                             &testPriority,
 					SourcePortRange:                      &testSourcePortRange,
 					DestinationPortRange:                 &testDestinationPortRange,
+					Direction:                            &testDirection,
 				},
 			}
 
@@ -396,7 +398,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						Protocol:  &testProtocol,
 						FromPort:  &testFromPort,
 						FromSrcIP: fromSrcIP,
-					}, NetworkPolicy: testAnpNamespace.String()},
+					}, NpNamespacedName: testAnpNamespace.String()},
 					{
 						Rule: &securitygroup.EgressRule{
 							Protocol: &testProtocol,
@@ -405,7 +407,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							ToSecurityGroups: []*securitygroup.CloudResourceID{
 								&webAddressGroupIdentifier03.CloudResourceID,
 							},
-						}, NetworkPolicy: testAnpNamespace.String()},
+						}, NpNamespacedName: testAnpNamespace.String()},
 				}
 
 				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
@@ -465,7 +467,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						Protocol:  &testProtocol,
 						FromPort:  &testFromPort,
 						FromSrcIP: fromSrcIP,
-					}, NetworkPolicy: testAnpNamespace.String()},
+					}, NpNamespacedName: testAnpNamespace.String()},
 					{
 						Rule: &securitygroup.EgressRule{
 							Protocol: &testProtocol,
@@ -474,7 +476,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							ToSecurityGroups: []*securitygroup.CloudResourceID{
 								&webAddressGroupIdentifier03.CloudResourceID,
 							},
-						}, NetworkPolicy: testAnpNamespace.String()},
+						}, NpNamespacedName: testAnpNamespace.String()},
 				}
 
 				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
@@ -507,7 +509,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						Protocol:  &testProtocol,
 						FromPort:  &testFromPort,
 						FromSrcIP: fromSrcIP,
-					}, NetworkPolicy: testAnpNamespace.String()},
+					}, NpNamespacedName: testAnpNamespace.String()},
 					{
 						Rule: &securitygroup.EgressRule{
 							Protocol: &testProtocol,
@@ -516,7 +518,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							ToSecurityGroups: []*securitygroup.CloudResourceID{
 								&webAddressGroupIdentifier03.CloudResourceID,
 							},
-						}, NetworkPolicy: testAnpNamespace.String()},
+						}, NpNamespacedName: testAnpNamespace.String()},
 				}
 
 				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)

--- a/pkg/cloudprovider/securitygroup/securitygroup.go
+++ b/pkg/cloudprovider/securitygroup/securitygroup.go
@@ -215,10 +215,10 @@ type EgressRule struct {
 func (e *EgressRule) isRule() {}
 
 type CloudRule struct {
-	Hash          string `json:"-"`
-	Rule          Rule
-	NetworkPolicy string `json:"-"`
-	AppliedToGrp  string
+	Hash             string `json:"-"`
+	Rule             Rule
+	NpNamespacedName string `json:"-"`
+	AppliedToGrp     string
 }
 
 func (c *CloudRule) GetHash() string {
@@ -235,8 +235,8 @@ type SynchronizationContent struct {
 	MembershipOnly             bool
 	Members                    []CloudResource
 	MembersWithOtherSGAttached []CloudResource
-	IngressRules               []IngressRule
-	EgressRules                []EgressRule
+	IngressRules               []CloudRule
+	EgressRules                []CloudRule
 }
 
 // CloudSecurityGroupAPI declares interface to program cloud security groups.


### PR DESCRIPTION
## Description
Currently, Nephe does not have the context to identify whether a cloud rule is user-created or Nephe-managed, and which NetworkPolicy it belongs to. As a result, we do not support user-created rules in the cloud and clean them up. During controller restart, Nephe can only guess and try to match cloud rules with NetworkPolicies.

This PR aims to address these issues by using the description field on cloud rules to identify user rules and Nephe rules, and which NetworkPolicy a rule belongs to. It adds support to preserve user-created custom cloud rules and removes the logic where it attempts to match unknown cloud rules with NetworkPolicies during cloud syncing.

## Changes
1. Modify GetEnforcedSecurity to parse the description and return CloudRule with NetworkPolicy information.
1. Fix an issue where the protocol on Azure changes to all caps on portal modification, breaking the protocol mapping.
1. Add logic to preserve user rules in the cloud.
1. Add logic to handle user rules in cloudSync.