### PR TITLE
remove appliedTo security group from rule description

### DIFF
--- a/pkg/cloudprovider/cloudapi/aws/aws_security.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_security.go
@@ -208,7 +208,7 @@ func (ec2Cfg *ec2ServiceConfig) realizeIngressIPPermissions(cloudSgObj *ec2.Secu
 		if rule == nil {
 			continue
 		}
-		description, err := securitygroup.GenerateCloudDescription(obj.NpNamespacedName, *cloudSgObj.GroupName)
+		description, err := securitygroup.GenerateCloudDescription(obj.NpNamespacedName)
 		if err != nil {
 			return fmt.Errorf("unable to generate rule description, err: %v", err)
 		}
@@ -257,7 +257,7 @@ func (ec2Cfg *ec2ServiceConfig) realizeEgressIPPermissions(cloudSgObj *ec2.Secur
 		if rule == nil {
 			continue
 		}
-		description, err := securitygroup.GenerateCloudDescription(obj.NpNamespacedName, *cloudSgObj.GroupName)
+		description, err := securitygroup.GenerateCloudDescription(obj.NpNamespacedName)
 		if err != nil {
 			return fmt.Errorf("unable to generate rule description, err: %v", err)
 		}

--- a/pkg/cloudprovider/cloudapi/aws/aws_security_test.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_security_test.go
@@ -403,9 +403,9 @@ var _ = Describe("AWS Cloud Security", func() {
 	Context("GetEnforcedSecurity", func() {
 		It("Should sync cloud security groups and rules with description", func() {
 			desc := securitygroup.CloudRuleDescription{
-				Name:           testAnpNamespacedName.Name,
-				Namespace:      testAnpNamespacedName.Namespace,
-				AppliedToGroup: "dummy"}
+				Name:      testAnpNamespacedName.Name,
+				Namespace: testAnpNamespacedName.Namespace,
+			}
 			descString := desc.String()
 			webAddressGroupIdentifier := &securitygroup.CloudResource{
 				Type: securitygroup.CloudResourceTypeVM,

--- a/pkg/cloudprovider/cloudapi/azure/azure_security.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_security.go
@@ -321,12 +321,10 @@ func (computeCfg *computeServiceConfig) buildEffectiveNSGSecurityRulesToApply(ap
 		}
 
 		// Nephe rules will be created from ruleStartPriority and have description.
-		desc, ok := securitygroup.ExtractCloudDescription(rule.Properties.Description)
+		_, ok := securitygroup.ExtractCloudDescription(rule.Properties.Description)
 		if *rule.Properties.Priority >= ruleStartPriority && ok {
 			// skip any rules created by current processing appliedToGroup (as we have new rules for this group).
-			ruleAddrGroupName := desc.AppliedToGroup
-			_, _, isNepheControllerCreatedRule := securitygroup.IsNepheControllerCreatedSG(desc.AppliedToGroup)
-			if isNepheControllerCreatedRule && strings.Compare(ruleAddrGroupName, appliedToGroupNepheControllerName) == 0 {
+			if isAzureRuleAttachedToAtSg(rule, appliedToGroupNepheControllerName) {
 				continue
 			}
 		}
@@ -393,12 +391,10 @@ func (computeCfg *computeServiceConfig) buildEffectivePeerNSGSecurityRulesToAppl
 		}
 
 		// Nephe rules will be created from ruleStartPriority and have description.
-		desc, ok := securitygroup.ExtractCloudDescription(rule.Properties.Description)
+		_, ok := securitygroup.ExtractCloudDescription(rule.Properties.Description)
 		if *rule.Properties.Priority >= ruleStartPriority && ok {
 			// skip any rules created by current processing appliedToGroup (as we have new rules for this group).
-			ruleAddrGroupName := desc.AppliedToGroup
-			_, _, isNepheControllerCreatedRule := securitygroup.IsNepheControllerCreatedSG(desc.AppliedToGroup)
-			if isNepheControllerCreatedRule && strings.Compare(ruleAddrGroupName, appliedToGroupNepheControllerName) == 0 {
+			if isAzureRuleAttachedToAtSg(rule, appliedToGroupNepheControllerName) {
 				continue
 			}
 		}

--- a/pkg/cloudprovider/securitygroup/helpers.go
+++ b/pkg/cloudprovider/securitygroup/helpers.go
@@ -16,6 +16,7 @@ package securitygroup
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -58,15 +59,14 @@ func FindResourcesBasedOnKind(cloudResources []*CloudResource) (map[string]struc
 }
 
 // GenerateCloudDescription generates a CloudRuleDescription object and converts to string.
-func GenerateCloudDescription(namespacedName string, appliedToGroup string) (string, error) {
+func GenerateCloudDescription(namespacedName string) (string, error) {
 	tokens := strings.Split(namespacedName, "/")
 	if len(tokens) != 2 {
 		return "", fmt.Errorf("invalid namespacedname %v", namespacedName)
 	}
 	desc := CloudRuleDescription{
-		Name:           tokens[1],
-		Namespace:      tokens[0],
-		AppliedToGroup: appliedToGroup,
+		Name:      tokens[1],
+		Namespace: tokens[0],
 	}
 	return desc.String(), nil
 }
@@ -76,7 +76,7 @@ func ExtractCloudDescription(description *string) (*CloudRuleDescription, bool) 
 	if description == nil {
 		return nil, false
 	}
-	numKeyValuePair := 3
+	numKeyValuePair := reflect.TypeOf(CloudRuleDescription{}).NumField()
 	descMap := map[string]string{}
 	tempSlice := strings.Split(*description, ",")
 	if len(tempSlice) != numKeyValuePair {
@@ -91,14 +91,13 @@ func ExtractCloudDescription(description *string) (*CloudRuleDescription, bool) 
 	}
 
 	// check if any of the fields are empty.
-	if descMap[Name] == "" || descMap[Namespace] == "" || descMap[AppliedToGroup] == "" {
+	if descMap[Name] == "" || descMap[Namespace] == "" {
 		return nil, false
 	}
 
 	desc := &CloudRuleDescription{
-		Name:           descMap[Name],
-		Namespace:      descMap[Namespace],
-		AppliedToGroup: descMap[AppliedToGroup],
+		Name:      descMap[Name],
+		Namespace: descMap[Namespace],
 	}
 	return desc, true
 }

--- a/pkg/cloudprovider/securitygroup/securitygroup.go
+++ b/pkg/cloudprovider/securitygroup/securitygroup.go
@@ -103,9 +103,8 @@ Antrea internal NetworkPolicy To SecurityGroup Mapping strategy
 
 const (
 	// Used to create a rule description.
-	Name           = "Name"
-	Namespace      = "Namespace"
-	AppliedToGroup = "AppliedToGroup"
+	Name      = "Name"
+	Namespace = "Ns"
 )
 
 var (
@@ -179,15 +178,13 @@ func (c *CloudResourceID) String() string {
 }
 
 type CloudRuleDescription struct {
-	Name           string
-	Namespace      string
-	AppliedToGroup string
+	Name      string
+	Namespace string
 }
 
 func (r *CloudRuleDescription) String() string {
 	return Name + ":" + r.Name + ", " +
-		Namespace + ":" + r.Namespace + ", " +
-		AppliedToGroup + ":" + r.AppliedToGroup
+		Namespace + ":" + r.Namespace
 }
 
 type Rule interface {


### PR DESCRIPTION
## Description
The rule description field on AWS has a char limit of 255 and on Azure 140. To conserve space and allowing longer possible ANP names, we want to remove appliedTo security group field from cloud rule descriptions, as these information can be directly inferred from rule properties.

## Changes
1. Remove at sg from cloud rule description and update corresponding helper functions.
2. Change Azure rule logic to use sgs in rule properties instead of parsing from description (AWS is already using rule properties).