### PR TITLE
Allow Nephe to talk to Antrea Controller directly

### DIFF
--- a/cmd/nephe-controller/main.go
+++ b/cmd/nephe-controller/main.go
@@ -135,7 +135,7 @@ func main() {
 		Inventory:         cloudInventory,
 	}
 
-	if err = npController.SetupWithManager(mgr); err != nil {
+	if err = npController.SetupWithManager(mgr, opts.config.AntreaKubeconfig); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NetworkPolicy")
 		os.Exit(1)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,4 +23,6 @@ const (
 type ControllerConfig struct {
 	CloudResourcePrefix string `yaml:"cloudResourcePrefix,omitempty"`
 	CloudSyncInterval   int64  `yaml:"cloudSyncInterval,omitempty"`
+	// AntreaKubeconfig The path to access the kubeconfig file used in the connection to Antrea Controller.
+	AntreaKubeconfig string `yaml:"antreaKubeconfig,omitempty"`
 }

--- a/pkg/controllers/networkpolicy/controller_test.go
+++ b/pkg/controllers/networkpolicy/controller_test.go
@@ -135,7 +135,7 @@ var _ = Describe("NetworkPolicy", func() {
 			Inventory:       mockInventory,
 		}
 
-		err := reconciler.SetupWithManager(nil)
+		err := reconciler.SetupWithManager(nil, "")
 		Expect(err).ToNot(HaveOccurred())
 		vmMembers = make(map[string]*cloudresource.CloudResource)
 		vmExternalEntities = make(map[string]*antreatypes.ExternalEntity)


### PR DESCRIPTION
## Description
Nephe controller talks to Antrea Controller API Server via K8s API Server. It has scale and performance issues, as the communication is via K8s Server.

## Changes
With this PR, we allow direct communication between Nephe controller and Antrea controller, if antreaKubeconfig is set in configMap.