### PR TITLE
Fix Secret Add event handling

### DIFF
--- a/pkg/accountmanager/manager.go
+++ b/pkg/accountmanager/manager.go
@@ -49,7 +49,7 @@ const (
 type Interface interface {
 	AddAccount(*types.NamespacedName, runtimev1alpha1.CloudProvider, *crdv1alpha1.CloudProviderAccount) (bool, error)
 	RemoveAccount(*types.NamespacedName) error
-	IsAccountCredentialsValid(namespacedName *types.NamespacedName) bool
+	IsAccountCredentialsValid(namespacedName *types.NamespacedName) (bool, error)
 	AddResourceFiltersToAccount(*types.NamespacedName, *types.NamespacedName, *crdv1alpha1.CloudEntitySelector, bool) (bool, error)
 	RemoveResourceFiltersFromAccount(*types.NamespacedName, *types.NamespacedName) error
 }
@@ -223,12 +223,12 @@ func (a *AccountManager) RemoveResourceFiltersFromAccount(accNamespacedName *typ
 }
 
 // IsAccountCredentialsValid return true for an account, if credentials are valid.
-func (a *AccountManager) IsAccountCredentialsValid(namespacedName *types.NamespacedName) bool {
+func (a *AccountManager) IsAccountCredentialsValid(namespacedName *types.NamespacedName) (bool, error) {
 	config := a.getAccountConfig(namespacedName)
 	if config != nil {
-		return config.credentialsValid
+		return config.credentialsValid, nil
 	}
-	return false
+	return false, fmt.Errorf("failed to get account config for account %v", namespacedName)
 }
 
 // addAccountPoller creates an account poller for a given account.
@@ -351,7 +351,7 @@ func (a *AccountManager) addSelectorToAccountConfig(accountNamespacedName, selec
 	selector *crdv1alpha1.CloudEntitySelector) error {
 	acctConfig := a.getAccountConfig(accountNamespacedName)
 	if acctConfig == nil {
-		return fmt.Errorf("failed to get account config")
+		return fmt.Errorf("failed to get account config for account %v", accountNamespacedName)
 	}
 	a.Log.V(1).Info("Adding selector config", "account", accountNamespacedName,
 		"selector", selectorNamespacedName)

--- a/pkg/controllers/cloudprovideraccount/controller_test.go
+++ b/pkg/controllers/cloudprovideraccount/controller_test.go
@@ -217,7 +217,7 @@ var _ = Describe("CloudProviderAccount Controller", func() {
 			// should be able to retrieve the Secret object.
 			It("Update", func() {
 				mockAccManager.EXPECT().AddAccount(&testAccountNamespacedName, accountCloudType, account).Return(false, nil).Times(2)
-				mockAccManager.EXPECT().IsAccountCredentialsValid(&testAccountNamespacedName).Return(true).Times(1)
+				mockAccManager.EXPECT().IsAccountCredentialsValid(&testAccountNamespacedName).Return(true, nil).Times(1)
 
 				By("Add the Secret")
 				_ = fakeClient.Create(context.Background(), secret)
@@ -265,7 +265,7 @@ var _ = Describe("CloudProviderAccount Controller", func() {
 			It("Delete", func() {
 				mockAccManager.EXPECT().AddAccount(&testAccountNamespacedName, accountCloudType, account).
 					Return(false, fmt.Errorf(util.ErrorMsgSecretReference)).Times(1)
-				mockAccManager.EXPECT().IsAccountCredentialsValid(&testAccountNamespacedName).Return(true).Times(1)
+				mockAccManager.EXPECT().IsAccountCredentialsValid(&testAccountNamespacedName).Return(true, nil).Times(1)
 				By("Add the Secret")
 				_ = fakeClient.Create(context.Background(), secret)
 				// Create CPA.
@@ -284,7 +284,7 @@ var _ = Describe("CloudProviderAccount Controller", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 			It("Add for AzureAccount", func() {
-				mockAccManager.EXPECT().IsAccountCredentialsValid(&testAccountNamespacedName).Return(true).Times(1)
+				mockAccManager.EXPECT().IsAccountCredentialsValid(&testAccountNamespacedName).Return(true, nil).Times(1)
 				credential := `{"subscriptionId": "subId", "clientId": "clientId", "tenantId": "tenantId", "clientKey": "clientKey"}`
 				secret.Data = map[string][]byte{credentials: []byte(credential)}
 				account.Spec.AWSConfig = nil

--- a/pkg/testing/accountmanager/mock.go
+++ b/pkg/testing/accountmanager/mock.go
@@ -82,11 +82,12 @@ func (mr *MockInterfaceMockRecorder) AddResourceFiltersToAccount(arg0, arg1, arg
 }
 
 // IsAccountCredentialsValid mocks base method.
-func (m *MockInterface) IsAccountCredentialsValid(arg0 *types.NamespacedName) bool {
+func (m *MockInterface) IsAccountCredentialsValid(arg0 *types.NamespacedName) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAccountCredentialsValid", arg0)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // IsAccountCredentialsValid indicates an expected call of IsAccountCredentialsValid.


### PR DESCRIPTION
If a Secret Add event is received, and the reconciler has not yet received the CloudProviderAccount CR, the Secret handler should not process/replay the account.

Also, do not throw a reconciler error if a CloudEntitySelector CR is not present.