### PR TITLE
stop converting azure any rule to ipv4 cidr

### DIFF
--- a/pkg/cloudprovider/cloudapi/azure/azure_nsg_rules.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_nsg_rules.go
@@ -585,12 +585,6 @@ func convertFromAzureIngressSecurityRuleToCloudRule(rule armnetwork.SecurityRule
 		return nil, err
 	}
 
-	// special handling for Azure any rule, where both srcIP and securityGroups will be empty.
-	if len(srcIP) == 0 && len(securityGroups) == 0 {
-		_, ipNet, _ := net.ParseCIDR("0.0.0.0/0")
-		srcIP = append(srcIP, ipNet)
-	}
-
 	for _, ip := range srcIP {
 		ingressRule := securitygroup.CloudRule{
 			Rule: &securitygroup.IngressRule{
@@ -636,12 +630,6 @@ func convertFromAzureEgressSecurityRuleToCloudRule(rule armnetwork.SecurityRule,
 	protoNum, err := convertFromAzureProtocolToNepheControllerProtocol(rule.Properties.Protocol)
 	if err != nil {
 		return nil, err
-	}
-
-	// special handling for Azure any rule, where both dstIP and securityGroups will be empty.
-	if len(dstIP) == 0 && len(securityGroups) == 0 {
-		_, ipNet, _ := net.ParseCIDR("0.0.0.0/0")
-		dstIP = append(dstIP, ipNet)
 	}
 
 	for _, ip := range dstIP {


### PR DESCRIPTION
## Description
Currently, Azure's "any" rule includes both IPv4 and IPv6. While converting the "any" rule into an IPv4 CIDR makes sense when only IPv4 is supported, it becomes incorrect if IPv6 is also taken into picture.

## Change
1. Eliminated the special handling that converts Azure's "any" rule into an IPv4 0.0.0.0/0 CIDR. From now on, the "any" rule in Azure will be treated as a user-defined custom rule and will not be converted by Nephe. Nephe will only handle specific IPv4 and IPv6 CIDRs.