### PR TITLE
Move Plugin level lock to Account level

### DIFF
--- a/pkg/cloudprovider/cloudresource/cloudresource.go
+++ b/pkg/cloudprovider/cloudresource/cloudresource.go
@@ -32,14 +32,6 @@ var (
 	ControllerAppliedToPrefix    string
 )
 
-var ProtocolNameNumMap = map[string]int{
-	"icmp":   1,
-	"igmp":   2,
-	"tcp":    6,
-	"udp":    17,
-	"icmpv6": 58,
-}
-
 // CloudResourceType specifies the type of cloud resource.
 type CloudResourceType string
 

--- a/pkg/cloudprovider/plugins/aws/aws_converters.go
+++ b/pkg/cloudprovider/plugins/aws/aws_converters.go
@@ -252,6 +252,6 @@ func convertFromIPPermissionProtocol(proto string) *int {
 	if strings.Compare(proto, awsAnyProtocolValue) == 0 {
 		return nil
 	}
-	protoNum := cloudresource.ProtocolNameNumMap[strings.ToLower(proto)]
+	protoNum := protocolNameNumMap[strings.ToLower(proto)]
 	return &protoNum
 }

--- a/pkg/cloudprovider/plugins/aws/aws_security.go
+++ b/pkg/cloudprovider/plugins/aws/aws_security.go
@@ -36,12 +36,18 @@ const (
 )
 
 var (
-	mutex sync.Mutex
-
 	awsAnyProtocolValue = "-1"
 	tcpUDPPortStart     = 0
 	tcpUDPPortEnd       = 65535
 )
+
+var protocolNameNumMap = map[string]int{
+	"icmp":   1,
+	"igmp":   2,
+	"tcp":    6,
+	"udp":    17,
+	"icmpv6": 58,
+}
 
 var vpcIDToDefaultSecurityGroup = make(map[string]string)
 

--- a/pkg/cloudprovider/plugins/azure/azure_security.go
+++ b/pkg/cloudprovider/plugins/azure/azure_security.go
@@ -28,10 +28,6 @@ import (
 	"antrea.io/nephe/pkg/cloudprovider/utils"
 )
 
-var (
-	mutex sync.Mutex
-)
-
 type networkInterfaceInternal struct {
 	armnetwork.Interface
 	vnetID string

--- a/pkg/cloudprovider/plugins/internal/accounts_common.go
+++ b/pkg/cloudprovider/plugins/internal/accounts_common.go
@@ -29,7 +29,8 @@ type CloudAccountInterface interface {
 	GetNamespacedName() *types.NamespacedName
 	GetServiceConfig() CloudServiceInterface
 	GetStatus() *crdv1alpha1.CloudProviderAccountStatus
-
+	LockMutex()
+	UnlockMutex()
 	performInventorySync() error
 	resetInventoryCache()
 }
@@ -116,9 +117,6 @@ func (c *cloudCommon) updateCloudAccountConfig(client client.Client, credentials
 }
 
 func (accCfg *cloudAccountConfig) performInventorySync() error {
-	accCfg.mutex.Lock()
-	defer accCfg.mutex.Unlock()
-
 	err := accCfg.serviceConfig.DoResourceInventory()
 	if err != nil {
 		// set the error status to be used later in `CloudProviderAccount` CR.
@@ -142,4 +140,12 @@ func (accCfg *cloudAccountConfig) GetStatus() *crdv1alpha1.CloudProviderAccountS
 
 func (accCfg *cloudAccountConfig) resetInventoryCache() {
 	accCfg.serviceConfig.ResetInventoryCache()
+}
+
+func (accCfg *cloudAccountConfig) LockMutex() {
+	accCfg.mutex.Lock()
+}
+
+func (accCfg *cloudAccountConfig) UnlockMutex() {
+	accCfg.mutex.Unlock()
 }


### PR DESCRIPTION
## Description
We had mutex lock at the plugin level, due to which any cloud operation for account1 was impacting account2. 

## Changes
Move plugin level lock to account level so that multiple cloud operation can happen in parallel. There is further room for optimization to identify what cloud calls can happen in parallel within an account rather than locking at account level. 