### PR TITLE
Adding IPv6 rule support in Nephe

### DIFF
--- a/pkg/cloudprovider/cloudapi/aws/aws_security.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_security.go
@@ -213,13 +213,14 @@ func (ec2Cfg *ec2ServiceConfig) realizeIngressIPPermissions(cloudSgObj *ec2.Secu
 			return fmt.Errorf("unable to generate rule description, err: %v", err)
 		}
 		idGroupPairs := buildEc2UserIDGroupPairs(rule.FromSecurityGroups, cloudSGNameToObj, &description)
-		ipRanges := convertToEc2IpRanges(rule.FromSrcIP, len(rule.FromSecurityGroups) > 0, &description)
+		ipv4Ranges, ipv6Ranges := convertToEc2IpRanges(rule.FromSrcIP, len(rule.FromSecurityGroups) > 0, &description)
 		startPort, endPort := convertToIPPermissionPort(rule.FromPort, rule.Protocol)
 		ipPermission := &ec2.IpPermission{
 			FromPort:         startPort,
 			ToPort:           endPort,
 			IpProtocol:       convertToIPPermissionProtocol(rule.Protocol),
-			IpRanges:         ipRanges,
+			IpRanges:         ipv4Ranges,
+			Ipv6Ranges:       ipv6Ranges,
 			UserIdGroupPairs: idGroupPairs,
 		}
 		newIpPermissions = append(newIpPermissions, ipPermission)
@@ -263,13 +264,14 @@ func (ec2Cfg *ec2ServiceConfig) realizeEgressIPPermissions(cloudSgObj *ec2.Secur
 		}
 
 		idGroupPairs := buildEc2UserIDGroupPairs(rule.ToSecurityGroups, cloudSGNameToObj, &description)
-		ipRanges := convertToEc2IpRanges(rule.ToDstIP, len(rule.ToSecurityGroups) > 0, &description)
+		ipv4Ranges, ipv6Ranges := convertToEc2IpRanges(rule.ToDstIP, len(rule.ToSecurityGroups) > 0, &description)
 		startPort, endPort := convertToIPPermissionPort(rule.ToPort, rule.Protocol)
 		ipPermission := &ec2.IpPermission{
 			FromPort:         startPort,
 			ToPort:           endPort,
 			IpProtocol:       convertToIPPermissionProtocol(rule.Protocol),
-			IpRanges:         ipRanges,
+			IpRanges:         ipv4Ranges,
+			Ipv6Ranges:       ipv6Ranges,
 			UserIdGroupPairs: idGroupPairs,
 		}
 		newIpPermissions = append(newIpPermissions, ipPermission)

--- a/pkg/cloudprovider/cloudapi/aws/aws_security_test.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_security_test.go
@@ -257,8 +257,11 @@ var _ = Describe("AWS Cloud Security", func() {
 			}
 			addRule := []*securitygroup.CloudRule{{
 				Rule: &securitygroup.IngressRule{
-					FromPort:           aws.Int(22),
-					FromSrcIP:          []*net.IPNet{},
+					FromPort: aws.Int(22),
+					FromSrcIP: []*net.IPNet{{
+						IP:   net.ParseIP("2600:1f16:c77:a001:fb97:21b2:a8dc:dc60"),
+						Mask: net.CIDRMask(128, 128)},
+					},
 					FromSecurityGroups: []*securitygroup.CloudResourceID{&webSgIdentifier.CloudResourceID},
 					Protocol:           aws.Int(6),
 				}, NpNamespacedName: testAnpNamespacedName.String()},

--- a/pkg/cloudprovider/cloudapi/azure/azure_security_test.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_security_test.go
@@ -415,6 +415,34 @@ var _ = Describe("Azure Cloud Security", func() {
 				Expect(err).Should(BeNil())
 			})
 
+			It("Should update IPv6 Security rules successfully", func() {
+				webAddressGroupIdentifier03 := &securitygroup.CloudResource{
+					Type: securitygroup.CloudResourceTypeVM,
+					CloudResourceID: securitygroup.CloudResourceID{
+						Name: atAsgName,
+						Vpc:  testVnetID01,
+					},
+					AccountID:     testAccountNamespacedName.String(),
+					CloudProvider: string(v1alpha1.AzureCloudProvider),
+				}
+				toSg := webAddressGroupIdentifier03.CloudResourceID
+				toSg.Name = agAsgName
+
+				addRules := []*securitygroup.CloudRule{{
+					Rule: &securitygroup.IngressRule{
+						Protocol: &testProtocol,
+						FromPort: &testFromPort,
+						FromSrcIP: []*net.IPNet{{
+							IP:   net.ParseIP("2600:1f16:c77:a001:fb97:21b2:a8dc:dc60"),
+							Mask: net.CIDRMask(128, 128)},
+						}},
+					NpNamespacedName: testAnpNamespace.String()},
+				}
+
+				err := c.UpdateSecurityGroupRules(webAddressGroupIdentifier03, addRules, []*securitygroup.CloudRule{})
+				Expect(err).Should(BeNil())
+			})
+
 			//  Creating cloud security rules without a description field is not allowed.
 			It("Should fail to update Security rules -- invalid namespacedname", func() {
 				webAddressGroupIdentifier03 := &securitygroup.CloudResource{

--- a/pkg/controllers/networkpolicy/networkpolicy.go
+++ b/pkg/controllers/networkpolicy/networkpolicy.go
@@ -1235,11 +1235,9 @@ func (r *networkPolicyRule) rules(rr *NetworkPolicyReconciler, policyAppliedToGr
 		for _, ip := range rule.From.IPBlocks {
 			ingress := &securitygroup.IngressRule{}
 			ingress.AppliedToGroup = make(map[string]struct{}, 0)
-			ipNet := net.IPNet{IP: net.IP(ip.CIDR.IP), Mask: net.CIDRMask(int(ip.CIDR.PrefixLength), 32)}
+			ipNet := net.IPNet{IP: net.IP(ip.CIDR.IP), Mask: net.CIDRMask(int(ip.CIDR.PrefixLength), 8*net.IPv4len)}
 			if ipNet.IP.To4() == nil {
-				// TODO: Enable this when IPv6 is supported in Nephe.
-				rr.Log.V(1).Info("IPv6 address detected in the rule. Skipping it for now.")
-				continue
+				ipNet = net.IPNet{IP: net.IP(ip.CIDR.IP), Mask: net.CIDRMask(int(ip.CIDR.PrefixLength), 8*net.IPv6len)}
 			}
 			ingress.FromSrcIP = append(ingress.FromSrcIP, &ipNet)
 			securitygroup.SetAppliedToGroup(rule.AppliedToGroups, policyAppliedToGroups, ingress)
@@ -1300,11 +1298,9 @@ func (r *networkPolicyRule) rules(rr *NetworkPolicyReconciler, policyAppliedToGr
 	for _, ip := range rule.To.IPBlocks {
 		egress := &securitygroup.EgressRule{}
 		egress.AppliedToGroup = make(map[string]struct{}, 0)
-		ipNet := net.IPNet{IP: net.IP(ip.CIDR.IP), Mask: net.CIDRMask(int(ip.CIDR.PrefixLength), 32)}
+		ipNet := net.IPNet{IP: net.IP(ip.CIDR.IP), Mask: net.CIDRMask(int(ip.CIDR.PrefixLength), 8*net.IPv4len)}
 		if ipNet.IP.To4() == nil {
-			// TODO: Enable this when IPv6 is supported in Nephe.
-			rr.Log.V(1).Info("IPv6 address detected in the rule. Skipping it for now.")
-			continue
+			ipNet = net.IPNet{IP: net.IP(ip.CIDR.IP), Mask: net.CIDRMask(int(ip.CIDR.PrefixLength), 8*net.IPv6len)}
 		}
 		egress.ToDstIP = append(egress.ToDstIP, &ipNet)
 		securitygroup.SetAppliedToGroup(rule.AppliedToGroups, policyAppliedToGroups, egress)

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/fields"
@@ -50,19 +52,19 @@ func InitInventory() *Inventory {
 }
 
 // BuildVpcCache builds vpc cache for given account using vpc list fetched from cloud.
-func (inventory *Inventory) BuildVpcCache(discoveredVpcMap map[string]*runtimev1alpha1.Vpc,
+func (i *Inventory) BuildVpcCache(discoveredVpcMap map[string]*runtimev1alpha1.Vpc,
 	namespacedName *types.NamespacedName) error {
 	var numVpcsToAdd, numVpcsToUpdate, numVpcsToDelete int
 	// Fetch all vpcs for a given account from the cache and check if it exists in the discovered vpc list.
-	vpcsInCache, _ := inventory.vpcStore.GetByIndex(indexer.VpcByNamespacedAccountName, namespacedName.String())
+	vpcsInCache, _ := i.vpcStore.GetByIndex(indexer.VpcByNamespacedAccountName, namespacedName.String())
 
 	// Remove vpcs in vpc cache which are not found in vpc list fetched from cloud.
-	for _, i := range vpcsInCache {
-		vpc := i.(*runtimev1alpha1.Vpc)
+	for _, object := range vpcsInCache {
+		vpc := object.(*runtimev1alpha1.Vpc)
 		if _, found := discoveredVpcMap[vpc.Status.CloudId]; !found {
-			if err := inventory.vpcStore.Delete(fmt.Sprintf("%v/%v-%v", vpc.Namespace,
+			if err := i.vpcStore.Delete(fmt.Sprintf("%v/%v-%v", vpc.Namespace,
 				vpc.Labels[nephelabels.CloudAccountName], vpc.Status.CloudId)); err != nil {
-				inventory.log.Error(err, "failed to delete vpc from vpc cache",
+				i.log.Error(err, "failed to delete vpc from vpc cache",
 					"vpc id", vpc.Status.CloudId, "account", namespacedName.String())
 			} else {
 				numVpcsToDelete++
@@ -75,86 +77,86 @@ func (inventory *Inventory) BuildVpcCache(discoveredVpcMap map[string]*runtimev1
 		key := fmt.Sprintf("%v/%v-%v", discoveredVpc.Namespace,
 			discoveredVpc.Labels[nephelabels.CloudAccountName],
 			discoveredVpc.Status.CloudId)
-		if cachedObj, found, _ := inventory.vpcStore.Get(key); !found {
-			err = inventory.vpcStore.Create(discoveredVpc)
+		if cachedObj, found, _ := i.vpcStore.Get(key); !found {
+			err = i.vpcStore.Create(discoveredVpc)
 			if err == nil {
 				numVpcsToAdd++
 			}
 		} else {
 			cachedVpc := cachedObj.(*runtimev1alpha1.Vpc)
 			if !reflect.DeepEqual(cachedVpc.Status, discoveredVpc.Status) {
-				err = inventory.vpcStore.Update(discoveredVpc)
+				err = i.vpcStore.Update(discoveredVpc)
 				if err == nil {
 					numVpcsToUpdate++
 				}
 			}
 		}
 		if err != nil {
-			inventory.log.Error(err, "failed to update vpc in vpc cache", "vpc", discoveredVpc.Status.CloudId,
+			i.log.Error(err, "failed to update vpc in vpc cache", "vpc", discoveredVpc.Status.CloudId,
 				"account", namespacedName.String())
 		}
 	}
 
 	if numVpcsToAdd != 0 || numVpcsToUpdate != 0 || numVpcsToDelete != 0 {
-		inventory.log.Info("Vpc poll statistics", "account", namespacedName, "added", numVpcsToAdd,
+		i.log.Info("Vpc poll statistics", "account", namespacedName, "added", numVpcsToAdd,
 			"update", numVpcsToUpdate, "delete", numVpcsToDelete)
 	}
 	return nil
 }
 
 // DeleteVpcsFromCache deletes all entries from vpc cache for a given account.
-func (inventory *Inventory) DeleteVpcsFromCache(namespacedName *types.NamespacedName) error {
-	vpcsInCache, err := inventory.vpcStore.GetByIndex(indexer.VpcByNamespacedAccountName, namespacedName.String())
+func (i *Inventory) DeleteVpcsFromCache(namespacedName *types.NamespacedName) error {
+	vpcsInCache, err := i.vpcStore.GetByIndex(indexer.VpcByNamespacedAccountName, namespacedName.String())
 	if err != nil {
 		return err
 	}
 	var numVpcsToDelete int
-	for _, i := range vpcsInCache {
-		vpc := i.(*runtimev1alpha1.Vpc)
+	for _, object := range vpcsInCache {
+		vpc := object.(*runtimev1alpha1.Vpc)
 		key := fmt.Sprintf("%v/%v-%v", vpc.Namespace, vpc.Labels[nephelabels.CloudAccountName], vpc.Status.CloudId)
-		if err := inventory.vpcStore.Delete(key); err != nil {
-			inventory.log.Error(err, "failed to delete vpc from vpc cache, account: %v", *namespacedName)
+		if err := i.vpcStore.Delete(key); err != nil {
+			i.log.Error(err, "failed to delete vpc from vpc cache, account: %v", *namespacedName)
 		} else {
 			numVpcsToDelete++
 		}
 	}
 
 	if numVpcsToDelete != 0 {
-		inventory.log.Info("Vpc poll statistics", "account", namespacedName, "deleted", numVpcsToDelete)
+		i.log.Info("Vpc poll statistics", "account", namespacedName, "deleted", numVpcsToDelete)
 	}
 	return nil
 }
 
 // GetVpcsFromIndexer returns vpcs matching the indexedValue for the requested indexName.
-func (inventory *Inventory) GetVpcsFromIndexer(indexName string, indexedValue string) ([]interface{}, error) {
-	return inventory.vpcStore.GetByIndex(indexName, indexedValue)
+func (i *Inventory) GetVpcsFromIndexer(indexName string, indexedValue string) ([]interface{}, error) {
+	return i.vpcStore.GetByIndex(indexName, indexedValue)
 }
 
 // GetAllVpcs returns all the vpcs from the vpc cache.
-func (inventory *Inventory) GetAllVpcs() []interface{} {
-	return inventory.vpcStore.List()
+func (i *Inventory) GetAllVpcs() []interface{} {
+	return i.vpcStore.List()
 }
 
 // WatchVpcs returns a Watch interface of vpc.
-func (inventory *Inventory) WatchVpcs(ctx context.Context, key string, labelSelector labels.Selector,
+func (i *Inventory) WatchVpcs(ctx context.Context, key string, labelSelector labels.Selector,
 	fieldSelector fields.Selector) (watch.Interface, error) {
-	return inventory.vpcStore.Watch(ctx, key, labelSelector, fieldSelector)
+	return i.vpcStore.Watch(ctx, key, labelSelector, fieldSelector)
 }
 
 // BuildVmCache builds vm cache for given account using vm list fetched from cloud.
-func (inventory *Inventory) BuildVmCache(discoveredVmMap map[string]*runtimev1alpha1.VirtualMachine,
+func (i *Inventory) BuildVmCache(discoveredVmMap map[string]*runtimev1alpha1.VirtualMachine,
 	namespacedName *types.NamespacedName) {
 	var numVmsToAdd, numVmsToUpdate, numVmsToDelete int
 
 	// Fetch all vms for a given account from the cache and check if it exists in the discovered vm list.
-	vmsInCache, _ := inventory.vmStore.GetByIndex(indexer.VirtualMachineByNamespacedAccountName, namespacedName.String())
+	vmsInCache, _ := i.vmStore.GetByIndex(indexer.VirtualMachineByNamespacedAccountName, namespacedName.String())
 	// Remove vm from vm cache which are not found in vm map fetched from cloud.
 	for _, cachedObject := range vmsInCache {
 		cachedVm := cachedObject.(*runtimev1alpha1.VirtualMachine)
 		if _, found := discoveredVmMap[cachedVm.Name]; !found {
 			key := fmt.Sprintf("%v/%v", cachedVm.Namespace, cachedVm.Name)
-			if err := inventory.vmStore.Delete(key); err != nil {
-				inventory.log.Error(err, "failed to delete vm from vm cache", "vm", cachedVm.Name, "account",
+			if err := i.vmStore.Delete(key); err != nil {
+				i.log.Error(err, "failed to delete vm from vm cache", "vm", cachedVm.Name, "account",
 					namespacedName.String())
 			} else {
 				numVmsToDelete++
@@ -166,22 +168,22 @@ func (inventory *Inventory) BuildVmCache(discoveredVmMap map[string]*runtimev1al
 	for _, discoveredVm := range discoveredVmMap {
 		var err error
 		key := fmt.Sprintf("%v/%v", discoveredVm.Namespace, discoveredVm.Name)
-		if cachedObject, found, _ := inventory.vmStore.Get(key); !found {
-			err = inventory.vmStore.Create(discoveredVm)
+		if cachedObject, found, _ := i.vmStore.Get(key); !found {
+			err = i.vmStore.Create(discoveredVm)
 			if err == nil {
 				numVmsToAdd++
 			}
 		} else {
 			cachedVm := cachedObject.(*runtimev1alpha1.VirtualMachine)
-			if !reflect.DeepEqual(cachedVm.Status, discoveredVm.Status) {
+			if !i.compareVirtualMachineObjects(cachedVm.Status, discoveredVm.Status) {
 				if cachedVm.Status.Agented != discoveredVm.Status.Agented {
 					key := fmt.Sprintf("%v/%v", cachedVm.Namespace, cachedVm.Name)
-					err = inventory.vmStore.Delete(key)
+					err = i.vmStore.Delete(key)
 					if err == nil {
-						err = inventory.vmStore.Create(discoveredVm)
+						err = i.vmStore.Create(discoveredVm)
 					}
 				} else {
-					err = inventory.vmStore.Update(discoveredVm)
+					err = i.vmStore.Update(discoveredVm)
 				}
 				if err == nil {
 					numVmsToUpdate++
@@ -189,20 +191,20 @@ func (inventory *Inventory) BuildVmCache(discoveredVmMap map[string]*runtimev1al
 			}
 		}
 		if err != nil {
-			inventory.log.Error(err, "failed to update vm in vm cache", "vm", discoveredVm.Name,
+			i.log.Error(err, "failed to update vm in vm cache", "vm", discoveredVm.Name,
 				"account", namespacedName.String())
 		}
 	}
 
 	if numVmsToAdd != 0 || numVmsToUpdate != 0 || numVmsToDelete != 0 {
-		inventory.log.Info("Vm poll statistics", "account", namespacedName, "added", numVmsToAdd,
+		i.log.Info("Vm poll statistics", "account", namespacedName, "added", numVmsToAdd,
 			"update", numVmsToUpdate, "delete", numVmsToDelete)
 	}
 }
 
 // DeleteVmsFromCache deletes all entries from vm cache for a given account.
-func (inventory *Inventory) DeleteVmsFromCache(namespacedName *types.NamespacedName) error {
-	vmsInCache, err := inventory.vmStore.GetByIndex(indexer.VirtualMachineByNamespacedAccountName, namespacedName.String())
+func (i *Inventory) DeleteVmsFromCache(namespacedName *types.NamespacedName) error {
+	vmsInCache, err := i.vmStore.GetByIndex(indexer.VirtualMachineByNamespacedAccountName, namespacedName.String())
 	if err != nil {
 		return err
 	}
@@ -210,35 +212,35 @@ func (inventory *Inventory) DeleteVmsFromCache(namespacedName *types.NamespacedN
 	for _, cachedObject := range vmsInCache {
 		cachedVm := cachedObject.(*runtimev1alpha1.VirtualMachine)
 		key := fmt.Sprintf("%v/%v", cachedVm.Namespace, cachedVm.Name)
-		if err := inventory.vmStore.Delete(key); err != nil {
-			inventory.log.Error(err, "failed to delete vm from vm cache, account: %v vm: %v", *namespacedName, cachedVm.Name)
+		if err := i.vmStore.Delete(key); err != nil {
+			i.log.Error(err, "failed to delete vm from vm cache, account: %v vm: %v", *namespacedName, cachedVm.Name)
 		} else {
 			numVmsToDelete++
 		}
 	}
 
 	if numVmsToDelete != 0 {
-		inventory.log.Info("Vm poll statistics", "account", namespacedName, "deleted", numVmsToDelete)
+		i.log.Info("Vm poll statistics", "account", namespacedName, "deleted", numVmsToDelete)
 	}
 	return nil
 }
 
 // GetAllVms returns all the vms from the vm cache.
-func (inventory *Inventory) GetAllVms() []interface{} {
-	return inventory.vmStore.List()
+func (i *Inventory) GetAllVms() []interface{} {
+	return i.vmStore.List()
 }
 
 // GetVmFromIndexer returns vms matching the indexedValue for the requested indexName.
-func (inventory *Inventory) GetVmFromIndexer(indexName string, indexedValue string) ([]interface{}, error) {
-	return inventory.vmStore.GetByIndex(indexName, indexedValue)
+func (i *Inventory) GetVmFromIndexer(indexName string, indexedValue string) ([]interface{}, error) {
+	return i.vmStore.GetByIndex(indexName, indexedValue)
 }
 
 // GetVmByKey returns vm from vm cache for a given key (namespace/name).
-func (inventory *Inventory) GetVmByKey(key string) (*runtimev1alpha1.VirtualMachine, bool) {
-	cachedObject, found, err := inventory.vmStore.Get(key)
+func (i *Inventory) GetVmByKey(key string) (*runtimev1alpha1.VirtualMachine, bool) {
+	cachedObject, found, err := i.vmStore.Get(key)
 	if err != nil {
 		// Shouldn't happen. Logging it.
-		inventory.log.Error(err, "failed to lookup vm", "vm", key)
+		i.log.Error(err, "failed to lookup vm", "vm", key)
 		return nil, false
 	}
 	if !found {
@@ -248,7 +250,35 @@ func (inventory *Inventory) GetVmByKey(key string) (*runtimev1alpha1.VirtualMach
 }
 
 // WatchVms returns a Watch interface of vm cache.
-func (inventory *Inventory) WatchVms(ctx context.Context, key string, labelSelector labels.Selector,
+func (i *Inventory) WatchVms(ctx context.Context, key string, labelSelector labels.Selector,
 	fieldSelector fields.Selector) (watch.Interface, error) {
-	return inventory.vmStore.Watch(ctx, key, labelSelector, fieldSelector)
+	return i.vmStore.Watch(ctx, key, labelSelector, fieldSelector)
+}
+
+// compareVirtualMachineObjects compare if two virtual machine objects are the same. Return true if same.
+func (i Inventory) compareVirtualMachineObjects(cached, discovered runtimev1alpha1.VirtualMachineStatus) bool {
+	// 1. Check if objects are same.
+	if reflect.DeepEqual(cached, discovered) {
+		return true
+	}
+	// 2. Check if NetworkInterface field differ.
+	if reflect.DeepEqual(cached.NetworkInterfaces, discovered.NetworkInterfaces) {
+		return false
+	}
+
+	// 3. Sort NetworkInterface field and re-compare.
+	sortInterfacesFunc := func(intfs []runtimev1alpha1.NetworkInterface) {
+		sort.Slice(intfs, func(i, j int) bool {
+			return strings.Compare(intfs[i].Name, intfs[j].Name) < 0
+		})
+		for _, intf := range intfs {
+			sort.Slice(intf.IPs, func(i, j int) bool {
+				return strings.Compare(intf.IPs[i].Address, intf.IPs[j].Address) < 0
+			})
+		}
+	}
+	sortInterfacesFunc(cached.NetworkInterfaces)
+	dis := discovered.DeepCopy()
+	sortInterfacesFunc(dis.NetworkInterfaces)
+	return reflect.DeepEqual(cached.NetworkInterfaces, dis.NetworkInterfaces)
 }


### PR DESCRIPTION
## Description
Handle IPv6 addresses configured on Antrea NetworkPolicy

## Changes 
With this checkin, Nephe controller will accept IPv6 IP blocks in Antrea NetworkPolicy and will apply them in cloud. Also, VirtualMachine Object will now include both IPv4 and IPv6 addresses in the network interface field.