### PR TITLE
Disable CloudSyncInterval in integration test

### DIFF
--- a/ci/jenkins/scripts/common.sh
+++ b/ci/jenkins/scripts/common.sh
@@ -64,3 +64,17 @@ function pull_docker_images() {
     docker pull quay.io/jetstack/cert-manager-cainjector:${CERT_MANAGER_VERSION}
     docker pull projects.registry.vmware.com/antrea/antrea-ubuntu:${ANTREA_VERSION}
 }
+
+function wait_for_cert_manager() {
+    i=1
+    while [ "$(kubectl get pods --kubeconfig=$1 -l=app='cert-manager' -n cert-manager -o jsonpath='{.items[*].status.containerStatuses[0].ready}')" != "true" ]; do
+        sleep 5
+        echo "Waiting for Cert Manager to be ready."
+        i=$(( $i + 1 ))
+        if [ $i -eq 20 ]; then
+            echo "Cert Manager failed to come up."
+            exit 1
+        fi
+    done
+    sleep 5
+}

--- a/ci/jenkins/scripts/test-aws.sh
+++ b/ci/jenkins/scripts/test-aws.sh
@@ -128,7 +128,7 @@ curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip
 unzip -q awscliv2.zip
 sudo ./aws/install
 
-source $(dirname "${BASH_SOURCE[0]}")/install-common.sh
+source $(dirname "${BASH_SOURCE[0]}")/common.sh
 install_common_packages
 
 echo "Building Nephe Docker image"

--- a/ci/jenkins/scripts/test-azure.sh
+++ b/ci/jenkins/scripts/test-azure.sh
@@ -97,7 +97,7 @@ if [ -z "$TF_VAR_azure_client_subscription_id" ] || [ -z "$TF_VAR_azure_client_i
     exit 1
 fi
 
-source $(dirname "${BASH_SOURCE[0]}")/install-common.sh
+source $(dirname "${BASH_SOURCE[0]}")/common.sh
 install_common_packages
 
 echo "Building Nephe Docker image"
@@ -110,11 +110,18 @@ echo "Creating Kind cluster"
 hack/install-cloud-tools.sh
 ci/kind/kind-setup.sh create kind
 
+wait_for_cert_manager "$HOME"/.kube/config
+
+# Pre install Nephe.
+helm repo add antrea https://charts.antrea.io
+helm repo update
+helm install nephe build/charts/nephe --create-namespace -n nephe-system --set cloudSyncInterval=3600
+
 mkdir -p "$HOME"/logs
 if [ "$UPGRADE" = true ] ; then
     ci/bin/upgrade.test -ginkgo.v -ginkgo.timeout 90m -ginkgo.focus=".*test-azure.*" -kubeconfig="$HOME"/.kube/config \
     -from-version=0.5.0 -to-version="latest" -chart-dir="build/charts/nephe" -cloud-provider=Azure -support-bundle-dir="$HOME"/logs
 else
     ci/bin/integration.test -ginkgo.v -ginkgo.timeout 90m -ginkgo.focus=".*test-azure.*" -kubeconfig="$HOME"/.kube/config \
-    -cloud-provider=Azure -support-bundle-dir="$HOME"/logs
+    -cloud-provider=Azure -support-bundle-dir="$HOME"/logs -pre-installed
 fi


### PR DESCRIPTION
## Description
It has been observed sync with cloud was making/auto-correcting network policy state in network policy controller. We need to run the CI with sync with cloud disable to uncover those errors.

## Changes
Updating the CI Jenkins test with cloudSyncInterval set to 1hr. This practically disables cloud with sync which was masking/auto-correcting random network policy realization failure. This is done for only azure kind test only for now. 