### PR TITLE
Update dependent CPAs for Secret add/modify/delete operation

### DIFF
--- a/pkg/accountmanager/manager.go
+++ b/pkg/accountmanager/manager.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	ErrorMsgAddOrUpdateAccount    = "failed to add or update account"
 	errorMsgAccountPollerNotFound = "account poller not found"
 )
 
@@ -108,7 +107,7 @@ func (a *AccountManager) AddAccount(namespacedName *types.NamespacedName, accoun
 
 	// Call plugin to add cloud account.
 	if err = cloudInterface.AddProviderAccount(a.Client, account); err != nil {
-		return fmt.Errorf("%s: %v", ErrorMsgAddOrUpdateAccount, err)
+		return err
 	}
 	// Create an account poller for polling cloud inventory.
 	accPoller, exists := a.addAccountPoller(cloudInterface, namespacedName, account)

--- a/pkg/cloudprovider/cloudapi/aws/aws_account_mgmt.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_account_mgmt.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	crdv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
+	"antrea.io/nephe/pkg/util"
 )
 
 type awsAccountConfig struct {
@@ -97,22 +98,27 @@ func extractSecret(c client.Client, s *crdv1alpha1.SecretReference) (*crdv1alpha
 		Version: "v1",
 	})
 	if err := c.Get(context.Background(), client.ObjectKey{Namespace: s.Namespace, Name: s.Name}, u); err != nil {
-		return nil, fmt.Errorf("error fetching Secret: %v/%v", s.Name, s.Namespace)
+		return nil, fmt.Errorf("%v: %v/%v", util.ErrorMsgSecretDoesNotExist, s.Namespace, s.Name)
 	}
 
 	data, ok := u.Object["data"].(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("error missing Secret config data: %v/%v", s.Name, s.Namespace)
+		return nil, fmt.Errorf("error missing Secret config data: %v/%v", s.Namespace, s.Name)
 	}
 
-	decode, err := base64.StdEncoding.DecodeString(data[s.Key].(string))
+	key, ok := data[s.Key].(string)
+	if !ok {
+		return nil, fmt.Errorf("error decoding Secret: %v/%v, key: %v", s.Namespace, s.Name, s.Key)
+	}
+
+	decode, err := base64.StdEncoding.DecodeString(key)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding Secret: %v/%v", s.Name, s.Namespace)
+		return nil, fmt.Errorf("error decoding Secret: %v/%v", s.Namespace, s.Name)
 	}
 
 	cred := &crdv1alpha1.AwsAccountCredential{}
 	if err = json.Unmarshal(decode, cred); err != nil {
-		return nil, fmt.Errorf("error unmarshalling credentials: %v/%v", s.Name, s.Namespace)
+		return nil, fmt.Errorf("error unmarshalling credentials: %v/%v", s.Namespace, s.Name)
 	}
 
 	return cred, nil

--- a/pkg/cloudprovider/cloudapi/internal/cloud_common.go
+++ b/pkg/cloudprovider/cloudapi/internal/cloud_common.go
@@ -107,7 +107,6 @@ func (c *cloudCommon) AddCloudAccount(client client.Client, account *crdv1alpha1
 func (c *cloudCommon) RemoveCloudAccount(namespacedName *types.NamespacedName) {
 	_, found := c.GetCloudAccountByName(namespacedName)
 	if !found {
-		c.logger().V(0).Info("unable to find cloud account", "account", *namespacedName)
 		return
 	}
 	c.mutex.Lock()

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -90,8 +90,8 @@ func (inventory *Inventory) BuildVpcCache(discoveredVpcMap map[string]*runtimev1
 			}
 		}
 		if err != nil {
-			return fmt.Errorf("failed to add vpc into vpc cache, vpc id: %s, error: %v",
-				discoveredVpc.Status.CloudId, err)
+			inventory.log.Error(err, "failed to update vpc in vpc cache", "vpc", discoveredVpc.Status.CloudId,
+				"account", namespacedName.String())
 		}
 	}
 

--- a/pkg/inventory/store/vm_inventory.go
+++ b/pkg/inventory/store/vm_inventory.go
@@ -15,8 +15,6 @@
 package store
 
 import (
-	"antrea.io/nephe/pkg/inventory/indexer"
-	labels2 "antrea.io/nephe/pkg/labels"
 	"fmt"
 	"reflect"
 
@@ -30,6 +28,8 @@ import (
 	antreastorage "antrea.io/antrea/pkg/apiserver/storage"
 	"antrea.io/antrea/pkg/apiserver/storage/ram"
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
+	"antrea.io/nephe/pkg/inventory/indexer"
+	nephelabels "antrea.io/nephe/pkg/labels"
 )
 
 // vpcInventoryEvent implements storage.InternalEvent.
@@ -141,8 +141,8 @@ func NewVmInventoryStore() antreastorage.Interface {
 		},
 		indexer.VirtualMachineByNamespacedAccountName: func(obj interface{}) ([]string, error) {
 			vm := obj.(*runtimev1alpha1.VirtualMachine)
-			return []string{vm.Labels[labels2.CloudAccountNamespace] + "/" +
-				vm.Labels[labels2.CloudAccountName]}, nil
+			return []string{vm.Labels[nephelabels.CloudAccountNamespace] + "/" +
+				vm.Labels[nephelabels.CloudAccountName]}, nil
 		},
 	}
 	return ram.NewStore(vmKeyFunc, indexers, genVmEvent, keyAndSpanSelectFuncVm,

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -25,7 +25,10 @@ import (
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
 )
 
-var ErrorMsgUnknownCloudProvider = "missing cloud provider config. Please add AWS or Azure Config"
+var (
+	ErrorMsgUnknownCloudProvider = "missing cloud provider config. Please add AWS or Azure Config"
+	ErrorMsgSecretDoesNotExist   = "error Secret does not exist"
+)
 
 // GetVMIPAddresses returns IP addresses of all network interfaces attached to the vm.
 func GetVMIPAddresses(vm *runtimev1alpha1.VirtualMachine) []runtimev1alpha1.IPAddress {


### PR DESCRIPTION
- Add: Updates account only if its error state with error as Secret does not exist.
- Update/Delete: Updates account to recompute account state, as Secret is changed
- Cleanup account state when account add/update fails.