### PR TITLE
remove user rules in Azure that are in Nephe priority range

### DIFF
--- a/pkg/cloudprovider/plugins/aws/aws_security.go
+++ b/pkg/cloudprovider/plugins/aws/aws_security.go
@@ -446,6 +446,9 @@ func (ec2Cfg *ec2ServiceConfig) updateSecurityGroupMembers(groupCloudSgID *strin
 				}
 
 				networkInterfacesToModify[*networkInterface.NetworkInterfaceId] = networkInterfaceCloudSgsSetToAttach
+			} else if !membershipOnly && len(networkInterfaceOtherCloudSgsSet) > 0 {
+				// remove non-nephe sgs if AT is attached.
+				networkInterfacesToModify[*networkInterface.NetworkInterfaceId] = networkInterfaceNepheControllerCreatedCloudSgsSet
 			}
 		} else {
 			if isNicAttachedToMemberVM || isNicMemberNetworkInterface {

--- a/pkg/controllers/networkpolicy/controller.go
+++ b/pkg/controllers/networkpolicy/controller.go
@@ -694,7 +694,7 @@ func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		})
 	// cloudRuleIndexer stores the realized rules on the cloud.
 	r.cloudRuleIndexer = cache.NewIndexer(
-		// Each cloudRule is uniquely identified by its UUID.
+		// Each cloudRule is uniquely identified by its hash.
 		func(obj interface{}) (string, error) {
 			rule := obj.(*cloudresource.CloudRule)
 			return rule.Hash, nil

--- a/pkg/controllers/networkpolicy/networkpolicy.go
+++ b/pkg/controllers/networkpolicy/networkpolicy.go
@@ -956,7 +956,11 @@ func (a *appliedToSecurityGroup) computeCloudRulesFromNp(r *NetworkPolicyReconci
 		sameNP := realizedRule.NpNamespacedName == npNamespacedName
 		currentRule, sameRule := currentRuleMap[realizedRule.Hash]
 		if sameRule && !sameNP {
-			err = fmt.Errorf("duplicate rules with anp %s", realizedRule.NpNamespacedName)
+			if realizedRule.NpNamespacedName != "" {
+				err = fmt.Errorf("duplicate rules with anp %s", realizedRule.NpNamespacedName)
+			} else {
+				err = fmt.Errorf("duplicate rules with user rule %+v", realizedRule)
+			}
 			r.Log.Error(err, "unable to compute rules", "rule", currentRule, "anp", npNamespacedName)
 			return nil, nil, err
 		}

--- a/pkg/controllers/networkpolicy/sync.go
+++ b/pkg/controllers/networkpolicy/sync.go
@@ -140,7 +140,7 @@ func (a *appliedToSecurityGroup) sync(syncContent *cloudresource.Synchronization
 	// roughly count and compare rules in syncContent against nps.
 	// also updates cloudRuleIndexer in the process.
 	for _, rule := range syncContent.IngressRules {
-		if rule.NpNamespacedName != "" {
+		if rule.NpNamespacedName != "" && rule.Rule != nil {
 			iRule := rule.Rule.(*cloudresource.IngressRule)
 			countIngressRuleItems(iRule, items, true)
 		}
@@ -149,7 +149,7 @@ func (a *appliedToSecurityGroup) sync(syncContent *cloudresource.Synchronization
 		}
 	}
 	for _, rule := range syncContent.EgressRules {
-		if rule.NpNamespacedName != "" {
+		if rule.NpNamespacedName != "" && rule.Rule != nil {
 			eRule := rule.Rule.(*cloudresource.EgressRule)
 			countEgressRuleItems(eRule, items, true)
 		}


### PR DESCRIPTION
Description
Currently, Nephe preserves all user custom rules in Azure, even if they fall within the priority range designated for Nephe (2000-4096). This approach can lead to issues and confusions with rule priority computation. To address this, this PR introduces a restriction on Azure user custom rules, removing user custom rules within the Nephe priority range.

## Changes
1. The cloud sync process now adds a dummy rule in sync content when user rules within the Nephe priority range are detected, triggering a rule update.
1. The rule update logic has been modified to remove user rules within the Nephe priority range.
1. The sync function has been adjusted to handle the dummy rule appropriately.