### PR TITLE
fix reconciliation ci error on controller restart

### DIFF
--- a/pkg/cloudprovider/cloudapi/azure/azure_nsg_rules.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_nsg_rules.go
@@ -121,7 +121,7 @@ func updateSecurityRuleNameAndPriority(existingRules []*armnetwork.SecurityRule,
 }
 
 // convertIngressToNsgSecurityRules converts ingress rules from securitygroup.CloudRule to azure rules.
-func convertIngressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
+func convertIngressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule, isRemove bool,
 	agAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup,
 	atAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup) ([]*armnetwork.SecurityRule, error) {
 	var securityRules []*armnetwork.SecurityRule
@@ -162,7 +162,10 @@ func convertIngressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResou
 
 		srcApplicationSecurityGroups, err := convertToAzureApplicationSecurityGroups(rule.FromSecurityGroups, agAsgMapByNepheControllerName)
 		if err != nil {
-			return []*armnetwork.SecurityRule{}, err
+			if !isRemove {
+				return []*armnetwork.SecurityRule{}, err
+			}
+			continue
 		}
 		if len(srcApplicationSecurityGroups) != 0 {
 			securityRule := buildSecurityRule(nil, protoName, armnetwork.SecurityRuleDirectionInbound,
@@ -183,7 +186,7 @@ func convertIngressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResou
 }
 
 // convertIngressToPeerNsgSecurityRules converts ingress rules that require peering from securitygroup.CloudRule to azure rules.
-func convertIngressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
+func convertIngressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule, isRemove bool,
 	agAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup,
 	ruleIP *string) ([]*armnetwork.SecurityRule, error) {
 	var securityRules []*armnetwork.SecurityRule
@@ -219,7 +222,10 @@ func convertIngressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudR
 			if fromSecurityGroup.Vpc == appliedToGroupID.Vpc {
 				srcApplicationSecurityGroups, err := convertToAzureApplicationSecurityGroups(rule.FromSecurityGroups, agAsgMapByNepheControllerName)
 				if err != nil {
-					return []*armnetwork.SecurityRule{}, err
+					if !isRemove {
+						return []*armnetwork.SecurityRule{}, err
+					}
+					continue
 				}
 				if len(srcApplicationSecurityGroups) != 0 {
 					securityRule := buildSecurityRule(nil, protoName, armnetwork.SecurityRuleDirectionInbound,
@@ -251,7 +257,7 @@ func convertIngressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudR
 }
 
 // convertEgressToNsgSecurityRules converts egress rules from securitygroup.CloudRule to azure rules.
-func convertEgressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
+func convertEgressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule, isRemove bool,
 	agAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup,
 	atAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup) ([]*armnetwork.SecurityRule, error) {
 	var securityRules []*armnetwork.SecurityRule
@@ -291,7 +297,10 @@ func convertEgressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResour
 
 		dstApplicationSecurityGroups, err := convertToAzureApplicationSecurityGroups(rule.ToSecurityGroups, agAsgMapByNepheControllerName)
 		if err != nil {
-			return []*armnetwork.SecurityRule{}, err
+			if !isRemove {
+				return []*armnetwork.SecurityRule{}, err
+			}
+			continue
 		}
 		if len(dstApplicationSecurityGroups) != 0 {
 			securityRule := buildSecurityRule(nil, protoName, armnetwork.SecurityRuleDirectionOutbound,
@@ -312,7 +321,7 @@ func convertEgressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResour
 }
 
 // convertEgressToPeerNsgSecurityRules converts egress rules that require peering from securitygroup.CloudRule to azure rules.
-func convertEgressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
+func convertEgressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule, isRemove bool,
 	agAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup,
 	ruleIP *string) ([]*armnetwork.SecurityRule, error) {
 	var securityRules []*armnetwork.SecurityRule
@@ -347,7 +356,10 @@ func convertEgressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudRe
 			if toSecurityGroup.Vpc == appliedToGroupID.Vpc {
 				dstApplicationSecurityGroups, err := convertToAzureApplicationSecurityGroups(rule.ToSecurityGroups, agAsgMapByNepheControllerName)
 				if err != nil {
-					return []*armnetwork.SecurityRule{}, err
+					if !isRemove {
+						return []*armnetwork.SecurityRule{}, err
+					}
+					continue
 				}
 				if len(dstApplicationSecurityGroups) != 0 {
 					securityRule := buildSecurityRule(nil, protoName, armnetwork.SecurityRuleDirectionOutbound,

--- a/pkg/cloudprovider/cloudapi/azure/azure_security.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_security.go
@@ -316,19 +316,19 @@ func (computeCfg *computeServiceConfig) buildEffectiveNSGSecurityRulesToApply(ap
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	addIngressSecurityRules, err := convertIngressToNsgSecurityRules(appliedToGroupID, addIRule, agAsgMapByNepheName, atAsgMapByNepheName)
+	addIngressRules, err := convertIngressToNsgSecurityRules(appliedToGroupID, addIRule, false, agAsgMapByNepheName, atAsgMapByNepheName)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	addEgressSecurityRules, err := convertEgressToNsgSecurityRules(appliedToGroupID, addERule, agAsgMapByNepheName, atAsgMapByNepheName)
+	addEgressRules, err := convertEgressToNsgSecurityRules(appliedToGroupID, addERule, false, agAsgMapByNepheName, atAsgMapByNepheName)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	rmIngressSecurityRules, err := convertIngressToNsgSecurityRules(appliedToGroupID, rmIRule, agAsgMapByNepheName, atAsgMapByNepheName)
+	rmIngressRules, err := convertIngressToNsgSecurityRules(appliedToGroupID, rmIRule, true, agAsgMapByNepheName, atAsgMapByNepheName)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	rmEgressSecurityRules, err := convertEgressToNsgSecurityRules(appliedToGroupID, rmERule, agAsgMapByNepheName, atAsgMapByNepheName)
+	rmEgressRules, err := convertEgressToNsgSecurityRules(appliedToGroupID, rmERule, true, agAsgMapByNepheName, atAsgMapByNepheName)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
@@ -349,9 +349,9 @@ func (computeCfg *computeServiceConfig) buildEffectiveNSGSecurityRulesToApply(ap
 			// check if the rule is created by current processing appliedToGroup.
 			if isAzureRuleAttachedToAtSg(rule, appliedToGroupNepheControllerName) {
 				// skip the rule if found in remove list.
-				removeRules := rmIngressSecurityRules
+				removeRules := rmIngressRules
 				if *rule.Properties.Direction == armnetwork.SecurityRuleDirectionOutbound {
-					removeRules = rmEgressSecurityRules
+					removeRules = rmEgressRules
 				}
 				normalizedRule := normalizeAzureSecurityRule(rule)
 				idx, found := findSecurityRule(normalizedRule, removeRules)
@@ -371,8 +371,8 @@ func (computeCfg *computeServiceConfig) buildEffectiveNSGSecurityRulesToApply(ap
 		}
 	}
 
-	allIngressRules := updateSecurityRuleNameAndPriority(currentNsgIngressRules, addIngressSecurityRules)
-	allEgressRules := updateSecurityRuleNameAndPriority(currentNsgEgressRules, addEgressSecurityRules)
+	allIngressRules := updateSecurityRuleNameAndPriority(currentNsgIngressRules, addIngressRules)
+	allEgressRules := updateSecurityRuleNameAndPriority(currentNsgEgressRules, addEgressRules)
 
 	return append(allIngressRules, allEgressRules...), nil
 }
@@ -396,19 +396,19 @@ func (computeCfg *computeServiceConfig) buildEffectivePeerNSGSecurityRulesToAppl
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	addIngressSecurityRules, err := convertIngressToPeerNsgSecurityRules(appliedToGroupID, addIRule, agAsgMapByNepheName, ruleIP)
+	addIngressSecurityRules, err := convertIngressToPeerNsgSecurityRules(appliedToGroupID, addIRule, false, agAsgMapByNepheName, ruleIP)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	addEgressSecurityRules, err := convertEgressToPeerNsgSecurityRules(appliedToGroupID, addERule, agAsgMapByNepheName, ruleIP)
+	addEgressSecurityRules, err := convertEgressToPeerNsgSecurityRules(appliedToGroupID, addERule, false, agAsgMapByNepheName, ruleIP)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	rmIngressSecurityRules, err := convertIngressToPeerNsgSecurityRules(appliedToGroupID, rmIRule, agAsgMapByNepheName, ruleIP)
+	rmIngressSecurityRules, err := convertIngressToPeerNsgSecurityRules(appliedToGroupID, rmIRule, true, agAsgMapByNepheName, ruleIP)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	rmEgressSecurityRules, err := convertEgressToPeerNsgSecurityRules(appliedToGroupID, rmERule, agAsgMapByNepheName, ruleIP)
+	rmEgressSecurityRules, err := convertEgressToPeerNsgSecurityRules(appliedToGroupID, rmERule, true, agAsgMapByNepheName, ruleIP)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}


### PR DESCRIPTION
## Description
This PR fixes #236. On rule addition, we want to check if target address asg exists and report an error if not. On deletion we don't care about this since the related rules must have been cleaned up on asg deletion. A check for deletion or not is added before reporting error.

## Changes
1. Add a parameter and check on building and converting Azure rules, so that asg not found will not report an error on rule deletion.