### PR TITLE
Add a state in cloud account config

### DIFF
--- a/pkg/accountmanager/poller.go
+++ b/pkg/accountmanager/poller.go
@@ -136,14 +136,15 @@ func (p *accountPoller) doAccountPolling() {
 	defer p.mutex.Unlock()
 
 	p.pollDone = false
-	// Ignoring error since it is captured in the CloudProviderAccount CR's status field.
-	_ = p.cloudInterface.DoInventoryPoll(p.accountNamespacedName)
-
 	defer func() {
 		p.pollDone = true
 		// Update status on CPA CR after polling.
 		p.updateAccountStatus(p.cloudInterface)
 	}()
+
+	if err := p.cloudInterface.DoInventoryPoll(p.accountNamespacedName); err != nil {
+		return
+	}
 
 	cloudInventory, err := p.cloudInterface.GetCloudInventory(p.accountNamespacedName)
 	if err != nil {

--- a/pkg/cloudprovider/plugins/aws/aws_account_mgmt.go
+++ b/pkg/cloudprovider/plugins/aws/aws_account_mgmt.go
@@ -122,7 +122,7 @@ func extractSecret(c client.Client, s *crdv1alpha1.SecretReference) (*crdv1alpha
 	}
 
 	if err = json.Unmarshal(decode, cred); err != nil {
-		return cred, fmt.Errorf("error unmarshalling credentials: %v/%v", s.Namespace, s.Name)
+		return cred, fmt.Errorf("%v, error unmarshalling credentials: %v/%v", util.ErrorMsgSecretReference, s.Namespace, s.Name)
 	}
 
 	if (cred.AccessKeyID == "" || cred.AccessKeySecret == "") && cred.RoleArn == "" {

--- a/pkg/cloudprovider/plugins/aws/aws_security_impl.go
+++ b/pkg/cloudprovider/plugins/aws/aws_security_impl.go
@@ -29,10 +29,11 @@ import (
 // CreateSecurityGroup invokes cloud api and creates the cloud security group based on securityGroupIdentifier.
 func (c *awsCloud) CreateSecurityGroup(securityGroupIdentifier *cloudresource.CloudResource, membershipOnly bool) (*string, error) {
 	vpcID := securityGroupIdentifier.Vpc
-	accCfg, found := c.cloudCommon.GetCloudAccountByAccountId(&securityGroupIdentifier.AccountID)
-	if !found {
-		return nil, fmt.Errorf("aws account not found managing virtual private cloud [%v]", vpcID)
+	accCfg, err := c.cloudCommon.GetCloudAccountByAccountId(&securityGroupIdentifier.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("%v, virtual private cloud: %v", err, vpcID)
 	}
+
 	accCfg.LockMutex()
 	defer accCfg.UnlockMutex()
 
@@ -54,10 +55,11 @@ func (c *awsCloud) UpdateSecurityGroupRules(appliedToGroupIdentifier *cloudresou
 	rmIRule, rmERule := utils.SplitCloudRulesByDirection(rmRules)
 
 	vpcID := appliedToGroupIdentifier.Vpc
-	accCfg, found := c.cloudCommon.GetCloudAccountByAccountId(&appliedToGroupIdentifier.AccountID)
-	if !found {
-		return fmt.Errorf("aws account not found managing virtual private cloud [%v]", vpcID)
+	accCfg, err := c.cloudCommon.GetCloudAccountByAccountId(&appliedToGroupIdentifier.AccountID)
+	if err != nil {
+		return fmt.Errorf("%v, virtual private cloud: %v", err, vpcID)
 	}
+
 	accCfg.LockMutex()
 	defer accCfg.UnlockMutex()
 
@@ -145,10 +147,11 @@ func (c *awsCloud) UpdateSecurityGroupRules(appliedToGroupIdentifier *cloudresou
 func (c *awsCloud) UpdateSecurityGroupMembers(securityGroupIdentifier *cloudresource.CloudResource,
 	cloudResourceIdentifiers []*cloudresource.CloudResource, membershipOnly bool) error {
 	vpcID := securityGroupIdentifier.Vpc
-	accCfg, found := c.cloudCommon.GetCloudAccountByAccountId(&securityGroupIdentifier.AccountID)
-	if !found {
-		return fmt.Errorf("aws account not found managing virtual private cloud [%v]", vpcID)
+	accCfg, err := c.cloudCommon.GetCloudAccountByAccountId(&securityGroupIdentifier.AccountID)
+	if err != nil {
+		return fmt.Errorf("%v, virtual private cloud: %v", err, vpcID)
 	}
+
 	accCfg.LockMutex()
 	defer accCfg.UnlockMutex()
 
@@ -178,10 +181,11 @@ func (c *awsCloud) UpdateSecurityGroupMembers(securityGroupIdentifier *cloudreso
 // DeleteSecurityGroup invokes cloud api and deletes the cloud security group. Any attached resource will be moved to default sg.
 func (c *awsCloud) DeleteSecurityGroup(securityGroupIdentifier *cloudresource.CloudResource, membershipOnly bool) error {
 	vpcID := securityGroupIdentifier.Vpc
-	accCfg, found := c.cloudCommon.GetCloudAccountByAccountId(&securityGroupIdentifier.AccountID)
-	if !found {
-		return fmt.Errorf("aws account not found managing virtual private cloud [%v]", vpcID)
+	accCfg, err := c.cloudCommon.GetCloudAccountByAccountId(&securityGroupIdentifier.AccountID)
+	if err != nil {
+		return fmt.Errorf("%v, virtual private cloud: %v", err, vpcID)
 	}
+
 	accCfg.LockMutex()
 	defer accCfg.UnlockMutex()
 
@@ -238,11 +242,12 @@ func (c *awsCloud) GetEnforcedSecurity() []cloudresource.SynchronizationContent 
 		go func(name *types.NamespacedName, sendCh chan<- []cloudresource.SynchronizationContent) {
 			defer wg.Done()
 
-			accCfg, found := c.cloudCommon.GetCloudAccountByName(name)
-			if !found {
-				awsPluginLogger().Info("Enforced-security-cloud-view GET for account skipped (account no longer exists)", "account", name)
+			accCfg, err := c.cloudCommon.GetCloudAccountByName(name)
+			if err != nil {
+				awsPluginLogger().Info("Enforced-security-cloud-view GET for account skipped", "err", err)
 				return
 			}
+
 			accCfg.LockMutex()
 			defer accCfg.UnlockMutex()
 

--- a/pkg/cloudprovider/plugins/azure/azure_security_test.go
+++ b/pkg/cloudprovider/plugins/azure/azure_security_test.go
@@ -239,7 +239,9 @@ var _ = Describe("Azure Cloud Security", func() {
 			err = c.AddAccountResourceSelector(testAccountNamespacedName, selector)
 			Expect(err).Should(BeNil())
 
-			accCfg, _ := c.cloudCommon.GetCloudAccountByName(testAccountNamespacedName)
+			accCfg, err := c.cloudCommon.GetCloudAccountByName(testAccountNamespacedName)
+			Expect(err).To(BeNil())
+			Expect(accCfg).To(Not(BeNil()))
 			serviceConfig := accCfg.GetServiceConfig()
 			selectorNamespacedName := types.NamespacedName{Namespace: selector.Namespace, Name: selector.Name}
 			inventory := serviceConfig.(*computeServiceConfig).GetCloudInventory()
@@ -895,7 +897,9 @@ var _ = Describe("Azure Cloud Security", func() {
 					VnetID: &testVnetID03,
 				})
 
-				accCfg, _ := c.cloudCommon.GetCloudAccountByName(testAccountNamespacedName)
+				accCfg, err := c.cloudCommon.GetCloudAccountByName(testAccountNamespacedName)
+				Expect(err).To(BeNil())
+				Expect(accCfg).To(Not(BeNil()))
 				serviceConfig := accCfg.GetServiceConfig()
 				selectorNamespacedName := types.NamespacedName{Namespace: selector.Namespace, Name: selector.Name}
 				snapshot := serviceConfig.(*computeServiceConfig).resourcesCache.GetSnapshot()

--- a/pkg/controllers/cloudprovideraccount/controller.go
+++ b/pkg/controllers/cloudprovideraccount/controller.go
@@ -293,7 +293,7 @@ func (r *CloudProviderAccountReconciler) setupSecretWatcher() {
 	r.watchSecret()
 }
 
-// updateStatus udpates the status on the CloudProviderAccount CR.
+// updateStatus updates the status on the CloudProviderAccount CR.
 func (r *CloudProviderAccountReconciler) updateStatus(namespacedName *types.NamespacedName, err error) {
 	var errorMsg string
 	if err != nil {


### PR DESCRIPTION
The cloud account config contains the service configs and cloud api clients. Whenever cloud account config update fails, set the cloud account config state to invalid. 

Any consumer of cloud account config which makes the cloud API calls should check the cloud account config state and proceed only if it's in a valid state.