### PR TITLE
Sync cloud inventory in parallel upon restart

### DIFF
--- a/pkg/accountmanager/manager_test.go
+++ b/pkg/accountmanager/manager_test.go
@@ -190,9 +190,6 @@ var _ = Describe("Account Manager", func() {
 			_, err = accountManager.AddResourceFiltersToAccount(&testAccountNamespacedName, &testCesNamespacedName,
 				ces, false)
 			Expect(err).ShouldNot(HaveOccurred())
-			_ = accountManager.UpdatePendingCesCount(&testAccountNamespacedName)
-			err = accountManager.WaitForPollDone(&testAccountNamespacedName)
-			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("Remove Resource Filters from Account", func() {
 			// Add a resource filters to account.

--- a/pkg/accountmanager/poller.go
+++ b/pkg/accountmanager/poller.go
@@ -276,6 +276,7 @@ func (p *accountPoller) restartPoller(name *types.NamespacedName) {
 	if p.ch != nil {
 		close(p.ch)
 		p.ch = nil
+		p.pollDone = false
 	}
 
 	p.log.Info("Restarting account poller", "account", name)

--- a/pkg/controllers/cloudprovideraccount/controller_test.go
+++ b/pkg/controllers/cloudprovideraccount/controller_test.go
@@ -43,7 +43,6 @@ import (
 	"antrea.io/nephe/apis/crd/v1alpha1"
 	crdv1alpha1 "antrea.io/nephe/apis/crd/v1alpha1"
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
-	ctrlsync "antrea.io/nephe/pkg/controllers/sync"
 	mockaccmanager "antrea.io/nephe/pkg/testing/accountmanager"
 	mocknpcontroller "antrea.io/nephe/pkg/testing/networkpolicy"
 	"antrea.io/nephe/pkg/util"
@@ -174,26 +173,6 @@ var _ = Describe("CloudProviderAccount Controller", func() {
 
 			err = reconciler.processDelete(&testAccountNamespacedName)
 			Expect(err).ShouldNot(HaveOccurred())
-		})
-		It("CloudProviderAccount set pending sync count to 2", func() {
-			ctrlsync.GetControllerSyncStatusInstance().Configure()
-			ctrlsync.GetControllerSyncStatusInstance().ResetControllerSyncStatus(ctrlsync.ControllerTypeCPA)
-			reconciler.pendingSyncCount = 2
-			reconciler.updatePendingSyncCountAndStatus()
-			val := ctrlsync.GetControllerSyncStatusInstance().IsControllerSynced(ctrlsync.ControllerTypeCPA)
-			Expect(val).Should(BeFalse())
-		})
-		It("CloudProviderAccount set pending sync count to 1", func() {
-			reconciler.clientset = fakewatch.NewSimpleClientset()
-			reconciler.pendingSyncCount = 1
-			err := os.Setenv("POD_NAMESPACE", testSecretNamespacedName.Namespace)
-			Expect(err).ShouldNot(HaveOccurred())
-			ctrlsync.GetControllerSyncStatusInstance().Configure()
-			ctrlsync.GetControllerSyncStatusInstance().ResetControllerSyncStatus(ctrlsync.ControllerTypeCPA)
-
-			reconciler.updatePendingSyncCountAndStatus()
-			val := ctrlsync.GetControllerSyncStatusInstance().IsControllerSynced(ctrlsync.ControllerTypeCPA)
-			Expect(val).Should(BeTrue())
 		})
 
 		Context("Secret watcher", func() {

--- a/pkg/testing/accountmanager/mock.go
+++ b/pkg/testing/accountmanager/mock.go
@@ -124,30 +124,14 @@ func (mr *MockInterfaceMockRecorder) RemoveResourceFiltersFromAccount(arg0, arg1
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveResourceFiltersFromAccount", reflect.TypeOf((*MockInterface)(nil).RemoveResourceFiltersFromAccount), arg0, arg1)
 }
 
-// UpdatePendingCesCount mocks base method.
-func (m *MockInterface) UpdatePendingCesCount(arg0 *types.NamespacedName) int {
+// SyncAllAccounts mocks base method.
+func (m *MockInterface) SyncAllAccounts() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePendingCesCount", arg0)
-	ret0, _ := ret[0].(int)
-	return ret0
+	m.ctrl.Call(m, "SyncAllAccounts")
 }
 
-// UpdatePendingCesCount indicates an expected call of UpdatePendingCesCount.
-func (mr *MockInterfaceMockRecorder) UpdatePendingCesCount(arg0 interface{}) *gomock.Call {
+// SyncAllAccounts indicates an expected call of SyncAllAccounts.
+func (mr *MockInterfaceMockRecorder) SyncAllAccounts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePendingCesCount", reflect.TypeOf((*MockInterface)(nil).UpdatePendingCesCount), arg0)
-}
-
-// WaitForPollDone mocks base method.
-func (m *MockInterface) WaitForPollDone(arg0 *types.NamespacedName) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForPollDone", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WaitForPollDone indicates an expected call of WaitForPollDone.
-func (mr *MockInterfaceMockRecorder) WaitForPollDone(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForPollDone", reflect.TypeOf((*MockInterface)(nil).WaitForPollDone), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncAllAccounts", reflect.TypeOf((*MockInterface)(nil).SyncAllAccounts))
 }


### PR DESCRIPTION
## Description
Sync all cloud accounts faster on restart

## Changes
Process all CPA and CES CRs first and then sync all accounts in blocking fashion. Each account sync will happen in separate go routine and the main thread will block on its completion.