### PR TITLE
Add explicit Antrea CRD dependency in Nephe

### DIFF
--- a/pkg/util/k8s/crd/crd.go
+++ b/pkg/util/k8s/crd/crd.go
@@ -63,6 +63,8 @@ func CheckCRDExistence(log logr.Logger) error {
 		crds := []string{
 			"cloudprovideraccounts.crd.cloud.antrea.io",
 			"cloudentityselectors.crd.cloud.antrea.io",
+			"externalentities.crd.antrea.io",
+			"externalnodes.crd.antrea.io",
 		}
 		for _, crd := range crds {
 			_, err := apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd, v1.GetOptions{})


### PR DESCRIPTION
## Description
Nephe controller has dependency on Antrea to be installed on the cluster first. If Antrea CRDs are not installed, Nephe controller will crash.

## Changes
Nephe controller will look for Antrea CRDs at boot, and if they are not installed, it will continue to loop and check for its existence in the cluster.