### PR TITLE
fix reconciliation issue when ag is modified during controller restart

### DIFF
--- a/pkg/cloudprovider/cloudapi/azure/azure_nsg_rules.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_nsg_rules.go
@@ -121,7 +121,7 @@ func updateSecurityRuleNameAndPriority(existingRules []*armnetwork.SecurityRule,
 }
 
 // convertIngressToNsgSecurityRules converts ingress rules from securitygroup.CloudRule to azure rules.
-func convertIngressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule, isRemove bool,
+func convertIngressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
 	agAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup,
 	atAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup) ([]*armnetwork.SecurityRule, error) {
 	var securityRules []*armnetwork.SecurityRule
@@ -162,10 +162,7 @@ func convertIngressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResou
 
 		srcApplicationSecurityGroups, err := convertToAzureApplicationSecurityGroups(rule.FromSecurityGroups, agAsgMapByNepheControllerName)
 		if err != nil {
-			if !isRemove {
-				return []*armnetwork.SecurityRule{}, err
-			}
-			continue
+			return []*armnetwork.SecurityRule{}, err
 		}
 		if len(srcApplicationSecurityGroups) != 0 {
 			securityRule := buildSecurityRule(nil, protoName, armnetwork.SecurityRuleDirectionInbound,
@@ -186,7 +183,7 @@ func convertIngressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResou
 }
 
 // convertIngressToPeerNsgSecurityRules converts ingress rules that require peering from securitygroup.CloudRule to azure rules.
-func convertIngressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule, isRemove bool,
+func convertIngressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
 	agAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup,
 	ruleIP *string) ([]*armnetwork.SecurityRule, error) {
 	var securityRules []*armnetwork.SecurityRule
@@ -222,10 +219,7 @@ func convertIngressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudR
 			if fromSecurityGroup.Vpc == appliedToGroupID.Vpc {
 				srcApplicationSecurityGroups, err := convertToAzureApplicationSecurityGroups(rule.FromSecurityGroups, agAsgMapByNepheControllerName)
 				if err != nil {
-					if !isRemove {
-						return []*armnetwork.SecurityRule{}, err
-					}
-					continue
+					return []*armnetwork.SecurityRule{}, err
 				}
 				if len(srcApplicationSecurityGroups) != 0 {
 					securityRule := buildSecurityRule(nil, protoName, armnetwork.SecurityRuleDirectionInbound,
@@ -257,7 +251,7 @@ func convertIngressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudR
 }
 
 // convertEgressToNsgSecurityRules converts egress rules from securitygroup.CloudRule to azure rules.
-func convertEgressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule, isRemove bool,
+func convertEgressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
 	agAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup,
 	atAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup) ([]*armnetwork.SecurityRule, error) {
 	var securityRules []*armnetwork.SecurityRule
@@ -297,10 +291,7 @@ func convertEgressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResour
 
 		dstApplicationSecurityGroups, err := convertToAzureApplicationSecurityGroups(rule.ToSecurityGroups, agAsgMapByNepheControllerName)
 		if err != nil {
-			if !isRemove {
-				return []*armnetwork.SecurityRule{}, err
-			}
-			continue
+			return []*armnetwork.SecurityRule{}, err
 		}
 		if len(dstApplicationSecurityGroups) != 0 {
 			securityRule := buildSecurityRule(nil, protoName, armnetwork.SecurityRuleDirectionOutbound,
@@ -321,7 +312,7 @@ func convertEgressToNsgSecurityRules(appliedToGroupID *securitygroup.CloudResour
 }
 
 // convertEgressToPeerNsgSecurityRules converts egress rules that require peering from securitygroup.CloudRule to azure rules.
-func convertEgressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule, isRemove bool,
+func convertEgressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudResourceID, rules []*securitygroup.CloudRule,
 	agAsgMapByNepheControllerName map[string]armnetwork.ApplicationSecurityGroup,
 	ruleIP *string) ([]*armnetwork.SecurityRule, error) {
 	var securityRules []*armnetwork.SecurityRule
@@ -356,10 +347,7 @@ func convertEgressToPeerNsgSecurityRules(appliedToGroupID *securitygroup.CloudRe
 			if toSecurityGroup.Vpc == appliedToGroupID.Vpc {
 				dstApplicationSecurityGroups, err := convertToAzureApplicationSecurityGroups(rule.ToSecurityGroups, agAsgMapByNepheControllerName)
 				if err != nil {
-					if !isRemove {
-						return []*armnetwork.SecurityRule{}, err
-					}
-					continue
+					return []*armnetwork.SecurityRule{}, err
 				}
 				if len(dstApplicationSecurityGroups) != 0 {
 					securityRule := buildSecurityRule(nil, protoName, armnetwork.SecurityRuleDirectionOutbound,

--- a/pkg/cloudprovider/cloudapi/azure/azure_security.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_security.go
@@ -316,19 +316,19 @@ func (computeCfg *computeServiceConfig) buildEffectiveNSGSecurityRulesToApply(ap
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	addIngressRules, err := convertIngressToNsgSecurityRules(appliedToGroupID, addIRule, false, agAsgMapByNepheName, atAsgMapByNepheName)
+	addIngressRules, err := convertIngressToNsgSecurityRules(appliedToGroupID, addIRule, agAsgMapByNepheName, atAsgMapByNepheName)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	addEgressRules, err := convertEgressToNsgSecurityRules(appliedToGroupID, addERule, false, agAsgMapByNepheName, atAsgMapByNepheName)
+	addEgressRules, err := convertEgressToNsgSecurityRules(appliedToGroupID, addERule, agAsgMapByNepheName, atAsgMapByNepheName)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	rmIngressRules, err := convertIngressToNsgSecurityRules(appliedToGroupID, rmIRule, true, agAsgMapByNepheName, atAsgMapByNepheName)
+	rmIngressRules, err := convertIngressToNsgSecurityRules(appliedToGroupID, rmIRule, agAsgMapByNepheName, atAsgMapByNepheName)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	rmEgressRules, err := convertEgressToNsgSecurityRules(appliedToGroupID, rmERule, true, agAsgMapByNepheName, atAsgMapByNepheName)
+	rmEgressRules, err := convertEgressToNsgSecurityRules(appliedToGroupID, rmERule, agAsgMapByNepheName, atAsgMapByNepheName)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
@@ -396,19 +396,19 @@ func (computeCfg *computeServiceConfig) buildEffectivePeerNSGSecurityRulesToAppl
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	addIngressSecurityRules, err := convertIngressToPeerNsgSecurityRules(appliedToGroupID, addIRule, false, agAsgMapByNepheName, ruleIP)
+	addIngressSecurityRules, err := convertIngressToPeerNsgSecurityRules(appliedToGroupID, addIRule, agAsgMapByNepheName, ruleIP)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	addEgressSecurityRules, err := convertEgressToPeerNsgSecurityRules(appliedToGroupID, addERule, false, agAsgMapByNepheName, ruleIP)
+	addEgressSecurityRules, err := convertEgressToPeerNsgSecurityRules(appliedToGroupID, addERule, agAsgMapByNepheName, ruleIP)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	rmIngressSecurityRules, err := convertIngressToPeerNsgSecurityRules(appliedToGroupID, rmIRule, true, agAsgMapByNepheName, ruleIP)
+	rmIngressSecurityRules, err := convertIngressToPeerNsgSecurityRules(appliedToGroupID, rmIRule, agAsgMapByNepheName, ruleIP)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
-	rmEgressSecurityRules, err := convertEgressToPeerNsgSecurityRules(appliedToGroupID, rmERule, true, agAsgMapByNepheName, ruleIP)
+	rmEgressSecurityRules, err := convertEgressToPeerNsgSecurityRules(appliedToGroupID, rmERule, agAsgMapByNepheName, ruleIP)
 	if err != nil {
 		return []*armnetwork.SecurityRule{}, err
 	}
@@ -1020,9 +1020,12 @@ func (c *azureCloud) DeleteSecurityGroup(securityGroupIdentifier *securitygroup.
 	if err != nil {
 		return err
 	}
-	err = computeService.removeReferencesToSecurityGroup(&securityGroupIdentifier.CloudResourceID, rgName, location, membershipOnly)
-	if err != nil {
-		return err
+	// remove attached rules for appliedTo sg but not address sg. This behavior is consistent with AWS.
+	if !membershipOnly {
+		err = computeService.removeReferencesToSecurityGroup(&securityGroupIdentifier.CloudResourceID, rgName, location, membershipOnly)
+		if err != nil {
+			return err
+		}
 	}
 
 	var cloudAsgName string

--- a/pkg/controllers/networkpolicy/networkpolicy.go
+++ b/pkg/controllers/networkpolicy/networkpolicy.go
@@ -1005,15 +1005,15 @@ func (a *appliedToSecurityGroup) checkRealization(r *NetworkPolicyReconciler, np
 // updateAddrGroupReference updates appliedTo group addrGroupRefs and notifies removed addrGroups that rules referencing them is removed.
 func (a *appliedToSecurityGroup) updateAddrGroupReference(r *NetworkPolicyReconciler) error {
 	// get latest irules and erules
-	nps, err := r.networkPolicyIndexer.ByIndex(networkPolicyIndexerByAppliedToGrp, a.id.Name)
+	rules, err := r.cloudRuleIndexer.ByIndex(cloudRuleIndexerByAppliedToGrp, a.id.CloudResourceID.String())
 	if err != nil {
-		return fmt.Errorf("unable to get networkPolicy with key %s from indexer: %w", a.id.Name, err)
+		return fmt.Errorf("unable to get cloud rules with key %s from indexer: %w", a.id.CloudResourceID.String(), err)
 	}
-	rules := a.getCloudRulesFromNps(nps)
 
 	// combine rules to get latest addrGroupRefs.
 	currentRefs := make(map[string]struct{})
-	for _, rule := range rules {
+	for _, obj := range rules {
+		rule := obj.(*securitygroup.CloudRule)
 		switch rule.Rule.(type) {
 		case *securitygroup.IngressRule:
 			for _, sg := range rule.Rule.(*securitygroup.IngressRule).FromSecurityGroups {


### PR DESCRIPTION
## Description
Currently, if the address group of network policies is modified during controller restart, the reconciliation process will encounter issues. The syncFromCloud will delete the previous address group before deleting the previous rules that still reference it. This lead to dependency violation in AWS and ASG not found error during rule updates in Azure. This PR addresses the problem by first updating address group references for appliedTo groups before deleting address groups.

## Changes
1. The appliedTo group sync now computes the address group references before performing rule updates on indexer changes, instead of only updating references after the async rule update completes.
2. SyncFromCloud will delete unknown address groups after appliedTo group sync finishes.
3. The isRemove flag, previously added for Azure to fix the ASG not found issue, has been removed.