### PR TITLE
Cleanup AWS service configs

### DIFF
--- a/pkg/cloudprovider/cloudapi/aws/aws_ec2.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_ec2.go
@@ -124,7 +124,7 @@ func (ec2Cfg *ec2ServiceConfig) getInstanceResourceFilters() ([][]*ec2.Filter, b
 func (ec2Cfg *ec2ServiceConfig) getCachedInstances() []*ec2.Instance {
 	snapshot := ec2Cfg.resourcesCache.GetSnapshot()
 	if snapshot == nil {
-		awsPluginLogger().V(4).Info("Cache snapshot nil", "service", awsComputeServiceNameEC2, "account", ec2Cfg.accountNamespacedName)
+		awsPluginLogger().V(4).Info("Cache snapshot nil", "account", ec2Cfg.accountNamespacedName)
 		return []*ec2.Instance{}
 	}
 	instances := snapshot.(*ec2ResourcesCacheSnapshot).instances
@@ -132,7 +132,7 @@ func (ec2Cfg *ec2ServiceConfig) getCachedInstances() []*ec2.Instance {
 	for _, instance := range instances {
 		instancesToReturn = append(instancesToReturn, instance)
 	}
-	awsPluginLogger().V(1).Info("Cached vm instances", "service", awsComputeServiceNameEC2, "account", ec2Cfg.accountNamespacedName,
+	awsPluginLogger().V(1).Info("Cached vm instances", "account", ec2Cfg.accountNamespacedName,
 		"instances", len(instancesToReturn))
 	return instancesToReturn
 }
@@ -142,7 +142,7 @@ func (ec2Cfg *ec2ServiceConfig) getManagedVpcIDs() map[string]struct{} {
 	vpcIDsCopy := make(map[string]struct{})
 	snapshot := ec2Cfg.resourcesCache.GetSnapshot()
 	if snapshot == nil {
-		awsPluginLogger().V(4).Info("Cache snapshot nil", "service", awsComputeServiceNameEC2, "account", ec2Cfg.accountNamespacedName)
+		awsPluginLogger().V(4).Info("Cache snapshot nil", "account", ec2Cfg.accountNamespacedName)
 		return vpcIDsCopy
 	}
 	vpcIDsSet := snapshot.(*ec2ResourcesCacheSnapshot).vpcIDs
@@ -191,8 +191,7 @@ func (ec2Cfg *ec2ServiceConfig) getCachedVpcNameToID() map[string]string {
 func (ec2Cfg *ec2ServiceConfig) GetCachedVpcs() []*ec2.Vpc {
 	snapshot := ec2Cfg.resourcesCache.GetSnapshot()
 	if snapshot == nil {
-		awsPluginLogger().Info("Cache snapshot nil", "service", awsComputeServiceNameEC2,
-			"account", ec2Cfg.accountNamespacedName)
+		awsPluginLogger().Info("Cache snapshot nil", "account", ec2Cfg.accountNamespacedName)
 		return []*ec2.Vpc{}
 	}
 	vpcs := snapshot.(*ec2ResourcesCacheSnapshot).vpcs
@@ -257,7 +256,7 @@ func (ec2Cfg *ec2ServiceConfig) getInstances() ([]*ec2.Instance, error) {
 		instances = append(instances, filterInstances...)
 	}
 
-	awsPluginLogger().V(1).Info("Vm instances from cloud", "service", awsComputeServiceNameEC2, "account", ec2Cfg.accountNamespacedName,
+	awsPluginLogger().V(1).Info("Vm instances from cloud", "account", ec2Cfg.accountNamespacedName,
 		"instances", len(instances))
 
 	return instances, nil
@@ -318,18 +317,10 @@ func (ec2Cfg *ec2ServiceConfig) GetInternalResourceObjects(namespace string,
 		vmObjects[vmObject.Name] = vmObject
 	}
 
-	awsPluginLogger().V(1).Info("Internal resource objects", "Service", awsComputeServiceNameEC2, "Account", ec2Cfg.accountNamespacedName,
+	awsPluginLogger().V(1).Info("Internal resource objects", "account", ec2Cfg.accountNamespacedName,
 		"VirtualMachine objects", len(vmObjects))
 
 	return vmObjects
-}
-
-func (ec2Cfg *ec2ServiceConfig) GetName() internal.CloudServiceName {
-	return awsComputeServiceNameEC2
-}
-
-func (ec2Cfg *ec2ServiceConfig) GetType() internal.CloudServiceType {
-	return internal.CloudServiceTypeCompute
 }
 
 func (ec2Cfg *ec2ServiceConfig) GetInventoryStats() *internal.CloudServiceStats {
@@ -345,7 +336,6 @@ func (ec2Cfg *ec2ServiceConfig) UpdateServiceConfig(newConfig internal.CloudServ
 	newEc2ServiceConfig := newConfig.(*ec2ServiceConfig)
 	ec2Cfg.apiClient = newEc2ServiceConfig.apiClient
 	ec2Cfg.credentials = newEc2ServiceConfig.credentials
-
 	return nil
 }
 
@@ -408,8 +398,7 @@ func (ec2Cfg *ec2ServiceConfig) GetVpcInventory() map[string]*runtimev1alpha1.Vp
 		vpcMap[strings.ToLower(*vpc.VpcId)] = vpcObj
 	}
 
-	awsPluginLogger().V(1).Info("Cached vpcs", "service", awsComputeServiceNameEC2,
-		"account", ec2Cfg.accountNamespacedName, "vpc objects", len(vpcMap))
+	awsPluginLogger().V(1).Info("Cached vpcs", "account", ec2Cfg.accountNamespacedName, "vpc objects", len(vpcMap))
 
 	return vpcMap
 }

--- a/pkg/cloudprovider/cloudapi/aws/aws_services.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_services.go
@@ -27,10 +27,6 @@ import (
 	"antrea.io/nephe/pkg/cloudprovider/cloudapi/internal"
 )
 
-const (
-	awsComputeServiceNameEC2 = internal.CloudServiceName("EC2")
-)
-
 // awsServiceClientCreateInterface provides interface to create aws service clients.
 type awsServiceClientCreateInterface interface {
 	compute() (awsEC2Wrapper, error)
@@ -112,11 +108,9 @@ func (h *awsServicesHelperImpl) newServiceSdkConfigProvider(accConfig *awsAccoun
 }
 
 func newAwsServiceConfigs(accountNamespacedName *types.NamespacedName, accCredentials interface{}, awsSpecificHelper interface{}) (
-	[]internal.CloudServiceInterface, error) {
+	internal.CloudServiceInterface, error) {
 	awsServicesHelper := awsSpecificHelper.(awsServicesHelper)
 	awsAccountCredentials := accCredentials.(*awsAccountConfig)
-
-	var serviceConfigs []internal.CloudServiceInterface
 
 	awsServiceClientCreator, err := awsServicesHelper.newServiceSdkConfigProvider(awsAccountCredentials)
 	if err != nil {
@@ -127,7 +121,6 @@ func newAwsServiceConfigs(accountNamespacedName *types.NamespacedName, accCreden
 	if err != nil {
 		return nil, err
 	}
-	serviceConfigs = append(serviceConfigs, ec2Service)
 
-	return serviceConfigs, nil
+	return ec2Service, nil
 }

--- a/pkg/cloudprovider/cloudapi/aws/aws_test.go
+++ b/pkg/cloudprovider/cloudapi/aws/aws_test.go
@@ -455,8 +455,7 @@ var _ = Describe("AWS cloud", func() {
 				Expect(err).Should(BeNil())
 
 				accCfg, _ := c.cloudCommon.GetCloudAccountByName(&testAccountNamespacedName)
-				serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-				filters := serviceConfig.(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
+				filters := accCfg.GetServiceConfig().(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
 				Expect(filters).To(Equal(expectedFilters))
 			})
 		})
@@ -487,8 +486,7 @@ var _ = Describe("AWS cloud", func() {
 			Expect(err).Should(BeNil())
 
 			accCfg, _ := c.cloudCommon.GetCloudAccountByName(&testAccountNamespacedName)
-			serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-			filters := serviceConfig.(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
+			filters := accCfg.GetServiceConfig().(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
 			Expect(filters).To(Equal(expectedFilters))
 		})
 		It("Should match expected filter - multiple vpcName only match", func() {
@@ -518,8 +516,7 @@ var _ = Describe("AWS cloud", func() {
 			Expect(err).Should(BeNil())
 
 			accCfg, _ := c.cloudCommon.GetCloudAccountByName(&testAccountNamespacedName)
-			serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-			filters := serviceConfig.(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
+			filters := accCfg.GetServiceConfig().(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
 			Expect(filters).To(Equal(expectedFilters))
 		})
 		It("Should match expected filter - multiple vpcID & vmName match", func() {
@@ -573,8 +570,7 @@ var _ = Describe("AWS cloud", func() {
 			Expect(err).Should(BeNil())
 
 			accCfg, _ := c.cloudCommon.GetCloudAccountByName(&testAccountNamespacedName)
-			serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-			filters := serviceConfig.(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
+			filters := accCfg.GetServiceConfig().(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
 			Expect(filters).To(Equal(expectedFilters))
 		})
 		It("Should match expected filter - multiple with one all", func() {
@@ -600,8 +596,7 @@ var _ = Describe("AWS cloud", func() {
 			Expect(err).Should(BeNil())
 
 			accCfg, _ := c.cloudCommon.GetCloudAccountByName(&testAccountNamespacedName)
-			serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-			filters := serviceConfig.(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
+			filters := accCfg.GetServiceConfig().(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
 			Expect(filters).To(Equal(expectedFilters))
 		})
 		It("Should match expected filter - multiple vm names only match", func() {
@@ -637,8 +632,7 @@ var _ = Describe("AWS cloud", func() {
 			Expect(err).Should(BeNil())
 
 			accCfg, _ := c.cloudCommon.GetCloudAccountByName(&testAccountNamespacedName)
-			serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-			filters := serviceConfig.(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
+			filters := accCfg.GetServiceConfig().(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
 			Expect(filters).To(Equal(expectedFilters))
 		})
 		It("Should match expected filter - multiple vm IDs only match", func() {
@@ -674,8 +668,7 @@ var _ = Describe("AWS cloud", func() {
 			Expect(err).Should(BeNil())
 
 			accCfg, _ := c.cloudCommon.GetCloudAccountByName(&testAccountNamespacedName)
-			serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-			filters := serviceConfig.(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
+			filters := accCfg.GetServiceConfig().(*ec2ServiceConfig).instanceFilters[testSelectorNamespacedName.String()]
 			Expect(filters).To(Equal(expectedFilters))
 		})
 	})
@@ -726,8 +719,7 @@ func checkAccountAddSuccessCondition(c *awsCloud, namespacedName types.Namespace
 			return true, errors.New("failed to find account")
 		}
 
-		serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-		instances := serviceConfig.(*ec2ServiceConfig).getCachedInstances()
+		instances := accCfg.GetServiceConfig().(*ec2ServiceConfig).getCachedInstances()
 		instanceIds := make([]string, 0, len(instances))
 		for _, instance := range instances {
 			instanceIds = append(instanceIds, *instance.InstanceId)
@@ -752,8 +744,7 @@ func checkVpcPollResult(c *awsCloud, namespacedName types.NamespacedName, ids []
 			return true, errors.New("failed to find account")
 		}
 
-		serviceConfig, _ := accCfg.GetServiceConfigByName(awsComputeServiceNameEC2)
-		vpcs := serviceConfig.(*ec2ServiceConfig).GetCachedVpcs()
+		vpcs := accCfg.GetServiceConfig().(*ec2ServiceConfig).GetCachedVpcs()
 		vpcIDs := make([]string, 0, len(vpcs))
 		for _, vpc := range vpcs {
 			_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("vpc id %s", *vpc.VpcId)))

--- a/pkg/cloudprovider/cloudapi/azure/azure_compute.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_compute.go
@@ -126,7 +126,7 @@ func (computeCfg *computeServiceConfig) getCachedVirtualMachines() []*virtualMac
 		instancesToReturn = append(instancesToReturn, virtualMachine)
 	}
 
-	azurePluginLogger().V(1).Info("Cached vm instances", "service", azureComputeServiceNameCompute, "account", computeCfg.account,
+	azurePluginLogger().V(1).Info("Cached vm instances", "account", computeCfg.account,
 		"instances", len(instancesToReturn))
 	return instancesToReturn
 }
@@ -205,7 +205,7 @@ func (computeCfg *computeServiceConfig) getVirtualMachines() ([]*virtualMachineT
 	}
 
 	azurePluginLogger().V(1).Info("Vm instances from cloud",
-		"service", azureComputeServiceNameCompute, "account", computeCfg.account, "instances", len(virtualMachines))
+		"account", computeCfg.account, "instances", len(virtualMachines))
 
 	return virtualMachines, nil
 }
@@ -296,18 +296,10 @@ func (computeCfg *computeServiceConfig) GetInternalResourceObjects(namespace str
 		vmObjects[vmObject.Name] = vmObject
 	}
 
-	azurePluginLogger().V(1).Info("Internal resource objects", "Service", azureComputeServiceNameCompute, "Account", computeCfg.account,
+	azurePluginLogger().V(1).Info("Internal resource objects", "account", computeCfg.account,
 		"VirtualMachine objects", len(vmObjects))
 
 	return vmObjects
-}
-
-func (computeCfg *computeServiceConfig) GetName() internal.CloudServiceName {
-	return azureComputeServiceNameCompute
-}
-
-func (computeCfg *computeServiceConfig) GetType() internal.CloudServiceType {
-	return internal.CloudServiceTypeCompute
 }
 
 func (computeCfg *computeServiceConfig) GetInventoryStats() *internal.CloudServiceStats {
@@ -396,8 +388,7 @@ func (computeCfg *computeServiceConfig) GetVpcInventory() map[string]*runtimev1a
 			vpcMap[strings.ToLower(*vpc.ID)] = vpcObj
 		}
 	}
-	azurePluginLogger().V(1).Info("Cached vpcs", "service", azureComputeServiceNameCompute,
-		"account", computeCfg.account, "vpc objects", len(vpcMap))
+	azurePluginLogger().V(1).Info("Cached vpcs", "account", computeCfg.account, "vpc objects", len(vpcMap))
 
 	return vpcMap
 }

--- a/pkg/cloudprovider/cloudapi/azure/azure_security.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_security.go
@@ -870,11 +870,7 @@ func (c *azureCloud) CreateSecurityGroup(securityGroupIdentifier *securitygroup.
 	}
 
 	// create/get nsg/asg on/from cloud
-	serviceCfg, err := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
-	if err != nil {
-		return nil, err
-	}
-	computeService := serviceCfg.(*computeServiceConfig)
+	computeService := accCfg.GetServiceConfig().(*computeServiceConfig)
 	location := computeService.credentials.region
 
 	if !membershipOnly {
@@ -917,11 +913,7 @@ func (c *azureCloud) UpdateSecurityGroupRules(appliedToGroupIdentifier *security
 	if !found {
 		return fmt.Errorf("azure account not found managing virtual network [%v]", vnetID)
 	}
-	serviceCfg, err := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
-	if err != nil {
-		return err
-	}
-	computeService := serviceCfg.(*computeServiceConfig)
+	computeService := accCfg.GetServiceConfig().(*computeServiceConfig)
 	location := computeService.credentials.region
 
 	// extract resource-group-name from vnet ID
@@ -987,12 +979,7 @@ func (c *azureCloud) UpdateSecurityGroupMembers(securityGroupIdentifier *securit
 	if !found {
 		return fmt.Errorf("azure account not found managing virtual network [%v]", vnetID)
 	}
-	serviceCfg, err := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
-	if err != nil {
-		return err
-	}
-	computeService := serviceCfg.(*computeServiceConfig)
-
+	computeService := accCfg.GetServiceConfig().(*computeServiceConfig)
 	return computeService.updateSecurityGroupMembers(&securityGroupIdentifier.CloudResourceID, computeResourceIdentifier, membershipOnly)
 }
 
@@ -1006,17 +993,13 @@ func (c *azureCloud) DeleteSecurityGroup(securityGroupIdentifier *securitygroup.
 	if !found {
 		return fmt.Errorf("azure account not found managing virtual network [%v]", vnetID)
 	}
-	serviceCfg, err := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
-	if err != nil {
-		return err
-	}
-	computeService := serviceCfg.(*computeServiceConfig)
+	computeService := accCfg.GetServiceConfig().(*computeServiceConfig)
 	location := computeService.credentials.region
 
 	_ = computeService.updateSecurityGroupMembers(&securityGroupIdentifier.CloudResourceID, nil, membershipOnly)
 
 	var rgName string
-	_, rgName, _, err = extractFieldsFromAzureResourceID(securityGroupIdentifier.Vpc)
+	_, rgName, _, err := extractFieldsFromAzureResourceID(securityGroupIdentifier.Vpc)
 	if err != nil {
 		return err
 	}
@@ -1075,14 +1058,8 @@ func (c *azureCloud) GetEnforcedSecurity() []securitygroup.SynchronizationConten
 				return
 			}
 
-			serviceCfg, err := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
-			if err != nil {
-				azurePluginLogger().Error(err, "nforced-security-cloud-view GET for account skipped", "account", accCfg.GetNamespacedName())
-				return
-			}
-			computeService := serviceCfg.(*computeServiceConfig)
-			err = computeService.waitForInventoryInit(inventoryInitWaitDuration)
-			if err != nil {
+			computeService := accCfg.GetServiceConfig().(*computeServiceConfig)
+			if err := computeService.waitForInventoryInit(inventoryInitWaitDuration); err != nil {
 				azurePluginLogger().Error(err, "enforced-security-cloud-view GET for account skipped", "account", accCfg.GetNamespacedName())
 				return
 			}

--- a/pkg/cloudprovider/cloudapi/azure/azure_security_test.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_security_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Azure Cloud Security", func() {
 			Expect(err).Should(BeNil())
 
 			accCfg, _ := c.cloudCommon.GetCloudAccountByName(testAccountNamespacedName)
-			serviceConfig, _ := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
+			serviceConfig := accCfg.GetServiceConfig()
 
 			vnetIDs := make(map[string]struct{})
 			vnetIDs[strings.ToLower(testVnetID01)] = struct{}{}
@@ -621,7 +621,7 @@ var _ = Describe("Azure Cloud Security", func() {
 				}
 
 				accCfg, _ := c.cloudCommon.GetCloudAccountByName(testAccountNamespacedName)
-				serviceConfig, _ := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
+				serviceConfig := accCfg.GetServiceConfig()
 				serviceConfig.(*computeServiceConfig).resourcesCache.UpdateSnapshot(&computeResourcesCacheSnapshot{vmToUpdateMap, nil, nil, nil})
 
 				serviceConfig.(*computeServiceConfig).GetInternalResourceObjects(testAccountNamespacedName.Namespace, testAccountNamespacedName)

--- a/pkg/cloudprovider/cloudapi/azure/azure_services.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_services.go
@@ -23,10 +23,6 @@ import (
 	"antrea.io/nephe/pkg/cloudprovider/cloudapi/internal"
 )
 
-const (
-	azureComputeServiceNameCompute = internal.CloudServiceName("COMPUTE")
-)
-
 // azureServiceClientCreateInterface provides interface to create azure service clients.
 type azureServiceClientCreateInterface interface {
 	resourceGraph() (azureResourceGraphWrapper, error)
@@ -68,11 +64,9 @@ func (h *azureServicesHelperImpl) newServiceSdkConfigProvider(accCreds *azureAcc
 }
 
 func newAzureServiceConfigs(accountNamespacedName *types.NamespacedName, accCredentials interface{}, azureSpecificHelper interface{}) (
-	[]internal.CloudServiceInterface, error) {
+	internal.CloudServiceInterface, error) {
 	azureServicesHelper := azureSpecificHelper.(azureServicesHelper)
 	azureAccountCredentials := accCredentials.(*azureAccountConfig)
-
-	var serviceConfigs []internal.CloudServiceInterface
 
 	azureServiceClientCreator, err := azureServicesHelper.newServiceSdkConfigProvider(azureAccountCredentials)
 	if err != nil {
@@ -83,7 +77,6 @@ func newAzureServiceConfigs(accountNamespacedName *types.NamespacedName, accCred
 	if err != nil {
 		return nil, err
 	}
-	serviceConfigs = append(serviceConfigs, computeService)
 
-	return serviceConfigs, nil
+	return computeService, nil
 }

--- a/pkg/cloudprovider/cloudapi/azure/azure_test.go
+++ b/pkg/cloudprovider/cloudapi/azure/azure_test.go
@@ -483,8 +483,7 @@ func getResourceGraphResult() resourcegraph.ClientResourcesResponse {
 
 func getFilters(c *azureCloud, selectorNamespacedName string) []*string {
 	accCfg, _ := c.cloudCommon.GetCloudAccountByName(&types.NamespacedName{Namespace: "namespace01", Name: "account01"})
-	serviceConfig, _ := accCfg.GetServiceConfigByName(azureComputeServiceNameCompute)
-	filters := serviceConfig.(*computeServiceConfig).computeFilters[selectorNamespacedName]
+	filters := accCfg.GetServiceConfig().(*computeServiceConfig).computeFilters[selectorNamespacedName]
 	return filters
 }
 func setupClientAndCloud(mockAzureServiceHelper *MockazureServicesHelper, account *v1alpha1.CloudProviderAccount, secret *corev1.Secret) (

--- a/pkg/cloudprovider/cloudapi/internal/cloud_common.go
+++ b/pkg/cloudprovider/cloudapi/internal/cloud_common.go
@@ -160,16 +160,7 @@ func (c *cloudCommon) GetCloudAccountComputeInternalResourceObjects(accountNames
 	if !found {
 		return nil, fmt.Errorf("unable to find cloud account config")
 	}
-
-	computeCRs := map[string]*runtimev1alpha1.VirtualMachine{}
-	serviceConfigs := accCfg.GetServiceConfigs()
-	for _, serviceConfig := range serviceConfigs {
-		if serviceConfig.getType() == CloudServiceTypeCompute {
-			return serviceConfig.getInternalResourceObjects(accCfg.GetNamespacedName().Namespace, accCfg.GetNamespacedName()), nil
-		}
-	}
-
-	return computeCRs, nil
+	return accCfg.GetServiceConfig().GetInternalResourceObjects(accCfg.GetNamespacedName().Namespace, accCfg.GetNamespacedName()), nil
 }
 
 func (c *cloudCommon) AddResourceFilters(accountNamespacedName *types.NamespacedName, selector *crdv1alpha1.CloudEntitySelector) error {
@@ -177,14 +168,7 @@ func (c *cloudCommon) AddResourceFilters(accountNamespacedName *types.Namespaced
 	if !found {
 		return fmt.Errorf("unable to find cloud account config")
 	}
-
-	for _, serviceCfg := range accCfg.GetServiceConfigs() {
-		if err := serviceCfg.addResourceFilters(selector); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return accCfg.GetServiceConfig().AddResourceFilters(selector)
 }
 
 func (c *cloudCommon) RemoveResourceFilters(accNamespacedName, selectorNamespacedName *types.NamespacedName) {
@@ -193,10 +177,7 @@ func (c *cloudCommon) RemoveResourceFilters(accNamespacedName, selectorNamespace
 		c.logger().Info("Cloud account config not found", "account", *accNamespacedName, "selector", selectorNamespacedName)
 		return
 	}
-
-	for _, serviceCfg := range accCfg.GetServiceConfigs() {
-		serviceCfg.removeResourceFilters(selectorNamespacedName)
-	}
+	accCfg.GetServiceConfig().RemoveResourceFilters(selectorNamespacedName)
 }
 
 func (c *cloudCommon) GetStatus(accountNamespacedName *types.NamespacedName) (*crdv1alpha1.CloudProviderAccountStatus, error) {
@@ -240,11 +221,5 @@ func (c *cloudCommon) GetVpcInventory(accountNamespacedName *types.NamespacedNam
 		return nil, fmt.Errorf("unable to find cloud account config")
 	}
 
-	serviceConfigs := accCfg.GetServiceConfigs()
-	for _, serviceConfig := range serviceConfigs {
-		if serviceConfig.getType() == CloudServiceTypeCompute {
-			return serviceConfig.getVpcInventory(), nil
-		}
-	}
-	return nil, nil
+	return accCfg.GetServiceConfig().GetVpcInventory(), nil
 }

--- a/pkg/cloudprovider/cloudapi/internal/services_common.go
+++ b/pkg/cloudprovider/cloudapi/internal/services_common.go
@@ -24,19 +24,6 @@ import (
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
 )
 
-type CloudServiceName string
-type CloudServiceType string
-
-const (
-	CloudServiceTypeCompute = CloudServiceType("Compute")
-)
-
-type CloudServiceCommon struct {
-	mutex sync.Mutex
-
-	serviceInterface CloudServiceInterface
-}
-
 // CloudServiceInterface needs to be implemented by every cloud-service to be added for a cloud-plugin.
 // Once implemented, cloud-service implementation of CloudServiceInterface will get injected into
 // plugin-common-framework using CloudCommonHelperInterface.
@@ -56,75 +43,10 @@ type CloudServiceInterface interface {
 	GetInventoryStats() *CloudServiceStats
 	// GetInternalResourceObjects returns VM instances saved in CloudServiceResourcesCache in terms of runtimev1alpha1.VirtualMachine.
 	GetInternalResourceObjects(namespace string, accountId *types.NamespacedName) map[string]*runtimev1alpha1.VirtualMachine
-	// GetName returns cloud name of the service.
-	GetName() CloudServiceName
-	// GetType returns service type (compute, any other type etc.)
-	GetType() CloudServiceType
 	// ResetInventoryCache clears any internal state built by the service as part of cloud resource discovery.
 	ResetInventoryCache()
 	// GetVpcInventory copies VPCs stored in internal snapshot(in cloud specific format) to runtimev1alpha1.Vpc format.
 	GetVpcInventory() map[string]*runtimev1alpha1.Vpc
-}
-
-func (cfg *CloudServiceCommon) updateServiceConfig(newConfig CloudServiceInterface) error {
-	cfg.mutex.Lock()
-	defer cfg.mutex.Unlock()
-
-	return cfg.serviceInterface.UpdateServiceConfig(newConfig)
-}
-
-func (cfg *CloudServiceCommon) addResourceFilters(selector *crdv1alpha1.CloudEntitySelector) error {
-	cfg.mutex.Lock()
-	defer cfg.mutex.Unlock()
-
-	return cfg.serviceInterface.AddResourceFilters(selector)
-}
-
-func (cfg *CloudServiceCommon) removeResourceFilters(selectorNamespacedName *types.NamespacedName) {
-	cfg.mutex.Lock()
-	defer cfg.mutex.Unlock()
-
-	cfg.serviceInterface.RemoveResourceFilters(selectorNamespacedName)
-}
-
-func (cfg *CloudServiceCommon) doResourceInventory() error {
-	cfg.mutex.Lock()
-	defer cfg.mutex.Unlock()
-
-	return cfg.serviceInterface.DoResourceInventory()
-}
-
-func (cfg *CloudServiceCommon) getInventoryStats() *CloudServiceStats {
-	cfg.mutex.Lock()
-	defer cfg.mutex.Unlock()
-
-	return cfg.serviceInterface.GetInventoryStats()
-}
-
-func (cfg *CloudServiceCommon) getInternalResourceObjects(namespace string,
-	account *types.NamespacedName) map[string]*runtimev1alpha1.VirtualMachine {
-	cfg.mutex.Lock()
-	defer cfg.mutex.Unlock()
-
-	return cfg.serviceInterface.GetInternalResourceObjects(namespace, account)
-}
-
-func (cfg *CloudServiceCommon) getType() CloudServiceType {
-	return cfg.serviceInterface.GetType()
-}
-
-func (cfg *CloudServiceCommon) resetInventoryCache() {
-	cfg.mutex.Lock()
-	defer cfg.mutex.Unlock()
-
-	cfg.serviceInterface.ResetInventoryCache()
-}
-
-func (cfg *CloudServiceCommon) getVpcInventory() map[string]*runtimev1alpha1.Vpc {
-	cfg.mutex.Lock()
-	defer cfg.mutex.Unlock()
-
-	return cfg.serviceInterface.GetVpcInventory()
 }
 
 // CloudServiceResourcesCache is cache used by all services. Each service can maintain


### PR DESCRIPTION
## Description
In AWS, we support only one service config. 

## Changes
Cleaning up the code to cater to that. Also, removed unnecessary service config common struct.