### PR TITLE
compute rule update delta against the cloud in plugins

### DIFF
--- a/pkg/cloudprovider/plugins/aws/aws_test.go
+++ b/pkg/cloudprovider/plugins/aws/aws_test.go
@@ -39,6 +39,7 @@ import (
 
 var (
 	testVpcID01 = "vpc-cb82c3b2"
+	testSgID    = 1
 )
 
 var _ = Describe("AWS cloud", func() {


### PR DESCRIPTION
## Description
Currently, the plugin directly invokes cloud APIs with the update rule set passed from the network policy. However, this approach becomes problematic if the cloud rule indexer is out of sync with the actual cloud state, due to user actions or other failures. To address this issue, this PR introduces a solution that fetches and compares the current cloud rules with the update sets in the plugin before invoking cloud APIs. It computes the final sets of rules that need to be updated based on this comparison.

## Changes
1. Implement normalization for AWS returned rules and introduced logic for deduplication and finding duplicates. Deduplication is used to compare the add rule set and avoid adding rules that already exist in the cloud. Finding duplicates is used to compare the remove rule set and avoid removing rules that do not exist in the cloud.
2. Move rule conversion to a separate function instead of inside cloud API call function.
3. Implement deduplication checks for Azure to prevent adding rules that already exist in the cloud. The logic for finding duplicates already existed.
4. Move adding Azure default deny rule to separate func to avoid unnecessary comparisons in delta compute logic.