### PR TITLE
Rename nephe.io to nephe.antrea.io

### DIFF
--- a/config/samples/vm-anp.yaml
+++ b/config/samples/vm-anp.yaml
@@ -9,7 +9,7 @@ spec:
   appliedTo:
   - externalEntitySelector:
       matchLabels:
-         nephe.io/kind: virtualmachine
+         nephe.antrea.io/kind: virtualmachine
   ingress:
   - action: Allow
     from:

--- a/docs/agented-vm-guide.md
+++ b/docs/agented-vm-guide.md
@@ -87,11 +87,11 @@ kubectl describe vm i-019459b33d951b62e -n vm-ns
 # Output
 Name:         i-019459b33d951b62e
 Namespace:    vm-ns
-Labels:       nephe.io/cloud-vm-uid=i-019459b33d951b62e
-              nephe.io/cloud-vpc-uid=vpc-0d6bb6a4a880bd9ad
-              nephe.io/cpa-name=cloudprovideraccount-aws-sample
-              nephe.io/cpa-namespace=vm-ns
-              nephe.io/vpc-name=vpc-0d6bb6a4a880bd9ad
+Labels:       nephe.antrea.io/cloud-vm-uid=i-019459b33d951b62e
+              nephe.antrea.io/cloud-vpc-uid=vpc-0d6bb6a4a880bd9ad
+              nephe.antrea.io/cpa-name=cloudprovideraccount-aws-sample
+              nephe.antrea.io/cpa-namespace=vm-ns
+              nephe.antrea.io/vpc-name=vpc-0d6bb6a4a880bd9ad
 Annotations:  <none>
 API Version:  runtime.cloud.antrea.io/v1alpha1
 Kind:         VirtualMachine

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -215,10 +215,10 @@ kubectl describe vpc vpc-0d6bb6a4a880bd9ad -n sample-ns
 # Output
 Name:         vpc-0d6bb6a4a880bd9ad
 Namespace:    sample-ns
-Labels:       nephe.io/cloud-region=us-west-1
-              nephe.io/cloud-vpc-uid=vpc-0d6bb6a4a880bd9ad
-              nephe.io/cpa-name=cloudprovideraccount-aws-sample
-              nephe.io/cpa-namespace=sample-ns
+Labels:       nephe.antrea.io/cloud-region=us-west-1
+              nephe.antrea.io/cloud-vpc-uid=vpc-0d6bb6a4a880bd9ad
+              nephe.antrea.io/cpa-name=cloudprovideraccount-aws-sample
+              nephe.antrea.io/cpa-namespace=sample-ns
 Annotations:  <none>
 API Version:  runtime.cloud.antrea.io/v1alpha1
 Kind:         Vpc
@@ -293,19 +293,19 @@ kubectl describe ee virtualmachine-i-0033eb4a6c846451d -n sample-ns
 # Output
 Name:         virtualmachine-i-0033eb4a6c846451d
 Namespace:    sample-ns
-Labels:       nephe.io/cloud-region=us-west-1
-              nephe.io/cloud-vm-name=vpc-0d6bb6a4a880bd9ad-ubuntu1
-              nephe.io/cloud-vm-uid=i-0033eb4a6c846451d
-              nephe.io/cloud-vpc-name=test-us-west1-vpc
-              nephe.io/cloud-vpc-uid=vpc-0d6bb6a4a880bd9ad
-              nephe.io/kind=virtualmachine
-              nephe.io/namespace=sample-ns
-              nephe.io/owner-vm=i-0033eb4a6c846451d
-              nephe.io/owner-vm-vpc=vpc-0d6bb6a4a880bd9ad
-              nephe.io/tag-Environment=nephe
-              nephe.io/tag-Login=ec2-user
-              nephe.io/tag-Name=vpc-0d6bb6a4a880bd9ad-ubuntu1
-              nephe.io/tag-Terraform=true
+Labels:       nephe.antrea.io/cloud-region=us-west-1
+              nephe.antrea.io/cloud-vm-name=vpc-0d6bb6a4a880bd9ad-ubuntu1
+              nephe.antrea.io/cloud-vm-uid=i-0033eb4a6c846451d
+              nephe.antrea.io/cloud-vpc-name=test-us-west1-vpc
+              nephe.antrea.io/cloud-vpc-uid=vpc-0d6bb6a4a880bd9ad
+              nephe.antrea.io/kind=virtualmachine
+              nephe.antrea.io/namespace=sample-ns
+              nephe.antrea.io/owner-vm=i-0033eb4a6c846451d
+              nephe.antrea.io/owner-vm-vpc=vpc-0d6bb6a4a880bd9ad
+              nephe.antrea.io/tag-Environment=nephe
+              nephe.antrea.io/tag-Login=ec2-user
+              nephe.antrea.io/tag-Name=vpc-0d6bb6a4a880bd9ad-ubuntu1
+              nephe.antrea.io/tag-Terraform=true
 Annotations:  <none>
 API Version:  crd.antrea.io/v1alpha2
 Kind:         ExternalEntity
@@ -319,19 +319,19 @@ Metadata:
       f:metadata:
         f:labels:
           .:
-          f:nephe.io/cloud-region:
-          f:nephe.io/cloud-vm-name:
-          f:nephe.io/cloud-vm-uid:
-          f:nephe.io/cloud-vpc-name:
-          f:nephe.io/cloud-vpc-uid:
-          f:nephe.io/kind:
-          f:nephe.io/namespace:
-          f:nephe.io/owner-vm:
-          f:nephe.io/owner-vm-vpc:
-          f:nephe.io/tag-environment:
-          f:nephe.io/tag-login:
-          f:nephe.io/tag-name:
-          f:nephe.io/tag-terraform:
+          f:nephe.antrea.io/cloud-region:
+          f:nephe.antrea.io/cloud-vm-name:
+          f:nephe.antrea.io/cloud-vm-uid:
+          f:nephe.antrea.io/cloud-vpc-name:
+          f:nephe.antrea.io/cloud-vpc-uid:
+          f:nephe.antrea.io/kind:
+          f:nephe.antrea.io/namespace:
+          f:nephe.antrea.io/owner-vm:
+          f:nephe.antrea.io/owner-vm-vpc:
+          f:nephe.antrea.io/tag-environment:
+          f:nephe.antrea.io/tag-login:
+          f:nephe.antrea.io/tag-name:
+          f:nephe.antrea.io/tag-terraform:
       f:spec:
         .:
         f:endpoints:
@@ -373,7 +373,7 @@ spec:
   appliedTo:
   - externalEntitySelector:
       matchLabels:
-         nephe.io/kind: virtualmachine
+         nephe.antrea.io/kind: virtualmachine
   ingress:
   - action: Allow
     from:
@@ -412,22 +412,22 @@ sample-ns   i-0033eb4a6c846451d   SUCCESS       1
 The `externalEntitySelector` field in ANP supports the following pre-defined
 labels:
 
-- `nephe.io/kind`: Select based on CRD type. Currently, only supported
+- `nephe.antrea.io/kind`: Select based on CRD type. Currently, only supported
   CRD type is `virtualmachine` in lower case. `virtualmachine` may be used in
   `To`, `From`, `AppliedTo` ANP fields. Thus, an ANP may be applied to virtual
   machines.
-- `nephe.io/owner-vm-vpc`: Select based on K8s VPC resource name of VPC where
+- `nephe.antrea.io/owner-vm-vpc`: Select based on K8s VPC resource name of VPC where
    VM belongs.
-- `nephe.io/owner-vm`: Select based on K8s VM resource name. The resource name
+- `nephe.antrea.io/owner-vm`: Select based on K8s VM resource name. The resource name
   is meaningful only within the K8s cluster. For AWS, virtual machine name is
   the AWS VM instance ID. For Azure virtual machine name is the hashed values of
   the Azure VM resource ID.
-- `nephe.io/cloud-vm-uid`: Select based on unique id(UID) of VM in cloud. For AWS,
+- `nephe.antrea.io/cloud-vm-uid`: Select based on unique id(UID) of VM in cloud. For AWS,
     UID is VM instance ID. For Azure, UID is vmID.
-- `nephe.io/cloud-vm-name`: Select based on VM name in cloud.
-- `nephe.io/cloud-vpc-name`: Select based on VPC name in cloud.
-- `nephe.io/cloud-vpc-uid`: Select based on unique id(UID) of VPC in cloud. For AWS,
+- `nephe.antrea.io/cloud-vm-name`: Select based on VM name in cloud.
+- `nephe.antrea.io/cloud-vpc-name`: Select based on VPC name in cloud.
+- `nephe.antrea.io/cloud-vpc-uid`: Select based on unique id(UID) of VPC in cloud. For AWS,
   UID is VPC ID. For Azure, UID is Resource GUID.
-- `nephe.io/tag-key`: Select based on cloud resource tag key/value pair,
+- `nephe.antrea.io/tag-key`: Select based on cloud resource tag key/value pair,
   where `key` is the cloud resource `Key` tag and the `label` value is
   cloud resource tag `Value`.

--- a/docs/networkpolicy.md
+++ b/docs/networkpolicy.md
@@ -218,9 +218,9 @@ aws-ns      virtualmachine-i-0a20bae92ddcdb60b   58m
 
 A sample Antrea `NetworkPolicy` is shown below, which specifies an Ingress rule
 allowing TCP traffic on port 22. The `from` field is an `externalEntitySelector`
-with matching labels as `nephe.io/owner-vm: i-0033eb4a6c846451d`.  And the `appliedTo`
+with matching labels as `nephe.antrea.io/owner-vm: i-0033eb4a6c846451d`.  And the `appliedTo`
 field is an `externalEntitySelector` with a matching label as
-`nephe.io/kind: virtualmachine`.
+`nephe.antrea.io/kind: virtualmachine`.
 
 ```bash
 # Add Policy to Allow SSH
@@ -234,13 +234,13 @@ spec:
   appliedTo:
   - externalEntitySelector:
       matchLabels:
-        nephe.io/kind: virtualmachine
+        nephe.antrea.io/kind: virtualmachine
   ingress:
   - action: Allow
     from:
     - externalEntitySelector:
         matchLabels:
-          nephe.io/owner-vm: i-0033eb4a6c846451d
+          nephe.antrea.io/owner-vm: i-0033eb4a6c846451d
     ports:
     - protocol: TCP
       port: 22
@@ -397,9 +397,9 @@ azure-ns    virtualmachine-ubuntu-host-vmlinux-0-16140   3m59s
 
 A sample Antrea `NetworkPolicy` is shown below, which specifies an Ingress rule
 allowing TCP traffic on port 22. The `from` field is an externalEntitySelector
-with matching labels as `nephe.io/owner-vm: rhel-host-vmlinux-0-15892`.
+with matching labels as `nephe.antrea.io/owner-vm: rhel-host-vmlinux-0-15892`.
 And the `appliedTo` field is an externalEntitySelector with a matching
-label as `nephe.io/kind: virtualmachine`.
+label as `nephe.antrea.io/kind: virtualmachine`.
 
 ```bash
 apiVersion: crd.antrea.io/v1alpha1
@@ -412,13 +412,13 @@ spec:
   appliedTo:
   - externalEntitySelector:
       matchLabels:
-        nephe.io/kind: virtualmachine
+        nephe.antrea.io/kind: virtualmachine
   ingress:
   - action: Allow
     from:
     - externalEntitySelector:
         matchLabels:
-          nephe.io/owner-vm: rhel-host-vmlinux-0-15892
+          nephe.antrea.io/owner-vm: rhel-host-vmlinux-0-15892
     ports:
     - protocol: TCP
       port: 22

--- a/pkg/apiserver/registry/inventory/virtualmachine/rest.go
+++ b/pkg/apiserver/registry/inventory/virtualmachine/rest.go
@@ -89,7 +89,7 @@ func (r *REST) List(ctx context.Context, options *internalversion.ListOptions) (
 	// List only supports three types of input options:
 	// 1. All namespaces.
 	// 2. Labelselector with only the specific namespace, the only valid labelselectors are
-	//    "nephe.io/cpa-name=<accountname>" and "nephe.io/cpa-namespace=<accountNamespace>".
+	//    "nephe.antrea.io/cpa-name=<accountname>" and "nephe.antrea.io/cpa-namespace=<accountNamespace>".
 	// 3. Specific Namespace.
 	accountName := ""
 	accountNamespace := ""
@@ -103,14 +103,14 @@ func (r *REST) List(ctx context.Context, options *internalversion.ListOptions) (
 				accountNamespace = labelKeyAndValue[1]
 			} else {
 				return nil, errors.NewBadRequest("unsupported label selector, supported labels are: " +
-					"nephe.io/cpa-name and nephe.io/cpa-namespace")
+					"nephe.antrea.io/cpa-name and nephe.antrea.io/cpa-namespace")
 			}
 		}
 	}
 
-	// Check if both nephe.io/cpa-name and nephe.io/cpa-namespace are specified.
+	// Check if both nephe.antrea.io/cpa-name and nephe.antrea.io/cpa-namespace are specified.
 	if (accountName != "" && accountNamespace == "") || (accountName == "" && accountNamespace != "") {
-		return nil, errors.NewBadRequest("unsupported query, both nephe.io/cpa-name and nephe.io/cpa-namespace" +
+		return nil, errors.NewBadRequest("unsupported query, both nephe.antrea.io/cpa-name and nephe.antrea.io/cpa-namespace" +
 			"labels should be specified")
 	}
 

--- a/pkg/apiserver/registry/inventory/vpc/rest.go
+++ b/pkg/apiserver/registry/inventory/vpc/rest.go
@@ -89,8 +89,8 @@ func (r *REST) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runt
 func (r *REST) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
 	// List only supports four types of input options:
 	// 1. All namespace.
-	// 2. Labelselector with only the specific namespace, the only valid labelselectors are "nephe.io/cpa-name=<accountname>",
-	//    "nephe.io/cpa-namespace=<accountNamespace> and "nephe.io/cloud-region=<region>".
+	// 2. Labelselector with only the specific namespace, the only valid labelselectors are "nephe.antrea.io/cpa-name=<accountname>",
+	//    "nephe.antrea.io/cpa-namespace=<accountNamespace> and "nephe.antrea.io/cloud-region=<region>".
 	// 3. Fieldselector with only the specific namespace, the only valid fieldselectors is "metadata.name=<metadata.name>".
 	// 4. Specific Namespace.
 	accountName := ""
@@ -108,7 +108,8 @@ func (r *REST) List(ctx context.Context, options *internalversion.ListOptions) (
 			} else if labelKeyAndValue[0] == labels.CloudRegion {
 				region = strings.ToLower(labelKeyAndValue[1])
 			} else {
-				return nil, errors.NewBadRequest("unsupported label selector, supported labels are: nephe.io/cpa-name and nephe.io/cloud-region")
+				return nil, errors.NewBadRequest("unsupported label selector, supported labels are: nephe.antrea.io/cpa-name" +
+					"and nephe.antrea.io/cloud-region")
 			}
 		}
 	}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -15,7 +15,7 @@
 package labels
 
 const (
-	LabelPrefixNephe = "nephe.io/"
+	LabelPrefixNephe = "nephe.antrea.io/"
 )
 
 // Well known labels on ExternalEntities so that they can be selected by Antrea NetworkPolicies.

--- a/pkg/util/k8s/tags.go
+++ b/pkg/util/k8s/tags.go
@@ -28,7 +28,7 @@ const (
 // ImportTags function returns tags which comply with kubernetes labels format.
 func ImportTags(tags map[string]string) map[string]string {
 	importedTags := make(map[string]string)
-	// Tags are used as kubernetes labels in External Entity in nephe.io/tag-<tag key>=<tag value> format.
+	// Tags are used as kubernetes labels in External Entity in nephe.antrea.io/tag-<tag key>=<tag value> format.
 	// Filter out the tags which don't comply with kubernetes label format.
 	// For Label format, refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set.
 	for key, value := range tags {


### PR DESCRIPTION
As nephe is sub-project of Antrea, all labels are updated to include antrea.io as the suffix.