### PR TITLE
Add support to clean Np indexers based on account

### DIFF
--- a/pkg/controllers/networkpolicy/networkpolicy.go
+++ b/pkg/controllers/networkpolicy/networkpolicy.go
@@ -402,7 +402,11 @@ func (s *securityGroupImpl) deleteImpl(c cloudSecurityGroup, membershipOnly bool
 	uName := getGroupUniqueName(s.id.CloudResourceID.String(), membershipOnly)
 	guName := getGroupUniqueName(s.id.Name, membershipOnly)
 	if !r.pendingDeleteGroups.Has(guName) {
-		r.pendingDeleteGroups.Add(guName, &pendingGroup{refCnt: new(int)})
+		var accountId string
+		if len(s.members) > 0 {
+			accountId = s.members[0].AccountID
+		}
+		r.pendingDeleteGroups.Add(guName, &pendingGroup{id: guName, refCnt: new(int), account: accountId})
 	}
 	var nps []interface{}
 	if s.state != securityGroupStateGarbageCollectState {

--- a/pkg/controllers/networkpolicy/pendingitem.go
+++ b/pkg/controllers/networkpolicy/pendingitem.go
@@ -160,6 +160,9 @@ type pendingGroup struct {
 	event          watch.EventType
 	addedMembers   map[string]antreanetworking.GroupMember
 	removedMembers map[string]antreanetworking.GroupMember
+	// Used to clean up internal state only when account is deleted.
+	account string
+	id      string
 }
 
 func (p *pendingGroup) RunPendingItem(id string, context interface{}) bool {


### PR DESCRIPTION
- When CPA is deleted, it will notify a local event to np controller.
- As part of processing local event, np controller will clear entries corresponding to the account from appliedToSGIndexer, addrSGIndexer, cloudRuleIndexer and networkPolicyIndexer.
- Remove AT/AG groups from retryQueue for the account.
- Remove groups from pendingDeleteGroups based on account.