### PR TITLE
Validate interface to object conversion

### DIFF
--- a/pkg/accountmanager/poller.go
+++ b/pkg/accountmanager/poller.go
@@ -229,8 +229,11 @@ func (p *accountPoller) getComputeResources(cloudInterface cloud.CloudInterface)
 // getVmSelectorMatch returns a VMSelector for a VirtualMachine only if it is agented.
 func (p *accountPoller) getVmSelectorMatch(vm *runtimev1alpha1.VirtualMachine) *crdv1alpha1.VirtualMachineSelector {
 	vmSelectors, _ := p.vmSelector.ByIndex(virtualMachineSelectorMatchIndexerByID, vm.Status.CloudId)
-	for _, i := range vmSelectors {
-		vmSelector := i.(*crdv1alpha1.VirtualMachineSelector)
+	for _, obj := range vmSelectors {
+		vmSelector, ok := obj.(*crdv1alpha1.VirtualMachineSelector)
+		if !ok {
+			continue
+		}
 		return vmSelector
 	}
 
@@ -239,8 +242,11 @@ func (p *accountPoller) getVmSelectorMatch(vm *runtimev1alpha1.VirtualMachine) *
 	// VM intended to match a selector with only vmMatch selector, falls under partial match.
 	var partialMatchSelector *crdv1alpha1.VirtualMachineSelector = nil
 	vmSelectors, _ = p.vmSelector.ByIndex(virtualMachineSelectorMatchIndexerByName, vm.Status.CloudName)
-	for _, i := range vmSelectors {
-		vmSelector := i.(*crdv1alpha1.VirtualMachineSelector)
+	for _, obj := range vmSelectors {
+		vmSelector, ok := obj.(*crdv1alpha1.VirtualMachineSelector)
+		if !ok {
+			continue
+		}
 		if vmSelector.VpcMatch != nil {
 			if vmSelector.VpcMatch.MatchID == vm.Status.CloudVpcId {
 				// Prioritize exact match(along with vpcMatch) over VM name only match.
@@ -255,8 +261,11 @@ func (p *accountPoller) getVmSelectorMatch(vm *runtimev1alpha1.VirtualMachine) *
 	}
 
 	vmSelectors, _ = p.vmSelector.ByIndex(virtualMachineSelectorMatchIndexerByVPC, vm.Status.CloudVpcId)
-	for _, i := range vmSelectors {
-		vmSelector := i.(*crdv1alpha1.VirtualMachineSelector)
+	for _, obj := range vmSelectors {
+		vmSelector, ok := obj.(*crdv1alpha1.VirtualMachineSelector)
+		if !ok {
+			continue
+		}
 		return vmSelector
 	}
 	return nil

--- a/pkg/apiserver/registry/virtualmachinepolicy/rest.go
+++ b/pkg/apiserver/registry/virtualmachinepolicy/rest.go
@@ -96,7 +96,11 @@ func (r *REST) List(ctx context.Context, _ *internalversion.ListOptions) (runtim
 	}
 	vmpList := &runtimev1alpha1.VirtualMachinePolicyList{}
 	for _, obj := range objs {
-		vmp := r.convertToVMP(obj.(*networkpolicy.NetworkPolicyStatus))
+		npStatus, ok := obj.(*networkpolicy.NetworkPolicyStatus)
+		if !ok {
+			continue
+		}
+		vmp := r.convertToVMP(npStatus)
 		vmpList.Items = append(vmpList.Items, *vmp)
 	}
 	return vmpList, nil

--- a/pkg/controllers/networkpolicy/cloudresource.go
+++ b/pkg/controllers/networkpolicy/cloudresource.go
@@ -216,10 +216,14 @@ func (c *cloudResourceNPTracker) computeNPStatus(r *NetworkPolicyReconciler) map
 			continue
 		}
 		// Not considering cloud resources belongs to multiple AppliedToGroups of same NetworkPolicy.
-		for _, i := range nps {
-			namespacedName := types.NamespacedName{Namespace: i.(*networkPolicy).Namespace, Name: i.(*networkPolicy).Name}
+		for _, obj := range nps {
+			np, ok := obj.(*networkPolicy)
+			if !ok {
+				continue
+			}
+			namespacedName := types.NamespacedName{Namespace: np.Namespace, Name: np.Name}
 			appliedToToNpMap[asg.id.Name] = append(appliedToToNpMap[asg.id.Name], namespacedName)
-			npMap[i] = key
+			npMap[np] = key
 		}
 	}
 
@@ -271,8 +275,11 @@ func (c *cloudResourceNPTracker) computeNPStatus(r *NetworkPolicyReconciler) map
 		}
 		errMsg := fmt.Sprintf(AppliedSecurityGroupDeleteError, asg.id.CloudResourceID.String(), asg.status.Error())
 		if len(nps) != 0 {
-			for _, i := range nps {
-				np := i.(*networkPolicy)
+			for _, obj := range nps {
+				np, ok := obj.(*networkPolicy)
+				if !ok {
+					continue
+				}
 				npList, ok := ret[np.Namespace]
 				if !ok {
 					npList = make(map[string]string)

--- a/pkg/controllers/networkpolicy/controller_test.go
+++ b/pkg/controllers/networkpolicy/controller_test.go
@@ -441,7 +441,10 @@ var _ = Describe("NetworkPolicy", func() {
 		currentIngress := make([]*cloudresource.IngressRule, 0)
 		currentEgress := make([]*cloudresource.EgressRule, 0)
 		for _, obj := range list {
-			rule := obj.(*cloudresource.CloudRule)
+			rule, ok := obj.(*cloudresource.CloudRule)
+			if !ok {
+				continue
+			}
 			switch rule.Rule.(type) {
 			case *cloudresource.IngressRule:
 				currentIngress = append(currentIngress, rule.Rule.(*cloudresource.IngressRule))

--- a/pkg/controllers/networkpolicy/sync.go
+++ b/pkg/controllers/networkpolicy/sync.go
@@ -96,8 +96,11 @@ func (a *appliedToSecurityGroup) sync(syncContent *cloudresource.Synchronization
 		return
 	}
 	items := make(map[string]int)
-	for _, i := range nps {
-		np := i.(*networkPolicy)
+	for _, obj := range nps {
+		np, ok := obj.(*networkPolicy)
+		if !ok {
+			continue
+		}
 		if !np.rulesReady {
 			r.Log.V(1).Info("Compute rules", "networkPolicy", np.Name)
 			if !np.computeRules(r) {
@@ -133,7 +136,10 @@ func (a *appliedToSecurityGroup) sync(syncContent *cloudresource.Synchronization
 	indexerUpdate := false
 	cloudRuleMap := make(map[string]*cloudresource.CloudRule)
 	for _, obj := range rules {
-		rule := obj.(*cloudresource.CloudRule)
+		rule, ok := obj.(*cloudresource.CloudRule)
+		if !ok {
+			continue
+		}
 		cloudRuleMap[rule.Hash] = rule
 	}
 

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -59,8 +59,11 @@ func (i *Inventory) BuildVpcCache(discoveredVpcMap map[string]*runtimev1alpha1.V
 	vpcsInCache, _ := i.vpcStore.GetByIndex(indexer.VpcByNamespacedAccountName, namespacedName.String())
 
 	// Remove vpcs in vpc cache which are not found in vpc list fetched from cloud.
-	for _, object := range vpcsInCache {
-		vpc := object.(*runtimev1alpha1.Vpc)
+	for _, obj := range vpcsInCache {
+		vpc, ok := obj.(*runtimev1alpha1.Vpc)
+		if !ok {
+			continue
+		}
 		if _, found := discoveredVpcMap[vpc.Status.CloudId]; !found {
 			if err := i.vpcStore.Delete(fmt.Sprintf("%v/%v-%v", vpc.Namespace,
 				vpc.Labels[nephelabels.CloudAccountName], vpc.Status.CloudId)); err != nil {
@@ -111,8 +114,11 @@ func (i *Inventory) DeleteVpcsFromCache(namespacedName *types.NamespacedName) er
 		return err
 	}
 	var numVpcsToDelete int
-	for _, object := range vpcsInCache {
-		vpc := object.(*runtimev1alpha1.Vpc)
+	for _, obj := range vpcsInCache {
+		vpc, ok := obj.(*runtimev1alpha1.Vpc)
+		if !ok {
+			continue
+		}
 		key := fmt.Sprintf("%v/%v-%v", vpc.Namespace, vpc.Labels[nephelabels.CloudAccountName], vpc.Status.CloudId)
 		if err := i.vpcStore.Delete(key); err != nil {
 			i.log.Error(err, "failed to delete vpc from vpc cache, account: %v", *namespacedName)
@@ -152,7 +158,10 @@ func (i *Inventory) BuildVmCache(discoveredVmMap map[string]*runtimev1alpha1.Vir
 	vmsInCache, _ := i.vmStore.GetByIndex(indexer.VirtualMachineByNamespacedAccountName, namespacedName.String())
 	// Remove vm from vm cache which are not found in vm map fetched from cloud.
 	for _, cachedObject := range vmsInCache {
-		cachedVm := cachedObject.(*runtimev1alpha1.VirtualMachine)
+		cachedVm, ok := cachedObject.(*runtimev1alpha1.VirtualMachine)
+		if !ok {
+			continue
+		}
 		if _, found := discoveredVmMap[cachedVm.Name]; !found {
 			key := fmt.Sprintf("%v/%v", cachedVm.Namespace, cachedVm.Name)
 			if err := i.vmStore.Delete(key); err != nil {
@@ -210,7 +219,10 @@ func (i *Inventory) DeleteVmsFromCache(namespacedName *types.NamespacedName) err
 	}
 	var numVmsToDelete int
 	for _, cachedObject := range vmsInCache {
-		cachedVm := cachedObject.(*runtimev1alpha1.VirtualMachine)
+		cachedVm, ok := cachedObject.(*runtimev1alpha1.VirtualMachine)
+		if !ok {
+			continue
+		}
 		key := fmt.Sprintf("%v/%v", cachedVm.Namespace, cachedVm.Name)
 		if err := i.vmStore.Delete(key); err != nil {
 			i.log.Error(err, "failed to delete vm from vm cache, account: %v vm: %v", *namespacedName, cachedVm.Name)

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -183,7 +183,10 @@ var _ = Describe("Validate VPC and Virtual Machine Inventory", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(vmListByIndex).Should(HaveLen(len(vmList)))
 			for _, i := range vmListByIndex {
-				vm := i.(*runtimev1alpha1.VirtualMachine)
+				vm, ok := i.(*runtimev1alpha1.VirtualMachine)
+				if !ok {
+					continue
+				}
 				Expect(vm.Name).To(Equal(testVmID01))
 			}
 		})
@@ -195,7 +198,10 @@ var _ = Describe("Validate VPC and Virtual Machine Inventory", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(vmListByIndex).Should(HaveLen(len(vmList)))
 			for _, i := range vmListByIndex {
-				vm := i.(*runtimev1alpha1.VirtualMachine)
+				vm, ok := i.(*runtimev1alpha1.VirtualMachine)
+				if !ok {
+					continue
+				}
 				Expect(vm.Name).To(Equal(testVmID01))
 			}
 


### PR DESCRIPTION
When the ByIndex function of cache indexer is used, it returns a list of interfaces. 
Validate if the interface can be converted to an object, before accessing the actual object.

When traversing through a list of interfaces, It is observed that the interface can be nil. 
If not handled, then it will result in a crash with error saying
"panic: interface conversion: interface {} is nil, not *XXXX"