### PR TITLE
preserve azure rule priority on rule update

### DIFF
--- a/pkg/cloudprovider/cloudapi/aws/aws_security.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_security.go
@@ -696,30 +696,12 @@ func (c *awsCloud) CreateSecurityGroup(securityGroupIdentifier *securitygroup.Cl
 
 // UpdateSecurityGroupRules invokes cloud api and updates cloud security group with addRules and rmRules.
 func (c *awsCloud) UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource,
-	addRules, rmRules, _ []*securitygroup.CloudRule) error {
+	addRules, rmRules []*securitygroup.CloudRule) error {
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	addIRule := make([]*securitygroup.CloudRule, 0)
-	rmIRule := make([]*securitygroup.CloudRule, 0)
-	addERule := make([]*securitygroup.CloudRule, 0)
-	rmERule := make([]*securitygroup.CloudRule, 0)
-	for _, rule := range addRules {
-		switch rule.Rule.(type) {
-		case *securitygroup.IngressRule:
-			addIRule = append(addIRule, rule)
-		case *securitygroup.EgressRule:
-			addERule = append(addERule, rule)
-		}
-	}
-	for _, rule := range rmRules {
-		switch rule.Rule.(type) {
-		case *securitygroup.IngressRule:
-			rmIRule = append(rmIRule, rule)
-		case *securitygroup.EgressRule:
-			rmERule = append(rmERule, rule)
-		}
-	}
+	addIRule, addERule := securitygroup.SplitCloudRulesByDirection(addRules)
+	rmIRule, rmERule := securitygroup.SplitCloudRulesByDirection(rmRules)
 
 	vpcID := appliedToGroupIdentifier.Vpc
 	accCfg, found := c.cloudCommon.GetCloudAccountByAccountId(&appliedToGroupIdentifier.AccountID)

--- a/pkg/cloudprovider/cloudapi/aws/aws_security_test.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_security_test.go
@@ -283,7 +283,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			mockawsEC2.EXPECT().revokeSecurityGroupEgress(gomock.Any()).Times(0)
 			mockawsEC2.EXPECT().authorizeSecurityGroupEgress(gomock.Any()).Times(0)
 
-			err := cloudInterface.UpdateSecurityGroupRules(webSgIdentifier, addRule, []*securitygroup.CloudRule{}, addRule)
+			err := cloudInterface.UpdateSecurityGroupRules(webSgIdentifier, addRule, []*securitygroup.CloudRule{})
 			Expect(err).Should(BeNil())
 		})
 		// Ingress rules without a description field is not allowed.
@@ -320,7 +320,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			mockawsEC2.EXPECT().revokeSecurityGroupIngress(gomock.Any()).Times(0)
 			mockawsEC2.EXPECT().revokeSecurityGroupEgress(gomock.Any()).Times(0)
 
-			err := cloudInterface.UpdateSecurityGroupRules(webSgIdentifier, addRule, []*securitygroup.CloudRule{}, addRule)
+			err := cloudInterface.UpdateSecurityGroupRules(webSgIdentifier, addRule, []*securitygroup.CloudRule{})
 			Expect(err).ShouldNot(BeNil())
 		})
 		It("Should create egress rules successfully", func() {
@@ -360,7 +360,7 @@ var _ = Describe("AWS Cloud Security", func() {
 					Expect(len(req.IpPermissions)).To(Equal(1))
 				})
 
-			err := cloudInterface.UpdateSecurityGroupRules(webSgIdentifier, addRule, []*securitygroup.CloudRule{}, addRule)
+			err := cloudInterface.UpdateSecurityGroupRules(webSgIdentifier, addRule, []*securitygroup.CloudRule{})
 			Expect(err).Should(BeNil())
 		})
 		// Egress rules without a description field is not allowed.
@@ -396,7 +396,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			mockawsEC2.EXPECT().revokeSecurityGroupIngress(gomock.Any()).Times(0)
 			mockawsEC2.EXPECT().revokeSecurityGroupEgress(gomock.Any()).Times(0)
 
-			err := cloudInterface.UpdateSecurityGroupRules(webSgIdentifier, addRule, []*securitygroup.CloudRule{}, addRule)
+			err := cloudInterface.UpdateSecurityGroupRules(webSgIdentifier, addRule, []*securitygroup.CloudRule{})
 			Expect(err).ShouldNot(BeNil())
 		})
 	})

--- a/pkg/cloudprovider/cloudapi/azure/azure_security_test.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_security_test.go
@@ -410,7 +410,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						}, NpNamespacedName: testAnpNamespace.String()},
 				}
 
-				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{})
 				Expect(err).Should(BeNil())
 			})
 
@@ -445,7 +445,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						}},
 				}
 
-				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{})
 				Expect(err).ShouldNot(BeNil())
 			})
 
@@ -479,7 +479,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						}, NpNamespacedName: testAnpNamespace.String()},
 				}
 
-				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{})
 				Expect(err).ShouldNot(BeNil())
 			})
 
@@ -521,7 +521,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						}, NpNamespacedName: testAnpNamespace.String()},
 				}
 
-				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{})
 				Expect(err).Should(BeNil())
 			})
 
@@ -564,7 +564,7 @@ var _ = Describe("Azure Cloud Security", func() {
 						}},
 				}
 
-				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{}, addRules)
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{})
 				Expect(err).ShouldNot(BeNil())
 			})
 		})

--- a/pkg/cloudprovider/cloudapi/common/cloud-mock_test.go
+++ b/pkg/cloudprovider/cloudapi/common/cloud-mock_test.go
@@ -250,17 +250,17 @@ func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupMembers(securityGro
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockCloudInterface) UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules, allRules []*securitygroup.CloudRule) error {
+func (m *MockCloudInterface) UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules []*securitygroup.CloudRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", appliedToGroupIdentifier, addRules, rmRules, allRules)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", appliedToGroupIdentifier, addRules, rmRules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupRules(appliedToGroupIdentifier, addRules, rmRules, allRules interface{}) *gomock.Call {
+func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupRules(appliedToGroupIdentifier, addRules, rmRules interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupRules), appliedToGroupIdentifier, addRules, rmRules, allRules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupRules), appliedToGroupIdentifier, addRules, rmRules)
 }
 
 // MockAccountMgmtInterface is a mock of AccountMgmtInterface interface.
@@ -515,15 +515,15 @@ func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupMembers(security
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockSecurityInterface) UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules, allRules []*securitygroup.CloudRule) error {
+func (m *MockSecurityInterface) UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules []*securitygroup.CloudRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", appliedToGroupIdentifier, addRules, rmRules, allRules)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", appliedToGroupIdentifier, addRules, rmRules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupRules(appliedToGroupIdentifier, addRules, rmRules, allRules interface{}) *gomock.Call {
+func (mr *MockSecurityInterfaceMockRecorder) UpdateSecurityGroupRules(appliedToGroupIdentifier, addRules, rmRules interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockSecurityInterface)(nil).UpdateSecurityGroupRules), appliedToGroupIdentifier, addRules, rmRules, allRules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockSecurityInterface)(nil).UpdateSecurityGroupRules), appliedToGroupIdentifier, addRules, rmRules)
 }

--- a/pkg/cloudprovider/cloudapi/common/cloud.go
+++ b/pkg/cloudprovider/cloudapi/common/cloud.go
@@ -80,8 +80,7 @@ type SecurityInterface interface {
 	CreateSecurityGroup(securityGroupIdentifier *securitygroup.CloudResource, membershipOnly bool) (*string, error)
 	// UpdateSecurityGroupRules updates cloud security group corresponding to provided appliedTo group with provided rules.
 	// addRules and rmRules are the changed rules, allRules are rules from all nps of the security group.
-	UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules,
-		allRules []*securitygroup.CloudRule) error
+	UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource, addRules, rmRules []*securitygroup.CloudRule) error
 	// UpdateSecurityGroupMembers updates membership of cloud security group corresponding to provided security group. Only
 	// provided computeResources will remain attached to cloud security group. UpdateSecurityGroupMembers will also make sure that
 	// after membership update, if compute resource is no longer attached to any nephe created cloud security group, then

--- a/pkg/cloudprovider/securitygroup/helpers.go
+++ b/pkg/cloudprovider/securitygroup/helpers.go
@@ -58,6 +58,21 @@ func FindResourcesBasedOnKind(cloudResources []*CloudResource) (map[string]struc
 	return virtualMachineIDs, networkInterfaceIDs
 }
 
+// SplitCloudRulesByDirection splits the given CloudRule slice into two, one for ingress rules and one for egress rules.
+func SplitCloudRulesByDirection(rules []*CloudRule) ([]*CloudRule, []*CloudRule) {
+	ingressRules := make([]*CloudRule, 0)
+	egressRules := make([]*CloudRule, 0)
+	for _, rule := range rules {
+		switch rule.Rule.(type) {
+		case *IngressRule:
+			ingressRules = append(ingressRules, rule)
+		case *EgressRule:
+			egressRules = append(egressRules, rule)
+		}
+	}
+	return ingressRules, egressRules
+}
+
 // GenerateCloudDescription generates a CloudRuleDescription object and converts to string.
 func GenerateCloudDescription(namespacedName string) (string, error) {
 	tokens := strings.Split(namespacedName, "/")

--- a/pkg/cloudprovider/securitygroup/securitygroup.go
+++ b/pkg/cloudprovider/securitygroup/securitygroup.go
@@ -269,7 +269,7 @@ type CloudSecurityGroupAPI interface {
 	// UpdateSecurityGroupRules updates SecurityGroup name's ingress/egress rules in entirety.
 	// SecurityGroup name must already been created. SecurityGroups referred to in ingressRules and
 	// egressRules must have been already created.
-	UpdateSecurityGroupRules(name *CloudResource, addRules, rmRules, allRules []*CloudRule) <-chan error
+	UpdateSecurityGroupRules(name *CloudResource, addRules, rmRules []*CloudRule) <-chan error
 
 	// UpdateSecurityGroupMembers updates SecurityGroup name with members.
 	// SecurityGroup name must already have been created.

--- a/pkg/cloudprovider/securitygroup_impl.go
+++ b/pkg/cloudprovider/securitygroup_impl.go
@@ -64,7 +64,7 @@ func (sg *SecurityGroupImpl) CreateSecurityGroup(securityGroupIdentifier *securi
 }
 
 func (sg *SecurityGroupImpl) UpdateSecurityGroupRules(appliedToGroupIdentifier *securitygroup.CloudResource,
-	addRules, rmRules, allRules []*securitygroup.CloudRule) <-chan error {
+	addRules, rmRules []*securitygroup.CloudRule) <-chan error {
 	ch := make(chan error)
 
 	go func() {
@@ -76,7 +76,7 @@ func (sg *SecurityGroupImpl) UpdateSecurityGroupRules(appliedToGroupIdentifier *
 			return
 		}
 
-		err = cloudInterface.UpdateSecurityGroupRules(appliedToGroupIdentifier, addRules, rmRules, allRules)
+		err = cloudInterface.UpdateSecurityGroupRules(appliedToGroupIdentifier, addRules, rmRules)
 		if err != nil {
 			ch <- err
 			return

--- a/pkg/controllers/networkpolicy/networkpolicy.go
+++ b/pkg/controllers/networkpolicy/networkpolicy.go
@@ -813,12 +813,9 @@ func (a *appliedToSecurityGroup) updateANPRules(r *NetworkPolicyReconciler, np *
 	}
 
 	a.cloudOpInProgress = true
-
-	// get full set of current rules for this security group.
-	allRules := a.getCloudRulesFromNps(nps)
 	r.Log.V(1).Info("Updating AppliedToSecurityGroup rules for anp", "anp", np.Name, "name", a.id.Name,
-		"added", addRules, "removed", rmRules, "allRules", allRules)
-	ch := securitygroup.CloudSecurityGroup.UpdateSecurityGroupRules(&a.id, addRules, rmRules, allRules)
+		"added", addRules, "removed", rmRules)
+	ch := securitygroup.CloudSecurityGroup.UpdateSecurityGroupRules(&a.id, addRules, rmRules)
 
 	go func() {
 		err = <-ch

--- a/pkg/testing/cloud/mock.go
+++ b/pkg/testing/cloud/mock.go
@@ -251,15 +251,15 @@ func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupMembers(arg0, arg1,
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockCloudInterface) UpdateSecurityGroupRules(arg0 *securitygroup.CloudResource, arg1, arg2, arg3 []*securitygroup.CloudRule) error {
+func (m *MockCloudInterface) UpdateSecurityGroupRules(arg0 *securitygroup.CloudResource, arg1, arg2 []*securitygroup.CloudRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupRules(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockCloudInterfaceMockRecorder) UpdateSecurityGroupRules(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupRules), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudInterface)(nil).UpdateSecurityGroupRules), arg0, arg1, arg2)
 }

--- a/pkg/testing/cloudsecurity/mock.go
+++ b/pkg/testing/cloudsecurity/mock.go
@@ -106,15 +106,15 @@ func (mr *MockCloudSecurityGroupAPIMockRecorder) UpdateSecurityGroupMembers(arg0
 }
 
 // UpdateSecurityGroupRules mocks base method.
-func (m *MockCloudSecurityGroupAPI) UpdateSecurityGroupRules(arg0 *securitygroup.CloudResource, arg1, arg2, arg3 []*securitygroup.CloudRule) <-chan error {
+func (m *MockCloudSecurityGroupAPI) UpdateSecurityGroupRules(arg0 *securitygroup.CloudResource, arg1, arg2 []*securitygroup.CloudRule) <-chan error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UpdateSecurityGroupRules", arg0, arg1, arg2)
 	ret0, _ := ret[0].(<-chan error)
 	return ret0
 }
 
 // UpdateSecurityGroupRules indicates an expected call of UpdateSecurityGroupRules.
-func (mr *MockCloudSecurityGroupAPIMockRecorder) UpdateSecurityGroupRules(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockCloudSecurityGroupAPIMockRecorder) UpdateSecurityGroupRules(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudSecurityGroupAPI)(nil).UpdateSecurityGroupRules), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockCloudSecurityGroupAPI)(nil).UpdateSecurityGroupRules), arg0, arg1, arg2)
 }


### PR DESCRIPTION
## Description
Currently when rules are updated on Azure, the priorities of rules are recomputed instead of preserving the previous priority. This PR resolves this problem by checking if rule already exists on Azure rule update and skips priority computation if it already exists.

## Changes
1. Implement function to compare Azure security rules based on fields Nephe uses.
2. Change update rule priority logic to skip existing rules and skip used priorities when computing new rules. New rules will take the first available priority starting from Nephe priority range 2000.
3. Change rule update logic to use addRules and rmRules to perform delta update on existing rules. addRules will be passed into rule priority update logic to compute priority.
4. Remove allRules from `UpdateSecurityGroupRules` func parameter as Azure no longer uses it. Now AWS and Azure are consistent.
5. Update corresponding unit tests.

## Closes
#206 