### PR TITLE
change deprecated ginkgo flag --failFast to --fail-fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,9 +133,9 @@ $(CONTROLLER_GEN):
 
 # Run integration-tests
 integration-test-aws:
-	ginkgo -v --failFast --focus=".*test-aws.*" test/integration/ -- \
+	ginkgo -v --fail-fast --focus=".*test-aws.*" test/integration/ -- \
 	    -manifest-path=../../config/nephe.yml -preserve-setup-on-fail=true -cloud-provider=AWS
 
 integration-test-azure:
-	ginkgo -v --failFast --focus=".*test-azure.*" test/integration/ -- \
+	ginkgo -v --fail-fast --focus=".*test-azure.*" test/integration/ -- \
         -manifest-path=../../config/nephe.yml -preserve-setup-on-fail=true -cloud-provider=Azure


### PR DESCRIPTION
## Description
```
You're using deprecated Ginkgo functionality:
=============================================
  --failFast is deprecated, use --fail-fast instead
```

## Changes
1. Change --failFast to --fail-fast in Makefile