### PR TITLE
Increase integration test timeout to 90m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,9 +133,9 @@ $(CONTROLLER_GEN):
 
 # Run integration-tests
 integration-test-aws:
-	ginkgo -v --fail-fast --focus=".*test-aws.*" test/integration/ -- \
+	ginkgo -v --timeout=90m --fail-fast --focus=".*test-aws.*" test/integration/ -- \
 	    -manifest-path=../../config/nephe.yml -preserve-setup-on-fail=true -cloud-provider=AWS
 
 integration-test-azure:
-	ginkgo -v --fail-fast --focus=".*test-azure.*" test/integration/ -- \
+	ginkgo -v --timeout=90m --fail-fast --focus=".*test-azure.*" test/integration/ -- \
         -manifest-path=../../config/nephe.yml -preserve-setup-on-fail=true -cloud-provider=Azure

--- a/ci/jenkins/scripts/test-aks.sh
+++ b/ci/jenkins/scripts/test-aks.sh
@@ -145,4 +145,4 @@ docker tag antrea/nephe:latest projects.registry.vmware.com/antrea/nephe:latest
 $HOME/terraform/aks load projects.registry.vmware.com/antrea/nephe
 
 mkdir -p $HOME/logs
-ci/bin/integration.test -ginkgo.v -ginkgo.focus=$TEST_FOCUS -kubeconfig=$HOME/tmp/terraform-aks/kubeconfig -cloud-provider=Azure -support-bundle-dir=$HOME/logs -with-agent=${WITH_AGENT} -with-windows=${WITH_WINDOWS}
+ci/bin/integration.test -ginkgo.v -ginkgo.timeout 90m -ginkgo.focus=$TEST_FOCUS -kubeconfig=$HOME/tmp/terraform-aks/kubeconfig -cloud-provider=Azure -support-bundle-dir=$HOME/logs -with-agent=${WITH_AGENT} -with-windows=${WITH_WINDOWS}

--- a/ci/jenkins/scripts/test-aws.sh
+++ b/ci/jenkins/scripts/test-aws.sh
@@ -151,4 +151,4 @@ function cleanup() {
 trap cleanup EXIT
 
 mkdir -p $HOME/logs
-ci/bin/integration.test -ginkgo.v -ginkgo.focus=".*test-aws.*" -kubeconfig=$HOME/.kube/config -cloud-provider=AWS -support-bundle-dir=$HOME/logs
+ci/bin/integration.test -ginkgo.v -ginkgo.timeout 90m -ginkgo.focus=".*test-aws.*" -kubeconfig=$HOME/.kube/config -cloud-provider=AWS -support-bundle-dir=$HOME/logs

--- a/ci/jenkins/scripts/test-azure.sh
+++ b/ci/jenkins/scripts/test-azure.sh
@@ -110,4 +110,4 @@ ci/kind/kind-setup.sh create kind
 echo $TF_VAR_azure_client_subscription_id $TF_VAR_azure_client_id $TF_VAR_azure_client_tenant_id $TF_VAR_azure_client_secret
 
 mkdir -p $HOME/logs
-ci/bin/integration.test -ginkgo.v -ginkgo.focus=".*test-azure.*" -kubeconfig=$HOME/.kube/config -cloud-provider=Azure -support-bundle-dir=$HOME/logs
+ci/bin/integration.test -ginkgo.v -ginkgo.timeout 90m -ginkgo.focus=".*test-azure.*" -kubeconfig=$HOME/.kube/config -cloud-provider=Azure -support-bundle-dir=$HOME/logs

--- a/ci/jenkins/scripts/test-eks.sh
+++ b/ci/jenkins/scripts/test-eks.sh
@@ -198,4 +198,4 @@ docker tag antrea/nephe:latest projects.registry.vmware.com/antrea/nephe:latest
 $HOME/terraform/eks load projects.registry.vmware.com/antrea/nephe
 
 mkdir -p $HOME/logs
-ci/bin/integration.test -ginkgo.v -ginkgo.focus=$TEST_FOCUS -kubeconfig=$HOME/tmp/terraform-eks/kubeconfig -cloud-provider=AWS -support-bundle-dir=$HOME/logs -with-agent=${WITH_AGENT} -with-windows=${WITH_WINDOWS}
+ci/bin/integration.test -ginkgo.v -ginkgo.timeout 90m -ginkgo.focus=$TEST_FOCUS -kubeconfig=$HOME/tmp/terraform-eks/kubeconfig -cloud-provider=AWS -support-bundle-dir=$HOME/logs -with-agent=${WITH_AGENT} -with-windows=${WITH_WINDOWS}


### PR DESCRIPTION
Azure cloud sometime takes more than 1hr to complete the integration test. Increasing the default timeout from 1 hour to 90 minutes.