### PR TITLE
Avoid crashing nephe if CRD is not present

### DIFF
--- a/build/charts/nephe/templates/controller/clusterrole.yaml
+++ b/build/charts/nephe/templates/controller/clusterrole.yaml
@@ -157,3 +157,9 @@ rules:
   verbs:
   - list
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get

--- a/cmd/nephe-controller/main.go
+++ b/cmd/nephe-controller/main.go
@@ -39,6 +39,7 @@ import (
 	"antrea.io/nephe/pkg/controllers/virtualmachine"
 	"antrea.io/nephe/pkg/inventory"
 	"antrea.io/nephe/pkg/logging"
+	"antrea.io/nephe/pkg/util/k8s/crd"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -94,6 +95,13 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	// Wait for CRD to be present.
+	setupLog.Info("Checking for CRDs existence")
+	if err = crd.CheckCRDExistence(setupLog); err != nil {
+		setupLog.Info("failed to check for CRDs", "err", err)
 		os.Exit(1)
 	}
 

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -450,6 +450,12 @@ rules:
   verbs:
   - list
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -158,3 +158,9 @@ rules:
   verbs:
   - list
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.26.4 // indirect
+	k8s.io/apiextensions-apiserver v0.26.4
 	k8s.io/component-base v0.26.4 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kms v0.26.4 // indirect

--- a/pkg/accountmanager/manager.go
+++ b/pkg/accountmanager/manager.go
@@ -33,6 +33,7 @@ import (
 	ctrlsync "antrea.io/nephe/pkg/controllers/sync"
 	"antrea.io/nephe/pkg/inventory"
 	"antrea.io/nephe/pkg/util"
+	"antrea.io/nephe/pkg/util/k8s/crd"
 )
 
 const (
@@ -101,7 +102,7 @@ func (a *AccountManager) AddAccount(namespacedName *types.NamespacedName, accoun
 	// Create an account poller for polling cloud inventory.
 	accPoller, exists := a.addAccountPoller(cloudInterface, namespacedName, account)
 	if !exists {
-		if !util.DoesCesCrExistsForAccount(a.Client, namespacedName) {
+		if !crd.DoesCesCrExistsForAccount(a.Client, namespacedName) {
 			a.Log.Info("Starting account poller", "account", namespacedName)
 			go wait.Until(accPoller.doAccountPolling, time.Duration(accPoller.pollIntvInSeconds)*time.Second, accPoller.ch)
 		} else {

--- a/pkg/cloudprovider/plugins/aws/aws_crd_helpers.go
+++ b/pkg/cloudprovider/plugins/aws/aws_crd_helpers.go
@@ -25,7 +25,7 @@ import (
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
 	common "antrea.io/nephe/pkg/cloudprovider/plugins/internal"
 	"antrea.io/nephe/pkg/labels"
-	"antrea.io/nephe/pkg/util/k8s"
+	"antrea.io/nephe/pkg/util/k8s/tags"
 )
 
 const ResourceNameTagKey = "Name"
@@ -40,7 +40,7 @@ func ec2InstanceToInternalVirtualMachineObject(instance *ec2.Instance, vpcs map[
 			vmTags[*tag.Key] = *tag.Value
 		}
 	}
-	importedTags := k8s.ImportTags(vmTags)
+	importedTags := tags.ImportTags(vmTags)
 
 	// Network interfaces associated with Virtual machine
 	instNetworkInterfaces := instance.NetworkInterfaces

--- a/pkg/cloudprovider/plugins/azure/azure_crd_helpers.go
+++ b/pkg/cloudprovider/plugins/azure/azure_crd_helpers.go
@@ -26,7 +26,7 @@ import (
 	"antrea.io/nephe/pkg/cloudprovider/plugins/internal"
 	"antrea.io/nephe/pkg/cloudprovider/utils"
 	"antrea.io/nephe/pkg/labels"
-	"antrea.io/nephe/pkg/util/k8s"
+	"antrea.io/nephe/pkg/util/k8s/tags"
 )
 
 var azureStateMap = map[string]runtimev1alpha1.VMState{
@@ -47,7 +47,7 @@ func computeInstanceToInternalVirtualMachineObject(instance *virtualMachineTable
 	for key, value := range instance.Tags {
 		vmTags[key] = *value
 	}
-	importedTags := k8s.ImportTags(vmTags)
+	importedTags := tags.ImportTags(vmTags)
 
 	// Network interfaces associated with Virtual machine
 	instNetworkInterfaces := instance.NetworkInterfaces

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -15,11 +15,7 @@
 package util
 
 import (
-	"context"
 	"fmt"
-
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	crdv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
@@ -52,22 +48,4 @@ func GetAccountProviderType(account *crdv1alpha1.CloudProviderAccount) (runtimev
 	} else {
 		return "", fmt.Errorf("%s", ErrorMsgUnknownCloudProvider)
 	}
-}
-
-// DoesCesCrExistsForAccount returns true if there is a CloudEntitySelector CR for a given account.
-func DoesCesCrExistsForAccount(k8sClient client.Client, namespacedName *types.NamespacedName) bool {
-	cesList := &crdv1alpha1.CloudEntitySelectorList{}
-	listOptions := &client.ListOptions{
-		Namespace: namespacedName.Namespace,
-	}
-	if err := k8sClient.List(context.TODO(), cesList, listOptions); err != nil {
-		return false
-	}
-
-	for _, ces := range cesList.Items {
-		if ces.Spec.AccountName == namespacedName.Name {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/util/k8s/crd/crd.go
+++ b/pkg/util/k8s/crd/crd.go
@@ -1,0 +1,77 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	crdv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/go-logr/logr"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DoesCesCrExistsForAccount returns true if there is a CloudEntitySelector CR for a given account.
+func DoesCesCrExistsForAccount(k8sClient client.Client, namespacedName *types.NamespacedName) bool {
+	cesList := &crdv1alpha1.CloudEntitySelectorList{}
+	listOptions := &client.ListOptions{
+		Namespace: namespacedName.Namespace,
+	}
+	if err := k8sClient.List(context.TODO(), cesList, listOptions); err != nil {
+		return false
+	}
+
+	for _, ces := range cesList.Items {
+		if ces.Spec.AccountName == namespacedName.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckCRDExistence checks if the custom resource definitions are installed on the API server.
+func CheckCRDExistence(log logr.Logger) error {
+	apiExtClient, err := apiextensionsclientset.NewForConfig(ctrl.GetConfigOrDie())
+	if err != nil {
+		return fmt.Errorf("failed to create API extensions client: %v", err)
+	}
+	b := backoff.NewExponentialBackOff()
+	// Configure the backoff parameters
+	b.InitialInterval = 1 * time.Second
+	b.MaxInterval = 30 * time.Second
+	b.MaxElapsedTime = 1 * time.Hour // Max retry
+
+	err = backoff.Retry(func() error {
+		crds := []string{
+			"cloudprovideraccounts.crd.cloud.antrea.io",
+			"cloudentityselectors.crd.cloud.antrea.io",
+		}
+		for _, crd := range crds {
+			_, err := apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd, v1.GetOptions{})
+			if err != nil {
+				log.Info("failed to get CRD", "name", crd)
+				return fmt.Errorf("failed to get CRD: %v", err)
+			}
+		}
+		return nil
+	}, b)
+	return err
+}

--- a/pkg/util/k8s/tags/tags.go
+++ b/pkg/util/k8s/tags/tags.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8s
+package tags
 
 import (
 	"regexp"

--- a/pkg/util/k8s/tags/tags_test.go
+++ b/pkg/util/k8s/tags/tags_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8s
+package tags
 
 import (
 	"testing"


### PR DESCRIPTION
## Description
CR controller tries to watch for CRs upon start. If the CRD definitions is not added by then, it use to restart the pod.

## Changes 
Added a routine to check for existence of CRDs before starting CR controller. It will loop for 1 hour with max backoff of 30 sec. After that nephe will be restarted.