### PR TITLE
Reset account status in case of success too

### DIFF
--- a/pkg/cloudprovider/plugins/internal/accounts_common.go
+++ b/pkg/cloudprovider/plugins/internal/accounts_common.go
@@ -118,9 +118,11 @@ func (c *cloudCommon) updateCloudAccountConfig(client client.Client, credentials
 
 func (accCfg *cloudAccountConfig) performInventorySync() error {
 	err := accCfg.serviceConfig.DoResourceInventory()
+	// set the error status to be used later in `CloudProviderAccount` CR.
 	if err != nil {
-		// set the error status to be used later in `CloudProviderAccount` CR.
 		accCfg.Status.Error = err.Error()
+	} else {
+		accCfg.Status.Error = ""
 	}
 	accCfg.serviceConfig.GetInventoryStats().UpdateInventoryPollStats(err)
 	return err


### PR DESCRIPTION
## Description
When we transition from failure to success, the cpa status was not getting updated. This was because account status was set only for failure case, not success. 

## Changes
Updated the handling to set the account status always.