### PR TITLE
Error handling for AppliedToGroup SG delete.

### DIFF
--- a/pkg/controllers/networkpolicy/controller.go
+++ b/pkg/controllers/networkpolicy/controller.go
@@ -427,7 +427,7 @@ func (r *NetworkPolicyReconciler) processNetworkPolicy(event watch.Event) error 
 	var np *networkPolicy
 	isCreate := false
 	npKey := types.NamespacedName{Name: anp.Name, Namespace: anp.Namespace}.String()
-	if i, ok, _ := r.networkPolicyIndexer.GetByKey(npKey); !ok {
+	if obj, ok, _ := r.networkPolicyIndexer.GetByKey(npKey); !ok {
 		np = &networkPolicy{}
 		anp.DeepCopyInto(&np.NetworkPolicy)
 		if err := r.networkPolicyIndexer.Add(np); err != nil {
@@ -435,7 +435,7 @@ func (r *NetworkPolicyReconciler) processNetworkPolicy(event watch.Event) error 
 		}
 		isCreate = true
 	} else {
-		np = i.(*networkPolicy)
+		np = obj.(*networkPolicy)
 	}
 	if event.Type == watch.Deleted {
 		_ = np.delete(r)

--- a/pkg/controllers/networkpolicy/sync.go
+++ b/pkg/controllers/networkpolicy/sync.go
@@ -99,6 +99,7 @@ func (a *appliedToSecurityGroup) sync(syncContent *cloudresource.Synchronization
 	for _, i := range nps {
 		np := i.(*networkPolicy)
 		if !np.rulesReady {
+			r.Log.V(1).Info("Compute rules", "networkPolicy", np.Name)
 			if !np.computeRules(r) {
 				log.V(1).Info("NetworkPolicy is not ready", "Name", np.Name, "Namespace", np.Namespace)
 			}


### PR DESCRIPTION
Consider a scenario where ANP contains two rule-level AppliedToGroups. Delete one of the AppliedToGroup. If the ATGroup could not be deleted on the cloud, then the internal state of NP controller still contains the rules, while the rules are deleted on the cloud.

This PR tries to address the issue, by clearing the internal state when an ATGroup is deleted, so that if the ATGroup is re-added, then NP controller will be able to recover and realize the rules on the cloud.