### PR TITLE
Change cert and config location in manifest

### DIFF
--- a/build/charts/nephe/templates/controller/deployment.yaml
+++ b/build/charts/nephe/templates/controller/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - args:
-        - --config=/tmp/nephe/nephe-controller.conf
+        - --config=/etc/nephe/nephe-controller.conf
         - --enable-debug-log
         command:
         - /nephe-controller
@@ -45,23 +45,16 @@ spec:
             cpu: 200m
             memory: 500Mi
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
+        - mountPath: /var/run/nephe/nephe-controller-tls
           name: cert
           readOnly: true
-        - mountPath: /tmp/k8s-apiserver/serving-certs
-          name: apiserver-cert
-          readOnly: true
-        - mountPath: /tmp/nephe/nephe-controller.conf
+        - mountPath: /etc/nephe/nephe-controller.conf
           name: nephe-config
           readOnly: true
           subPath: nephe-controller.conf
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert
-        secret:
-          defaultMode: 420
-          secretName: serving-cert
-      - name: apiserver-cert
         secret:
           defaultMode: 420
           secretName: serving-cert

--- a/cmd/nephe-controller/config.go
+++ b/cmd/nephe-controller/config.go
@@ -19,4 +19,5 @@ const (
 	defaultLeaderElectionFlag = false
 	defaultMetricsAddress     = ":8080"
 	defaultDebugLogFlag       = false
+	defaultCertDir            = "/var/run/nephe/nephe-controller-tls"
 )

--- a/cmd/nephe-controller/main.go
+++ b/cmd/nephe-controller/main.go
@@ -90,6 +90,7 @@ func main() {
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   electionID,
+		CertDir:            defaultCertDir,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -153,7 +154,7 @@ func main() {
 	}
 
 	if err = (&apiserver.NepheControllerAPIServer{}).SetupWithManager(mgr,
-		npController.GetVirtualMachinePolicyIndexer(), cloudInventory, logging.GetLogger("apiServer")); err != nil {
+		npController.GetVirtualMachinePolicyIndexer(), cloudInventory, defaultCertDir, logging.GetLogger("apiServer")); err != nil {
 		setupLog.Error(err, "unable to create APIServer")
 		os.Exit(1)
 	}

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -12,12 +12,3 @@ spec:
             - containerPort: 9443
               name: webhook-server
               protocol: TCP
-          volumeMounts:
-            - mountPath: /tmp/k8s-webhook-server/serving-certs
-              name: cert
-              readOnly: true
-      volumes:
-        - name: cert
-          secret:
-            defaultMode: 420
-            secretName: serving-cert

--- a/config/manager/nephe-controller.yaml
+++ b/config/manager/nephe-controller.yaml
@@ -50,7 +50,7 @@ spec:
       - command:
         - /nephe-controller
         args:
-        - --config=/tmp/nephe/nephe-controller.conf
+        - --config=/etc/nephe/nephe-controller.conf
         - --enable-debug-log
         image: "antrea/nephe:latest"
         imagePullPolicy: IfNotPresent
@@ -68,15 +68,15 @@ spec:
             cpu: 200m
             memory: 500Mi
         volumeMounts:
-          - name: apiserver-cert
-            mountPath: /tmp/k8s-apiserver/serving-certs
+          - name: cert
+            mountPath: /var/run/nephe/nephe-controller-tls
             readOnly: true
           - name: nephe-config
-            mountPath: /tmp/nephe/nephe-controller.conf
+            mountPath: /etc/nephe/nephe-controller.conf
             subPath: nephe-controller.conf
             readOnly: true
       volumes:
-        - name: apiserver-cert
+        - name: cert
           secret:
             defaultMode: 420
             secretName: serving-cert

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -525,7 +525,7 @@ spec:
     spec:
       containers:
       - args:
-        - --config=/tmp/nephe/nephe-controller.conf
+        - --config=/etc/nephe/nephe-controller.conf
         - --enable-debug-log
         command:
         - /nephe-controller
@@ -549,23 +549,16 @@ spec:
             cpu: 200m
             memory: 500Mi
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
+        - mountPath: /var/run/nephe/nephe-controller-tls
           name: cert
           readOnly: true
-        - mountPath: /tmp/k8s-apiserver/serving-certs
-          name: apiserver-cert
-          readOnly: true
-        - mountPath: /tmp/nephe/nephe-controller.conf
+        - mountPath: /etc/nephe/nephe-controller.conf
           name: nephe-config
           readOnly: true
           subPath: nephe-controller.conf
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert
-        secret:
-          defaultMode: 420
-          secretName: serving-cert
-      - name: apiserver-cert
         secret:
           defaultMode: 420
           secretName: serving-cert


### PR DESCRIPTION
## Description
Both Webhook and API Server are using same TLS cert generated by cert manager. Avoid generating two volumes and different mount path for them

## Chanages
Move config to /etc/nephe dir and also update API Server and Webhook to use cert from same location.