### PR TITLE
Upgrade k8s cluster version to 1.26

### DIFF
--- a/hack/terraform/aks/main.tf
+++ b/hack/terraform/aks/main.tf
@@ -91,7 +91,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     type = "SystemAssigned"
   }
 
-  kubernetes_version = "1.25.5"
+  kubernetes_version = "1.26.3"
 
   tags = {
     Environment = "nephe"

--- a/hack/terraform/eks/main.tf
+++ b/hack/terraform/eks/main.tf
@@ -100,7 +100,7 @@ module "eks" {
   version         = "~>17.24.0"
   cluster_name    = local.cluster_name
   subnets         = module.vpc.public_subnets
-  cluster_version = "1.25"
+  cluster_version = "1.26"
 
   tags = {
     Terraform   = "true"


### PR DESCRIPTION
On AKS upgrade k8s cluster to version 1.26.3     
On EKS upgrade k8s cluster to version 1.26

Signed-off-by: Anand Kumar <kumaranand@vmware.com>