### PR TITLE
implement multi region support for cpa

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.6.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.1.0
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/aws/aws-sdk-go v1.44.201
 	github.com/cenkalti/backoff/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourceg
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.6.0/go.mod h1:KKrvyReEXgIA2D4ez2Jq5dRynJW4bOjRDkONdze2qjs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0/go.mod h1:s1tW/At+xHqjNFvWU4G0c0Qv33KOhvbGNj0RCTQDV8s=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.1.0 h1:pYhaMoTHP/zYIJGDA1sWsfyTDjdglaoYjIFMOEcL+/U=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.1.0/go.mod h1:iLq8GwpQhj09gpI4EdELwifR9kHrb/Q0LThq6iQq9yY=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=

--- a/pkg/accountmanager/poller.go
+++ b/pkg/accountmanager/poller.go
@@ -148,7 +148,7 @@ func (p *accountPoller) doAccountPolling() {
 	}
 
 	// TODO: Remove this when event based push is implemented in the plugin.
-	cloudInventory, err := p.cloudInterface.GetCloudInventory(p.accountNamespacedName)
+	cloudInventory, err := p.cloudInterface.GetAccountCloudInventory(p.accountNamespacedName)
 	if err != nil {
 		// Chances are while polling was happening, account is removed.
 		return

--- a/pkg/accountmanager/poller_test.go
+++ b/pkg/accountmanager/poller_test.go
@@ -217,21 +217,21 @@ var _ = Describe("Account Poller", func() {
 				CloudProviderAccountStatus{}, nil).AnyTimes()
 
 			// Invalid VPC.
-			mockCloudInterface.EXPECT().GetCloudInventory(&testAccountNamespacedName).Return(nil,
+			mockCloudInterface.EXPECT().GetAccountCloudInventory(&testAccountNamespacedName).Return(nil,
 				fmt.Errorf("error")).Times(1)
 			accountPollerObj.doAccountPolling()
 			Expect(len(accountPollerObj.inventory.GetAllVpcs())).To(Equal(0))
 
 			// Empty VPC.
 			cloudInventory := nephetypes.CloudInventory{}
-			mockCloudInterface.EXPECT().GetCloudInventory(&testAccountNamespacedName).Return(&cloudInventory,
+			mockCloudInterface.EXPECT().GetAccountCloudInventory(&testAccountNamespacedName).Return(&cloudInventory,
 				nil).Times(1)
 			accountPollerObj.doAccountPolling()
 			Expect(len(accountPollerObj.inventory.GetAllVpcs())).To(Equal(0))
 
 			// Valid VPC.
 			cloudInventory = nephetypes.CloudInventory{VpcMap: vpcList}
-			mockCloudInterface.EXPECT().GetCloudInventory(&testAccountNamespacedName).Return(&cloudInventory,
+			mockCloudInterface.EXPECT().GetAccountCloudInventory(&testAccountNamespacedName).Return(&cloudInventory,
 				nil).Times(1)
 			accountPollerObj.doAccountPolling()
 			Expect(len(accountPollerObj.inventory.GetAllVpcs())).To(Equal(len(vpcList)))
@@ -253,7 +253,7 @@ var _ = Describe("Account Poller", func() {
 
 			cloudInventory = nephetypes.CloudInventory{VpcMap: vpcList}
 			// Invalid VMs.
-			mockCloudInterface.EXPECT().GetCloudInventory(&testAccountNamespacedName).Return(&cloudInventory,
+			mockCloudInterface.EXPECT().GetAccountCloudInventory(&testAccountNamespacedName).Return(&cloudInventory,
 				nil).Times(1)
 			accountPollerObj.doAccountPolling()
 			Expect(len(accountPollerObj.inventory.GetAllVms())).To(Equal(0))
@@ -262,7 +262,7 @@ var _ = Describe("Account Poller", func() {
 			vmMap := make(map[types.NamespacedName]map[string]*runtimev1alpha1.VirtualMachine)
 			vmMap[testCesNamespacedName] = vmList
 			cloudInventory = nephetypes.CloudInventory{VpcMap: vpcList, VmMap: vmMap}
-			mockCloudInterface.EXPECT().GetCloudInventory(&testAccountNamespacedName).Return(&cloudInventory,
+			mockCloudInterface.EXPECT().GetAccountCloudInventory(&testAccountNamespacedName).Return(&cloudInventory,
 				nil).Times(1)
 			accountPollerObj.doAccountPolling()
 			Expect(len(accountPollerObj.inventory.GetAllVms())).To(Equal(len(vmList)))

--- a/pkg/cloudprovider/cloud/cloud.go
+++ b/pkg/cloudprovider/cloud/cloud.go
@@ -62,8 +62,8 @@ type AccountMgmtInterface interface {
 
 // ComputeInterface is an abstract providing set of methods to get inventory details to be implemented by cloud providers.
 type ComputeInterface interface {
-	// GetCloudInventory gets VPC and VM inventory from plugin snapshot for a given cloud provider account.
-	GetCloudInventory(accountNamespacedName *types.NamespacedName) (*nephetypes.CloudInventory, error)
+	// GetAccountCloudInventory gets VPC and VM inventory from plugin snapshot for a given cloud provider account.
+	GetAccountCloudInventory(accountNamespacedName *types.NamespacedName) (*nephetypes.CloudInventory, error)
 }
 
 type SecurityInterface interface {

--- a/pkg/cloudprovider/plugins/aws/aws_account_impl.go
+++ b/pkg/cloudprovider/plugins/aws/aws_account_impl.go
@@ -15,6 +15,8 @@
 package aws
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -23,6 +25,9 @@ import (
 
 // AddProviderAccount adds and initializes given account of a cloud provider.
 func (c *awsCloud) AddProviderAccount(client client.Client, account *crdv1alpha1.CloudProviderAccount) error {
+	for idx := range account.Spec.AWSConfig.Region {
+		account.Spec.AWSConfig.Region[idx] = strings.ToLower(account.Spec.AWSConfig.Region[idx])
+	}
 	return c.cloudCommon.AddCloudAccount(client, account, account.Spec.AWSConfig)
 }
 

--- a/pkg/cloudprovider/plugins/aws/aws_api_wrappers-mock_test.go
+++ b/pkg/cloudprovider/plugins/aws/aws_api_wrappers-mock_test.go
@@ -154,6 +154,20 @@ func (mr *MockawsEC2WrapperMockRecorder) describeVpcsWrapper(input interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "describeVpcsWrapper", reflect.TypeOf((*MockawsEC2Wrapper)(nil).describeVpcsWrapper), input)
 }
 
+// getRegion mocks base method.
+func (m *MockawsEC2Wrapper) getRegion() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getRegion")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// getRegion indicates an expected call of getRegion.
+func (mr *MockawsEC2WrapperMockRecorder) getRegion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getRegion", reflect.TypeOf((*MockawsEC2Wrapper)(nil).getRegion))
+}
+
 // modifyNetworkInterfaceAttribute mocks base method.
 func (m *MockawsEC2Wrapper) modifyNetworkInterfaceAttribute(input *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloudprovider/plugins/aws/aws_cloudcommonhelper_impl.go
+++ b/pkg/cloudprovider/plugins/aws/aws_cloudcommonhelper_impl.go
@@ -22,10 +22,14 @@ func (h *awsCloudCommonHelperImpl) GetCloudServicesCreateFunc() internal.CloudSe
 	return newAwsServiceConfigs
 }
 
-func (h *awsCloudCommonHelperImpl) SetAccountCredentialsFunc() internal.CloudCredentialValidatorFunc {
-	return setAccountCredentials
+func (h *awsCloudCommonHelperImpl) GetCloudServicesUpdateFunc() internal.CloudServiceConfigUpdateFunc {
+	return updateAwsServiceConfigs
 }
 
-func (h *awsCloudCommonHelperImpl) GetCloudCredentialsComparatorFunc() internal.CloudCredentialComparatorFunc {
-	return compareAccountCredentials
+func (h *awsCloudCommonHelperImpl) SetAccountConfigFunc() internal.CloudConfigValidatorFunc {
+	return setAccountConfig
+}
+
+func (h *awsCloudCommonHelperImpl) GetCloudConfigComparatorFunc() internal.CloudConfigComparatorFunc {
+	return compareAccountConfig
 }

--- a/pkg/cloudprovider/plugins/aws/aws_services-mock_test.go
+++ b/pkg/cloudprovider/plugins/aws/aws_services-mock_test.go
@@ -87,16 +87,16 @@ func (m *MockawsServicesHelper) EXPECT() *MockawsServicesHelperMockRecorder {
 }
 
 // newServiceSdkConfigProvider mocks base method.
-func (m *MockawsServicesHelper) newServiceSdkConfigProvider(accCfg *awsAccountConfig) (awsServiceClientCreateInterface, error) {
+func (m *MockawsServicesHelper) newServiceSdkConfigProvider(accCfg *awsAccountConfig, region string) (awsServiceClientCreateInterface, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "newServiceSdkConfigProvider", accCfg)
+	ret := m.ctrl.Call(m, "newServiceSdkConfigProvider", accCfg, region)
 	ret0, _ := ret[0].(awsServiceClientCreateInterface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // newServiceSdkConfigProvider indicates an expected call of newServiceSdkConfigProvider.
-func (mr *MockawsServicesHelperMockRecorder) newServiceSdkConfigProvider(accCfg interface{}) *gomock.Call {
+func (mr *MockawsServicesHelperMockRecorder) newServiceSdkConfigProvider(accCfg, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newServiceSdkConfigProvider", reflect.TypeOf((*MockawsServicesHelper)(nil).newServiceSdkConfigProvider), accCfg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newServiceSdkConfigProvider", reflect.TypeOf((*MockawsServicesHelper)(nil).newServiceSdkConfigProvider), accCfg, region)
 }

--- a/pkg/cloudprovider/plugins/aws/aws_services.go
+++ b/pkg/cloudprovider/plugins/aws/aws_services.go
@@ -20,17 +20,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/types"
 
+	crdv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
 	"antrea.io/nephe/pkg/cloudprovider/plugins/internal"
+	"antrea.io/nephe/pkg/util"
 )
 
 // awsServiceClientCreateInterface provides interface to create aws service clients.
 type awsServiceClientCreateInterface interface {
 	compute() (awsEC2Wrapper, error)
-	// Add any aws service (like rds, elb etc) apiClient creation methods here
+	// Add any aws service (like rds, elb etc.) apiClient creation methods here
 }
 
 // awsServiceSdkConfigProvider provides config required to create aws service (ec2) clients.
@@ -42,13 +46,14 @@ type awsServiceSdkConfigProvider struct {
 
 // awsServicesHelper.
 type awsServicesHelper interface {
-	newServiceSdkConfigProvider(accCfg *awsAccountConfig) (awsServiceClientCreateInterface, error)
+	newServiceSdkConfigProvider(accCfg *awsAccountConfig, region string) (awsServiceClientCreateInterface, error)
 }
 
 type awsServicesHelperImpl struct{}
 
 // newServiceSdkConfigProvider returns config to create aws services clients.
-func (h *awsServicesHelperImpl) newServiceSdkConfigProvider(accConfig *awsAccountConfig) (awsServiceClientCreateInterface, error) {
+func (h *awsServicesHelperImpl) newServiceSdkConfigProvider(accConfig *awsAccountConfig, region string) (
+	awsServiceClientCreateInterface, error) {
 	var creds *credentials.Credentials
 	var err error
 	if len(accConfig.RoleArn) != 0 {
@@ -57,7 +62,7 @@ func (h *awsServicesHelperImpl) newServiceSdkConfigProvider(accConfig *awsAccoun
 		if len(accConfig.AccessKeyID) != 0 && len(accConfig.AccessKeySecret) != 0 {
 			tempCreds := credentials.NewStaticCredentials(accConfig.AccessKeyID, accConfig.AccessKeySecret, accConfig.SessionToken)
 			if sess, err = session.NewSession(&aws.Config{
-				Region:                        &accConfig.region,
+				Region:                        aws.String(region),
 				Credentials:                   tempCreds,
 				CredentialsChainVerboseErrors: aws.Bool(true),
 			}); err != nil {
@@ -67,7 +72,7 @@ func (h *awsServicesHelperImpl) newServiceSdkConfigProvider(accConfig *awsAccoun
 			// use role base access if role provided
 			// new session using worker node role, it should have AssumeRole permissions to the Customer's role ARN resource
 			if sess, err = session.NewSession(&aws.Config{
-				Region:                        &accConfig.region,
+				Region:                        aws.String(region),
 				CredentialsChainVerboseErrors: aws.Bool(true),
 			}); err != nil {
 				return nil, fmt.Errorf("error initializing AWS session: %v", err)
@@ -91,7 +96,7 @@ func (h *awsServicesHelperImpl) newServiceSdkConfigProvider(accConfig *awsAccoun
 	}
 
 	awsConfig := &aws.Config{
-		Region:                        &accConfig.region,
+		Region:                        aws.String(region),
 		Endpoint:                      &accConfig.endpoint,
 		Credentials:                   creds,
 		CredentialsChainVerboseErrors: aws.Bool(true),
@@ -107,20 +112,87 @@ func (h *awsServicesHelperImpl) newServiceSdkConfigProvider(accConfig *awsAccoun
 	return configProvider, nil
 }
 
-func newAwsServiceConfigs(accountNamespacedName *types.NamespacedName, accCredentials interface{}, awsSpecificHelper interface{}) (
-	internal.CloudServiceInterface, error) {
+// newAwsServiceConfigs creates service configs for each region for an account and returns a region to service config map for successful
+// creations and multierr for any errors.
+func newAwsServiceConfigs(accountNamespacedName *types.NamespacedName, config interface{}, awsSpecificHelper interface{}) (
+	map[string]internal.CloudServiceInterface, error) {
 	awsServicesHelper := awsSpecificHelper.(awsServicesHelper)
-	awsAccountCredentials := accCredentials.(*awsAccountConfig)
+	awsConfig := config.(*awsAccountConfig)
 
-	awsServiceClientCreator, err := awsServicesHelper.newServiceSdkConfigProvider(awsAccountCredentials)
+	// check regions valid and process regions.
+	regions, err := processRegions(awsConfig)
 	if err != nil {
-		return nil, err
+		return map[string]internal.CloudServiceInterface{}, err
+	}
+	awsConfig.regions = regions
+
+	// create config provider.
+	var retErr error
+	configProviders := make(map[string]awsServiceClientCreateInterface)
+	for _, region := range awsConfig.regions {
+		configProvider, err := awsServicesHelper.newServiceSdkConfigProvider(awsConfig, region)
+		retErr = multierr.Append(retErr, err)
+		if err == nil {
+			configProviders[region] = configProvider
+		}
 	}
 
-	ec2Service, err := newEC2ServiceConfig(*accountNamespacedName, awsServiceClientCreator, awsAccountCredentials)
-	if err != nil {
-		return nil, err
-	}
+	// create service configs.
+	ec2Service, err := newEC2ServiceConfig(*accountNamespacedName, configProviders)
+	retErr = multierr.Append(retErr, err)
 
-	return ec2Service, nil
+	return ec2Service, retErr
+}
+
+// updateAwsServiceConfigs updates the current region to service config map according to the new map.
+func updateAwsServiceConfigs(current, new map[string]internal.CloudServiceInterface) error {
+	var retErr error
+	var selectors map[types.NamespacedName]*crdv1alpha1.CloudEntitySelector
+	for region, s := range current {
+		selectors = s.GetResourceFilters()
+		newServiceConfig, found := new[region]
+		if !found {
+			delete(current, region)
+		} else {
+			// update the service config if new service config is different object from current service config.
+			if err := s.UpdateServiceConfig(newServiceConfig); err != nil {
+				retErr = multierr.Append(retErr, err)
+			}
+			delete(new, region)
+		}
+	}
+	for region, s := range new {
+		current[region] = s
+		// resource selectors from previous service configs needs to be replayed.
+		for _, selector := range selectors {
+			if err := s.AddResourceFilters(selector); err != nil {
+				retErr = multierr.Append(retErr, err)
+				delete(current, region)
+				break
+			}
+		}
+	}
+	return retErr
+}
+
+// processRegions check if account regions are all valid and deduplicate regions.
+func processRegions(config *awsAccountConfig) ([]string, error) {
+	awsRegionMap := endpoints.AwsPartition().Regions()
+	existingRegions := make(map[string]struct{})
+	retRegions := make([]string, 0, len(config.regions))
+	for _, region := range config.regions {
+		if _, found := existingRegions[region]; found {
+			continue
+		}
+		if _, found := awsRegionMap[region]; !found {
+			allRegions := make([]string, 0, len(awsRegionMap))
+			for r := range awsRegionMap {
+				allRegions = append(allRegions, r)
+			}
+			return nil, fmt.Errorf("%s, %s not in supported regions %v", util.ErrorMsgRegion, region, allRegions)
+		}
+		existingRegions[region] = struct{}{}
+		retRegions = append(retRegions, region)
+	}
+	return retRegions, nil
 }

--- a/pkg/cloudprovider/plugins/azure/azure_account_impl.go
+++ b/pkg/cloudprovider/plugins/azure/azure_account_impl.go
@@ -15,6 +15,8 @@
 package azure
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -23,6 +25,9 @@ import (
 
 // AddProviderAccount adds and initializes given account of a cloud provider.
 func (c *azureCloud) AddProviderAccount(client client.Client, account *crdv1alpha1.CloudProviderAccount) error {
+	for idx := range account.Spec.AzureConfig.Region {
+		account.Spec.AzureConfig.Region[idx] = strings.ToLower(account.Spec.AzureConfig.Region[idx])
+	}
 	return c.cloudCommon.AddCloudAccount(client, account, account.Spec.AzureConfig)
 }
 

--- a/pkg/cloudprovider/plugins/azure/azure_api_wrappers-mock_test.go
+++ b/pkg/cloudprovider/plugins/azure/azure_api_wrappers-mock_test.go
@@ -25,6 +25,7 @@ import (
 
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	armresourcegraph "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	armsubscription "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -334,4 +335,42 @@ func (m *MockazureVirtualNetworksWrapper) listAllComplete(ctx context.Context) (
 func (mr *MockazureVirtualNetworksWrapperMockRecorder) listAllComplete(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "listAllComplete", reflect.TypeOf((*MockazureVirtualNetworksWrapper)(nil).listAllComplete), ctx)
+}
+
+// MockazureSubscriptionsWrapper is a mock of azureSubscriptionsWrapper interface.
+type MockazureSubscriptionsWrapper struct {
+	ctrl     *gomock.Controller
+	recorder *MockazureSubscriptionsWrapperMockRecorder
+}
+
+// MockazureSubscriptionsWrapperMockRecorder is the mock recorder for MockazureSubscriptionsWrapper.
+type MockazureSubscriptionsWrapperMockRecorder struct {
+	mock *MockazureSubscriptionsWrapper
+}
+
+// NewMockazureSubscriptionsWrapper creates a new mock instance.
+func NewMockazureSubscriptionsWrapper(ctrl *gomock.Controller) *MockazureSubscriptionsWrapper {
+	mock := &MockazureSubscriptionsWrapper{ctrl: ctrl}
+	mock.recorder = &MockazureSubscriptionsWrapperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockazureSubscriptionsWrapper) EXPECT() *MockazureSubscriptionsWrapperMockRecorder {
+	return m.recorder
+}
+
+// listComplete mocks base method.
+func (m *MockazureSubscriptionsWrapper) listComplete(ctx context.Context, subscriptionId string) ([]armsubscription.Location, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "listComplete", ctx, subscriptionId)
+	ret0, _ := ret[0].([]armsubscription.Location)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// listComplete indicates an expected call of listComplete.
+func (mr *MockazureSubscriptionsWrapperMockRecorder) listComplete(ctx, subscriptionId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "listComplete", reflect.TypeOf((*MockazureSubscriptionsWrapper)(nil).listComplete), ctx, subscriptionId)
 }

--- a/pkg/cloudprovider/plugins/azure/azure_cloudcommonhelper_impl.go
+++ b/pkg/cloudprovider/plugins/azure/azure_cloudcommonhelper_impl.go
@@ -24,10 +24,14 @@ func (h *azureCloudCommonHelperImpl) GetCloudServicesCreateFunc() internal.Cloud
 	return newAzureServiceConfigs
 }
 
-func (h *azureCloudCommonHelperImpl) SetAccountCredentialsFunc() internal.CloudCredentialValidatorFunc {
-	return setAccountCredentials
+func (h *azureCloudCommonHelperImpl) GetCloudServicesUpdateFunc() internal.CloudServiceConfigUpdateFunc {
+	return updateAzureServiceConfigs
 }
 
-func (h *azureCloudCommonHelperImpl) GetCloudCredentialsComparatorFunc() internal.CloudCredentialComparatorFunc {
-	return compareAccountCredentials
+func (h *azureCloudCommonHelperImpl) SetAccountConfigFunc() internal.CloudConfigValidatorFunc {
+	return setAccountConfig
+}
+
+func (h *azureCloudCommonHelperImpl) GetCloudConfigComparatorFunc() internal.CloudConfigComparatorFunc {
+	return compareAccountConfig
 }

--- a/pkg/cloudprovider/plugins/azure/azure_compute_impl.go
+++ b/pkg/cloudprovider/plugins/azure/azure_compute_impl.go
@@ -20,7 +20,7 @@ import (
 	nephetypes "antrea.io/nephe/pkg/types"
 )
 
-// GetCloudInventory pulls cloud vpc and vm inventory from internal snapshot.
-func (c *azureCloud) GetCloudInventory(accountNamespacedName *types.NamespacedName) (*nephetypes.CloudInventory, error) {
-	return c.cloudCommon.GetCloudInventory(accountNamespacedName)
+// GetAccountCloudInventory pulls cloud vpc and vm inventory from internal snapshot.
+func (c *azureCloud) GetAccountCloudInventory(accountNamespacedName *types.NamespacedName) (*nephetypes.CloudInventory, error) {
+	return c.cloudCommon.GetAccountCloudInventory(accountNamespacedName)
 }

--- a/pkg/cloudprovider/plugins/azure/azure_crd_helpers.go
+++ b/pkg/cloudprovider/plugins/azure/azure_crd_helpers.go
@@ -40,9 +40,8 @@ var azureStateMap = map[string]runtimev1alpha1.VMState{
 }
 
 // computeInstanceToInternalVirtualMachineObject converts compute instance to VirtualMachine runtime object.
-func computeInstanceToInternalVirtualMachineObject(instance *virtualMachineTable,
-	vnets map[string]armnetwork.VirtualNetwork, selectorNamespacedName *types.NamespacedName, accountNamespacedName *types.NamespacedName,
-	region string) *runtimev1alpha1.VirtualMachine {
+func computeInstanceToInternalVirtualMachineObject(instance *virtualMachineTable, vnets map[string]armnetwork.VirtualNetwork,
+	selectorNamespacedName *types.NamespacedName, accountNamespacedName *types.NamespacedName) *runtimev1alpha1.VirtualMachine {
 	vmTags := make(map[string]string)
 	for key, value := range instance.Tags {
 		vmTags[key] = *value
@@ -132,7 +131,7 @@ func computeInstanceToInternalVirtualMachineObject(instance *virtualMachineTable
 		Tags:              importedTags,
 		State:             state,
 		NetworkInterfaces: networkInterfaces,
-		Region:            strings.ToLower(region),
+		Region:            strings.ToLower(*instance.Location),
 		Agented:           false,
 		CloudId:           strings.ToLower(cloudID),
 		CloudName:         strings.ToLower(cloudName),
@@ -168,8 +167,8 @@ func computeInstanceToInternalVirtualMachineObject(instance *virtualMachineTable
 }
 
 // ComputeVpcToInternalVpcObject converts vnet object from cloud format(network.VirtualNetwork) to vpc runtime object.
-func ComputeVpcToInternalVpcObject(vnet *armnetwork.VirtualNetwork, accountNamespace, accountName,
-	region string, managed bool) *runtimev1alpha1.Vpc {
+func ComputeVpcToInternalVpcObject(vnet *armnetwork.VirtualNetwork, accountNamespace, accountName string,
+	managed bool) *runtimev1alpha1.Vpc {
 	crdName := utils.GenerateShortResourceIdentifier(*vnet.ID, *vnet.Name)
 	tags := make(map[string]string, 0)
 	if len(vnet.Tags) != 0 {
@@ -195,7 +194,7 @@ func ComputeVpcToInternalVpcObject(vnet *armnetwork.VirtualNetwork, accountNames
 		CloudName: strings.ToLower(*vnet.Name),
 		CloudId:   strings.ToLower(*vnet.ID),
 		Provider:  runtimev1alpha1.AzureCloudProvider,
-		Region:    region,
+		Region:    strings.ToLower(*vnet.Location),
 		Tags:      tags,
 		Cidrs:     cidrs,
 		Managed:   managed,
@@ -221,12 +220,12 @@ func ComputeVpcToInternalVpcObject(vnet *armnetwork.VirtualNetwork, accountNames
 
 // computeSgToInternalSgObject converts nsg object from cloud format(nsgTable) to security group runtime object.
 func computeSgToInternalSgObject(nsg *nsgTable, selectorNamespacedName,
-	accountNamespacedName *types.NamespacedName, region string) *runtimev1alpha1.SecurityGroup {
+	accountNamespacedName *types.NamespacedName) *runtimev1alpha1.SecurityGroup {
 	status := &runtimev1alpha1.SecurityGroupStatus{
 		CloudName: strings.ToLower(*nsg.Name),
 		CloudId:   strings.ToLower(*nsg.ID),
 		Provider:  runtimev1alpha1.AzureCloudProvider,
-		Region:    region,
+		Region:    strings.ToLower(*nsg.Location),
 	}
 
 	if nsg.Properties != nil {

--- a/pkg/cloudprovider/plugins/azure/azure_resourcegraph_vmTable.go
+++ b/pkg/cloudprovider/plugins/azure/azure_resourcegraph_vmTable.go
@@ -113,8 +113,8 @@ const (
 		"nicPrivateIps, \"publicIps\", nicPublicIps, \"tags\", nicTags, \"vnetId\", vnetId, \"nsgId\", nsgId, " +
 		"\"applicationSecurityGroupIds\", applicationSecurityGroupIds)" +
 		"| summarize vnetId = any(vnetId), properties = make_bag(properties), tags = make_bag(tags), " +
-		"networkInterfaces = make_list(networkInterfaceDetails) by id, name" +
-		"| project id, name, properties, status=properties.extended.instanceView.powerState.code, networkInterfaces, tags, vnetId"
+		"networkInterfaces = make_list(networkInterfaceDetails) by id, name, location = locationLowerCase" +
+		"| project id, name, properties, status=properties.extended.instanceView.powerState.code, networkInterfaces, tags, vnetId, location"
 )
 
 func ToTimeHookFunc() mapstructure.DecodeHookFunc {

--- a/pkg/cloudprovider/plugins/azure/azure_services-mock_test.go
+++ b/pkg/cloudprovider/plugins/azure/azure_services-mock_test.go
@@ -108,6 +108,21 @@ func (mr *MockazureServiceClientCreateInterfaceMockRecorder) securityGroups(subs
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "securityGroups", reflect.TypeOf((*MockazureServiceClientCreateInterface)(nil).securityGroups), subscriptionID)
 }
 
+// subscriptions mocks base method.
+func (m *MockazureServiceClientCreateInterface) subscriptions() (azureSubscriptionsWrapper, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "subscriptions")
+	ret0, _ := ret[0].(azureSubscriptionsWrapper)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// subscriptions indicates an expected call of subscriptions.
+func (mr *MockazureServiceClientCreateInterfaceMockRecorder) subscriptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "subscriptions", reflect.TypeOf((*MockazureServiceClientCreateInterface)(nil).subscriptions))
+}
+
 // virtualNetworks mocks base method.
 func (m *MockazureServiceClientCreateInterface) virtualNetworks(subscriptionID string) (azureVirtualNetworksWrapper, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloudprovider/plugins/azure/azure_services.go
+++ b/pkg/cloudprovider/plugins/azure/azure_services.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"antrea.io/nephe/pkg/cloudprovider/plugins/internal"
+	"antrea.io/nephe/pkg/util"
 )
 
 // azureServiceClientCreateInterface provides interface to create azure service clients.
@@ -33,6 +34,7 @@ type azureServiceClientCreateInterface interface {
 	securityGroups(subscriptionID string) (azureNsgWrapper, error)
 	applicationSecurityGroups(subscriptionID string) (azureAsgWrapper, error)
 	virtualNetworks(subscriptionID string) (azureVirtualNetworksWrapper, error)
+	subscriptions() (azureSubscriptionsWrapper, error)
 	// Add any azure service api client creation methods here
 }
 
@@ -50,7 +52,7 @@ type azureServicesHelper interface {
 type azureServicesHelperImpl struct{}
 
 // newServiceSdkConfigProvider returns config to create azure services clients.
-func (h *azureServicesHelperImpl) newServiceSdkConfigProvider(accCreds *azureAccountConfig) (
+func (h *azureServicesHelperImpl) newServiceSdkConfigProvider(config *azureAccountConfig) (
 	azureServiceClientCreateInterface, error) {
 	var err error
 	var cred azcore.TokenCredential
@@ -58,15 +60,15 @@ func (h *azureServicesHelperImpl) newServiceSdkConfigProvider(accCreds *azureAcc
 	// TODO: Expose an option in CPA to specify the cloud type, AzurePublic, AzureGovernment and AzureChina.
 
 	// use role based access if session token is configured.
-	if len(strings.TrimSpace(accCreds.SessionToken)) > 0 {
-		token := accCreds.SessionToken
+	if len(strings.TrimSpace(config.SessionToken)) > 0 {
+		token := config.SessionToken
 		getAssertion := func(_ context.Context) (string, error) { return token, nil }
-		cred, err = azidentity.NewClientAssertionCredential(accCreds.TenantID, accCreds.ClientID, getAssertion, nil)
+		cred, err = azidentity.NewClientAssertionCredential(config.TenantID, config.ClientID, getAssertion, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error initializing Azure authorizer from session token: %v", err)
 		}
 	} else {
-		cred, err = azidentity.NewClientSecretCredential(accCreds.TenantID, accCreds.ClientID, accCreds.ClientKey, nil)
+		cred, err = azidentity.NewClientSecretCredential(config.TenantID, config.ClientID, config.ClientKey, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error initializing Azure authorizer from credentials: %v", err)
 		}
@@ -78,20 +80,91 @@ func (h *azureServicesHelperImpl) newServiceSdkConfigProvider(accCreds *azureAcc
 	return configProvider, nil
 }
 
-func newAzureServiceConfigs(accountNamespacedName *types.NamespacedName, accCredentials interface{}, azureSpecificHelper interface{}) (
-	internal.CloudServiceInterface, error) {
+// newAzureServiceConfigs creates a service config for an account and returns a region to service config map or error happened.
+func newAzureServiceConfigs(accountNamespacedName *types.NamespacedName, config interface{}, azureSpecificHelper interface{}) (
+	map[string]internal.CloudServiceInterface, error) {
 	azureServicesHelper := azureSpecificHelper.(azureServicesHelper)
-	azureAccountCredentials := accCredentials.(*azureAccountConfig)
+	azureConfig := config.(*azureAccountConfig)
 
-	azureServiceClientCreator, err := azureServicesHelper.newServiceSdkConfigProvider(azureAccountCredentials)
+	// create config provider.
+	azureServiceClientCreator, err := azureServicesHelper.newServiceSdkConfigProvider(azureConfig)
 	if err != nil {
-		return nil, err
+		return map[string]internal.CloudServiceInterface{}, err
 	}
 
-	computeService, err := newComputeServiceConfig(*accountNamespacedName, azureServiceClientCreator, azureAccountCredentials)
+	// check locations valid and process locations.
+	regions, err := processRegions(accountNamespacedName, azureServiceClientCreator, azureConfig)
 	if err != nil {
-		return nil, err
+		return map[string]internal.CloudServiceInterface{}, err
+	}
+	azureConfig.regions = regions
+
+	// create service config.
+	computeService, err := newComputeServiceConfig(*accountNamespacedName, azureServiceClientCreator, azureConfig)
+	if err != nil {
+		return map[string]internal.CloudServiceInterface{}, err
 	}
 
 	return computeService, nil
+}
+
+// updateAzureServiceConfigs updates the current region to service config map according to the new map.
+// The current single Azure service config is reused and updated.
+func updateAzureServiceConfigs(current, new map[string]internal.CloudServiceInterface) error {
+	// get the current service config and the new service config.
+	var currentServiceConfig internal.CloudServiceInterface
+	var newServiceConfig internal.CloudServiceInterface
+	for _, s := range current {
+		currentServiceConfig = s
+		break
+	}
+	for _, s := range new {
+		newServiceConfig = s
+		break
+	}
+	// update the regions in the map.
+	for region := range current {
+		_, found := new[region]
+		if !found {
+			delete(current, region)
+		} else {
+			delete(new, region)
+		}
+	}
+	for region := range new {
+		current[region] = currentServiceConfig
+	}
+	return currentServiceConfig.UpdateServiceConfig(newServiceConfig)
+}
+
+// processRegions check if account regions are all valid and deduplicate regions.
+func processRegions(acc *types.NamespacedName, services azureServiceClientCreateInterface, config *azureAccountConfig) ([]string, error) {
+	subscriptionsClient, err := services.subscriptions()
+	if err != nil {
+		return nil, fmt.Errorf("error creating subscriptions sdk api client for account: %v, err: %v", *acc, err)
+	}
+	locations, err := subscriptionsClient.listComplete(context.Background(), config.SubscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("error listing locations for subscription: %v, err: %v", config.SubscriptionID, err)
+	}
+
+	locationMap := make(map[string]struct{})
+	existingLocations := make(map[string]struct{})
+	allLocations := make([]string, 0, len(locations))
+	retLocations := make([]string, 0, len(config.regions))
+	for _, location := range locations {
+		locationMap[strings.ToLower(*location.Name)] = struct{}{}
+		allLocations = append(allLocations, *location.Name)
+	}
+	for _, location := range config.regions {
+		if _, found := existingLocations[location]; found {
+			continue
+		}
+		if _, found := locationMap[location]; !found {
+			return nil, fmt.Errorf("%s, %s not in supported locations %v", util.ErrorMsgRegion, location, allLocations)
+		}
+		existingLocations[location] = struct{}{}
+		retLocations = append(retLocations, location)
+	}
+	return retLocations, nil
 }

--- a/pkg/cloudprovider/plugins/azure/azure_subscription.go
+++ b/pkg/cloudprovider/plugins/azure/azure_subscription.go
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aws
+package azure
 
 import (
-	"k8s.io/apimachinery/pkg/types"
-
-	nephetypes "antrea.io/nephe/pkg/types"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
 )
 
-// GetAccountCloudInventory pulls cloud vpc and vm inventory from internal snapshot.
-func (c *awsCloud) GetAccountCloudInventory(accountNamespacedName *types.NamespacedName) (*nephetypes.CloudInventory, error) {
-	return c.cloudCommon.GetAccountCloudInventory(accountNamespacedName)
+// subscriptions returns subscriptions apiClient.
+func (p *azureServiceSdkConfigProvider) subscriptions() (azureSubscriptionsWrapper, error) {
+	subscriptionsClient, err := armsubscription.NewSubscriptionsClient(p.cred, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &azureSubscriptionsWrapperImpl{subscriptionsClient: *subscriptionsClient}, nil
 }

--- a/pkg/cloudprovider/plugins/internal/services_common.go
+++ b/pkg/cloudprovider/plugins/internal/services_common.go
@@ -34,6 +34,8 @@ type CloudServiceInterface interface {
 	// AddResourceFilters will be used by service to get resources from cloud for the service. Each will convert
 	// CloudEntitySelector to service understandable filters.
 	AddResourceFilters(selector *crdv1alpha1.CloudEntitySelector) error
+	// GetResourceFilters gets all instances resource filters for the service.
+	GetResourceFilters() map[types.NamespacedName]*crdv1alpha1.CloudEntitySelector
 	// RemoveResourceFilters will be used by service to remove configured filter.
 	RemoveResourceFilters(selectorNamespacedName *types.NamespacedName)
 	// DoResourceInventory performs resource inventory for the cloud service based on configured filters. As part

--- a/pkg/controllers/cloudprovideraccount/controller.go
+++ b/pkg/controllers/cloudprovideraccount/controller.go
@@ -167,10 +167,10 @@ func (r *CloudProviderAccountReconciler) processCreateOrUpdate(namespacedName *t
 	}
 
 	retryAdd, err := r.AccManager.AddAccount(namespacedName, accountCloudType, account)
+	r.updateStatus(namespacedName, err)
 	if err != nil && retryAdd {
 		return err
 	}
-	r.updateStatus(namespacedName, err)
 	return nil
 }
 

--- a/pkg/controllers/networkpolicy/networkpolicy.go
+++ b/pkg/controllers/networkpolicy/networkpolicy.go
@@ -1062,8 +1062,10 @@ func (a *appliedToSecurityGroup) checkRealization(r *NetworkPolicyReconciler, np
 	}
 
 	for _, irule := range np.ingressRules {
+		ruleCopy := deepcopy.Copy(irule).(*cloudresource.IngressRule)
+		ruleCopy.AppliedToGroup = nil
 		desiredRule := cloudresource.CloudRule{
-			Rule:         irule,
+			Rule:         ruleCopy,
 			AppliedToGrp: a.id.CloudResourceID.String(),
 		}
 		desiredRule.Hash = desiredRule.GetHash()
@@ -1074,8 +1076,10 @@ func (a *appliedToSecurityGroup) checkRealization(r *NetworkPolicyReconciler, np
 		delete(realizedRuleMap, desiredRule.Hash)
 	}
 	for _, erule := range np.egressRules {
+		ruleCopy := deepcopy.Copy(erule).(*cloudresource.EgressRule)
+		ruleCopy.AppliedToGroup = nil
 		desiredRule := cloudresource.CloudRule{
-			Rule:         erule,
+			Rule:         ruleCopy,
 			AppliedToGrp: a.id.CloudResourceID.String(),
 		}
 		desiredRule.Hash = desiredRule.GetHash()

--- a/pkg/converter/source/virtualmachine_test.go
+++ b/pkg/converter/source/virtualmachine_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	controllerruntime "sigs.k8s.io/controller-runtime"

--- a/pkg/testing/cloud/mock.go
+++ b/pkg/testing/cloud/mock.go
@@ -125,6 +125,21 @@ func (mr *MockCloudInterfaceMockRecorder) DoInventoryPoll(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoInventoryPoll", reflect.TypeOf((*MockCloudInterface)(nil).DoInventoryPoll), arg0)
 }
 
+// GetAccountCloudInventory mocks base method.
+func (m *MockCloudInterface) GetAccountCloudInventory(arg0 *types0.NamespacedName) (*types.CloudInventory, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAccountCloudInventory", arg0)
+	ret0, _ := ret[0].(*types.CloudInventory)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAccountCloudInventory indicates an expected call of GetAccountCloudInventory.
+func (mr *MockCloudInterfaceMockRecorder) GetAccountCloudInventory(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountCloudInventory", reflect.TypeOf((*MockCloudInterface)(nil).GetAccountCloudInventory), arg0)
+}
+
 // GetAccountStatus mocks base method.
 func (m *MockCloudInterface) GetAccountStatus(arg0 *types0.NamespacedName) (*v1alpha1.CloudProviderAccountStatus, error) {
 	m.ctrl.T.Helper()
@@ -138,21 +153,6 @@ func (m *MockCloudInterface) GetAccountStatus(arg0 *types0.NamespacedName) (*v1a
 func (mr *MockCloudInterfaceMockRecorder) GetAccountStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountStatus", reflect.TypeOf((*MockCloudInterface)(nil).GetAccountStatus), arg0)
-}
-
-// GetCloudInventory mocks base method.
-func (m *MockCloudInterface) GetCloudInventory(arg0 *types0.NamespacedName) (*types.CloudInventory, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudInventory", arg0)
-	ret0, _ := ret[0].(*types.CloudInventory)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCloudInventory indicates an expected call of GetCloudInventory.
-func (mr *MockCloudInterfaceMockRecorder) GetCloudInventory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudInventory", reflect.TypeOf((*MockCloudInterface)(nil).GetCloudInventory), arg0)
 }
 
 // GetEnforcedSecurity mocks base method.

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -21,9 +21,10 @@ import (
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
 )
 
-var (
+const (
 	ErrorMsgUnknownCloudProvider = "missing cloud provider config. Please add AWS or Azure Config"
 	ErrorMsgSecretReference      = "error fetching Secret reference"
+	ErrorMsgRegion               = "error processing region"
 )
 
 // GetVMIPAddresses returns IP addresses of all network interfaces attached to the vm.

--- a/test/utils/cloud_provider_aws.go
+++ b/test/utils/cloud_provider_aws.go
@@ -217,6 +217,7 @@ func (p *awsVPC) GetCloudAccountParameters(name, namespace string, useInvalidCre
 			cred.RoleArn = os.Getenv("TF_VAR_nephe_controller_role_arn")
 			cred.AccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
 			cred.AccessKeySecret = os.Getenv("AWS_SECRET_ACCESS_KEY")
+			cred.SessionToken = os.Getenv("AWS_SESSION_TOKEN")
 		}
 	}
 	secretString, _ := json.Marshal(cred)


### PR DESCRIPTION
## Description
This PR adds support for multi region configuration in CloudProviderAccount CRD.

## Changes
1. Change account config to have multiple service configs based on regions.
2. Modify webhook to validate all regions in the account config. For AWS it checks if region is supported or not, for Azure it only checks if its empty or not. Also added region validation in service config creation, where both AWS and Azure are checked if region is supported.
3. Adding handling to create AWS service config for each region and single Azure service config with multi-region filter.
4. Change account operations to support multiple service configs and run in parallel, such as inventory poll and cloud sync.
5. Add multi error in multi region operations, so success regions will be processed and error regions will be reported separately.
6. Change security group operations to retrieve regions using vpc/vnet IDs instead of from cloud account.
7. Change Azure cloud sync process to use ASG ID internally when syncing to avoid ASGs with the same name in different region being grouped into one.
8. Update unit-tests to work with multi region.