### PR TITLE
Block nephe installation for upgrade test

### DIFF
--- a/ci/jenkins/scripts/test-azure.sh
+++ b/ci/jenkins/scripts/test-azure.sh
@@ -112,16 +112,16 @@ ci/kind/kind-setup.sh create kind
 
 wait_for_cert_manager "$HOME"/.kube/config
 
-# Pre install Nephe.
-helm repo add antrea https://charts.antrea.io
-helm repo update
-helm install nephe build/charts/nephe --create-namespace -n nephe-system --set cloudSyncInterval=3600
-
 mkdir -p "$HOME"/logs
 if [ "$UPGRADE" = true ] ; then
     ci/bin/upgrade.test -ginkgo.v -ginkgo.timeout 90m -ginkgo.focus=".*test-azure.*" -kubeconfig="$HOME"/.kube/config \
     -from-version=0.5.0 -to-version="latest" -chart-dir="build/charts/nephe" -cloud-provider=Azure -support-bundle-dir="$HOME"/logs
 else
+    # Pre install Nephe.
+    helm repo add antrea https://charts.antrea.io
+    helm repo update
+    helm install nephe build/charts/nephe --create-namespace -n nephe-system --set cloudSyncInterval=3600
+
     ci/bin/integration.test -ginkgo.v -ginkgo.timeout 90m -ginkgo.focus=".*test-azure.*" -kubeconfig="$HOME"/.kube/config \
     -cloud-provider=Azure -support-bundle-dir="$HOME"/logs -pre-installed
 fi


### PR DESCRIPTION
Upgrade test installs Nephe via helm chart within the test. Hence blocking explicit installation via script.