### PR TITLE
Set poll interval is not specified in cpa cr

### DIFF
--- a/apis/crd/v1alpha1/cloudprovideraccount_types.go
+++ b/apis/crd/v1alpha1/cloudprovideraccount_types.go
@@ -21,6 +21,10 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	DefaultPollIntervalInSeconds = 60
+)
+
 // CloudProviderAccountSpec defines the desired state of CloudProviderAccount.
 type CloudProviderAccountSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster.

--- a/pkg/accountmanager/manager.go
+++ b/pkg/accountmanager/manager.go
@@ -238,6 +238,12 @@ func (a *AccountManager) IsAccountCredentialsValid(namespacedName *types.Namespa
 // addAccountPoller creates an account poller for a given account.
 func (a *AccountManager) addAccountPoller(cloudInterface common.CloudInterface, namespacedName *types.NamespacedName,
 	account *crdv1alpha1.CloudProviderAccount) (*accountPoller, bool) {
+	// Set poller interval to default if not specified.
+	if account.Spec.PollIntervalInSeconds == nil {
+		var pollInterval uint = crdv1alpha1.DefaultPollIntervalInSeconds
+		account.Spec.PollIntervalInSeconds = &pollInterval
+	}
+
 	// Restart account poller after removing the selector.
 	accPoller, exists := a.getAccountPoller(namespacedName)
 	if exists {

--- a/pkg/apiserver/webhook/cloudprovideraccount_webhook.go
+++ b/pkg/apiserver/webhook/cloudprovideraccount_webhook.go
@@ -76,7 +76,7 @@ func (m *CPAMutator) Handle(_ context.Context, req admission.Request) admission.
 
 	m.Log.V(1).Info("CPA Mutator", "name", account.Name)
 	if account.Spec.PollIntervalInSeconds == nil {
-		var defaultIntv uint = 60
+		var defaultIntv uint = crdv1alpha1.DefaultPollIntervalInSeconds
 		account.Spec.PollIntervalInSeconds = &defaultIntv
 	}
 


### PR DESCRIPTION
## Description
Fix nephe controller crash if poll interval is not specified and webhook is disabled.

## Changes
Add a check to see if the field is not specified, explicitly set to default 60 sec.