### PR TITLE
Remove account config struct from manager

### DIFF
--- a/pkg/accountmanager/manager.go
+++ b/pkg/accountmanager/manager.go
@@ -17,7 +17,6 @@ package accountmanager
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -29,11 +28,6 @@ import (
 	"antrea.io/nephe/pkg/cloudprovider/cloud"
 	ctrlsync "antrea.io/nephe/pkg/controllers/sync"
 	"antrea.io/nephe/pkg/inventory"
-	"antrea.io/nephe/pkg/util"
-)
-
-const (
-	errorMsgAccountPollerNotFound = "account poller not found"
 )
 
 const (
@@ -45,144 +39,81 @@ const (
 type Interface interface {
 	AddAccount(*types.NamespacedName, runtimev1alpha1.CloudProvider, *crdv1alpha1.CloudProviderAccount) (bool, error)
 	RemoveAccount(*types.NamespacedName) error
-	IsAccountCredentialsValid(namespacedName *types.NamespacedName) (bool, error)
-	AddResourceFiltersToAccount(*types.NamespacedName, *types.NamespacedName, *crdv1alpha1.CloudEntitySelector, bool) (bool, error)
+	AddResourceFiltersToAccount(*types.NamespacedName, *types.NamespacedName, *crdv1alpha1.CloudEntitySelector) (bool, error)
 	RemoveResourceFiltersFromAccount(*types.NamespacedName, *types.NamespacedName) error
 	SyncAllAccounts()
 }
 
 type AccountManager struct {
 	client.Client
-	Log              logr.Logger
-	mutex            sync.RWMutex
-	Inventory        inventory.Interface
-	accPollers       map[types.NamespacedName]*accountPoller
-	accountConfigMap map[types.NamespacedName]*accountConfig
-	// accountToSelectorCount stores number of configured CloudEntitySelector CRs for a given account.
-	// This is required for handling nephe restart case when multiple CloudEntitySelector CRs exist.
-	accountToSelectorCount map[types.NamespacedName]int
-}
-
-type accountConfig struct {
-	providerType runtimev1alpha1.CloudProvider
-	// Indicates account initialization state.
-	initialized bool
-	// Indicates credentials are valid or not.
-	credentialsValid bool
-	// retry upon failure.
-	retry bool
-	// map of selector namespaced name to selector.
-	selectorMap map[types.NamespacedName]*crdv1alpha1.CloudEntitySelector
+	Log        logr.Logger
+	mutex      sync.RWMutex
+	Inventory  inventory.Interface
+	accPollers map[types.NamespacedName]*accountPoller
 }
 
 // ConfigureAccountManager configures and initializes account manager.
 func (a *AccountManager) ConfigureAccountManager() {
 	// Init maps.
 	a.accPollers = make(map[types.NamespacedName]*accountPoller)
-	a.accountConfigMap = make(map[types.NamespacedName]*accountConfig)
-	a.accountToSelectorCount = make(map[types.NamespacedName]int)
 }
 
 // AddAccount consumes CloudProviderAccount CR and calls cloud plugin to add account. It also creates and starts account
 // poller thread for polling inventory.
-func (a *AccountManager) AddAccount(namespacedName *types.NamespacedName, accountCloudType runtimev1alpha1.CloudProvider,
-	account *crdv1alpha1.CloudProviderAccount) (bool, error) {
-	// Create account config.
-	config := a.addAccountConfig(namespacedName, accountCloudType)
+func (a *AccountManager) AddAccount(namespacedName *types.NamespacedName, cloudProviderType runtimev1alpha1.CloudProvider,
+	cpa *crdv1alpha1.CloudProviderAccount) (bool, error) {
 	// Cloud Provider Type is used to fetch the cloud interface.
-	cloudInterface, err := cloud.GetCloudInterface(config.providerType)
+	cloudInterface, err := cloud.GetCloudInterface(cloudProviderType)
 	if err != nil {
 		return false, err
 	}
 
-	// Call plugin to add cloud account.
-	if err = cloudInterface.AddProviderAccount(a.Client, account); err != nil {
-		return a.handleAddProviderAccountError(namespacedName, config, err), err
+	// Create an account poller for polling cloud inventory.
+	accPoller, _ := a.addAccountPoller(cloudInterface, namespacedName, cpa)
+	if err = accPoller.cloudInterface.AddProviderAccount(a.Client, cpa); err != nil {
+		// If an error occurs while adding the account, stop its poller and cleanup inventory.
+		accPoller.stopPoller()
+		_ = a.Inventory.DeleteVpcsFromCache(namespacedName)
+		_ = a.Inventory.DeleteAllVmsFromCache(namespacedName)
+		return false, err
 	}
 
-	// Create an account poller for polling cloud inventory.
-	accPoller, _ := a.addAccountPoller(cloudInterface, namespacedName, account)
-
+	// If the controller is syncing (restart case), don't start the poller.
 	if ctrlsync.GetControllerSyncStatusInstance().IsControllerSynced(ctrlsync.ControllerTypeCPA) {
 		go accPoller.restartPoller(namespacedName)
 	}
-
-	// Set account init state to true as there were no errors reported from cloud plug-in.
-	config.retry = false
-	config.credentialsValid = true
-	config.initialized = true
-
 	return false, nil
 }
 
 // RemoveAccount removes account poller thread and cleans up all internal state in cloud plugin and inventory for
 // this account.
 func (a *AccountManager) RemoveAccount(namespacedName *types.NamespacedName) error {
-	// Stop and remove the poller.
-	_ = a.removeAccountPoller(namespacedName)
-
-	// Cleanup vpc inventory data for this account, vm inventory is deleted in removeAccountPoller.
-	_ = a.Inventory.DeleteVpcsFromCache(namespacedName)
-
-	defer func() {
-		// Remove account config.
-		a.removeAccountConfig(namespacedName)
-	}()
-
-	// Clear state in cloud plugin.
-	cloudProviderType, ok := a.getAccountProviderType(namespacedName)
-	if !ok {
-		// Couldn't find a provider type for this account. May not be deleted.
+	accPoller, exists := a.getAccountPoller(namespacedName)
+	if !exists {
+		a.Log.Info("Failed to remove account, account poller doesn't exist", "account", namespacedName)
 		return nil
 	}
-
-	cloudInterface, err := cloud.GetCloudInterface(cloudProviderType)
-	if err != nil {
-		return err
-	}
-	_ = cloudInterface.ResetInventoryCache(namespacedName)
-	cloudInterface.RemoveProviderAccount(namespacedName)
-
+	accPoller.cloudInterface.RemoveProviderAccount(namespacedName)
+	// Stop and remove the poller.
+	go a.removeAccountPoller(accPoller)
 	return nil
 }
 
 // AddResourceFiltersToAccount add/update cloud plugin for a given account to include the new selector and
 // restart poller once done.
 func (a *AccountManager) AddResourceFiltersToAccount(accNamespacedName *types.NamespacedName,
-	selectorNamespacedName *types.NamespacedName, selector *crdv1alpha1.CloudEntitySelector, replay bool) (bool, error) {
-	cloudProviderType, ok := a.getAccountProviderType(accNamespacedName)
-	if !ok {
-		return true, fmt.Errorf(fmt.Sprintf("failed to add or update selector %v, account %v: "+
-			"account config not found", selectorNamespacedName, accNamespacedName))
-	}
-	cloudInterface, _ := cloud.GetCloudInterface(cloudProviderType)
-	if !replay {
-		// Update the selector config only when the reconciler processes the CR request.
-		if err := a.addSelectorToAccountConfig(accNamespacedName, selectorNamespacedName, selector); err != nil {
-			return false, fmt.Errorf(fmt.Sprintf("failed to add or update selector %v, %v: %v",
-				selectorNamespacedName, accNamespacedName, err))
-		}
-	}
-
-	if err := cloudInterface.AddAccountResourceSelector(accNamespacedName, selector); err != nil {
-		return false, fmt.Errorf(fmt.Sprintf("failed to add or update selector %v, account %v: %v",
-			selectorNamespacedName, accNamespacedName, err))
-	}
-
-	// Fetch and restart account poller as selector has changed.
+	selectorNamespacedName *types.NamespacedName, selector *crdv1alpha1.CloudEntitySelector) (bool, error) {
 	accPoller, exists := a.getAccountPoller(accNamespacedName)
 	if !exists {
-		// Account poller may not exist when account is not successfully initialized.
-		return false, fmt.Errorf(fmt.Sprintf("failed to add or update selector %v, account %v: %v",
-			selectorNamespacedName, accNamespacedName, errorMsgAccountPollerNotFound))
+		return true, fmt.Errorf(fmt.Sprintf("failed to add or update selector, account %v: "+
+			"not configured", accNamespacedName))
 	}
-
-	// Update account poller with selector config.
-	selectorCopy := a.getSelectorFromAccountConfig(accNamespacedName, selectorNamespacedName)
-	if selectorCopy != nil {
-		accPoller.addOrUpdateSelector(selectorCopy)
+	if err := accPoller.cloudInterface.AddAccountResourceSelector(accNamespacedName, selector); err != nil {
+		return true, fmt.Errorf(fmt.Sprintf("failed to add or update selector %v, account %v: %v",
+			selectorNamespacedName, accNamespacedName, err))
 	}
-
+	// Update selectors in account poller.
+	accPoller.addOrUpdateSelector(selector)
 	if ctrlsync.GetControllerSyncStatusInstance().IsControllerSynced(ctrlsync.ControllerTypeCES) {
 		go accPoller.restartPoller(accNamespacedName)
 	}
@@ -192,51 +123,32 @@ func (a *AccountManager) AddResourceFiltersToAccount(accNamespacedName *types.Na
 // RemoveResourceFiltersFromAccount removes selector from cloud plugin and restart the poller.
 func (a *AccountManager) RemoveResourceFiltersFromAccount(accNamespacedName *types.NamespacedName,
 	selectorNamespacedName *types.NamespacedName) error {
-	cloudProviderType, ok := a.getAccountProviderType(accNamespacedName)
-	if !ok {
-		// If we cannot find cloud provider type, that means CPA may not be added, or it's already removed.
-		return fmt.Errorf(fmt.Sprintf("failed to delete selector %v, account %v: account config not found",
-			selectorNamespacedName, accNamespacedName))
-	}
-	cloudInterface, _ := cloud.GetCloudInterface(cloudProviderType)
-	cloudInterface.RemoveAccountResourcesSelector(accNamespacedName, selectorNamespacedName)
-	// Delete selector config from the account config.
-	a.removeSelectorFromAccountConfig(accNamespacedName, selectorNamespacedName)
-
-	// Restart account poller after removing the selector.
 	accPoller, exists := a.getAccountPoller(accNamespacedName)
 	if !exists {
-		return fmt.Errorf(fmt.Sprintf("failed to delete selector %v, account %v: %v",
-			selectorNamespacedName, accNamespacedName, errorMsgAccountPollerNotFound))
+		return nil
 	}
-	_ = accPoller.inventory.DeleteVmsFromCache(accNamespacedName, selectorNamespacedName)
-	accPoller.restartPoller(accNamespacedName)
+	accPoller.cloudInterface.RemoveAccountResourcesSelector(accNamespacedName, selectorNamespacedName)
+	// TODO: Update accPoller with selector delete.
+	go func() {
+		accPoller.restartPoller(accNamespacedName)
+		_ = accPoller.inventory.DeleteVmsFromCache(accNamespacedName, selectorNamespacedName)
+	}()
 	return nil
-}
-
-// IsAccountCredentialsValid return true for an account, if credentials are valid.
-func (a *AccountManager) IsAccountCredentialsValid(namespacedName *types.NamespacedName) (bool, error) {
-	config := a.getAccountConfig(namespacedName)
-	if config != nil {
-		return config.credentialsValid, nil
-	}
-	return false, fmt.Errorf("failed to get account config for account %v", namespacedName)
 }
 
 // addAccountPoller creates an account poller for a given account.
 func (a *AccountManager) addAccountPoller(cloudInterface cloud.CloudInterface, namespacedName *types.NamespacedName,
-	account *crdv1alpha1.CloudProviderAccount) (*accountPoller, bool) {
+	cpa *crdv1alpha1.CloudProviderAccount) (*accountPoller, bool) {
 	// Set poller interval to default if not specified.
-	if account.Spec.PollIntervalInSeconds == nil {
+	if cpa.Spec.PollIntervalInSeconds == nil {
 		var pollInterval uint = crdv1alpha1.DefaultPollIntervalInSeconds
-		account.Spec.PollIntervalInSeconds = &pollInterval
+		cpa.Spec.PollIntervalInSeconds = &pollInterval
 	}
 
-	// Restart account poller after removing the selector.
 	accPoller, exists := a.getAccountPoller(namespacedName)
 	if exists {
 		// Update the polling interval.
-		accPoller.pollIntvInSeconds = *account.Spec.PollIntervalInSeconds
+		accPoller.pollIntvInSeconds = *cpa.Spec.PollIntervalInSeconds
 		return accPoller, true
 	}
 
@@ -244,7 +156,7 @@ func (a *AccountManager) addAccountPoller(cloudInterface cloud.CloudInterface, n
 	poller := &accountPoller{
 		Client:                a.Client,
 		log:                   a.Log.WithName("Poller"),
-		pollIntvInSeconds:     *account.Spec.PollIntervalInSeconds,
+		pollIntvInSeconds:     *cpa.Spec.PollIntervalInSeconds,
 		cloudInterface:        cloudInterface,
 		accountNamespacedName: namespacedName,
 		ch:                    make(chan struct{}),
@@ -259,20 +171,16 @@ func (a *AccountManager) addAccountPoller(cloudInterface cloud.CloudInterface, n
 }
 
 // removeAccountPoller stops account poller thread and removes account poller entry from accPollers map.
-func (a *AccountManager) removeAccountPoller(namespacedName *types.NamespacedName) error {
-	a.Log.V(1).Info("Removing account poller", "account", namespacedName)
-	accPoller, exists := a.getAccountPoller(namespacedName)
-	if !exists {
-		return fmt.Errorf(fmt.Sprintf("%v %v", errorMsgAccountPollerNotFound, namespacedName))
-	}
-
+func (a *AccountManager) removeAccountPoller(accPoller *accountPoller) {
+	a.Log.V(1).Info("Removing account poller", "account", *accPoller.accountNamespacedName)
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
-	delete(a.accPollers, *namespacedName)
+	delete(a.accPollers, *accPoller.accountNamespacedName)
 
+	// Stop the poller and cleanup inventory.
 	accPoller.stopPoller()
-	_ = accPoller.inventory.DeleteAllVmsFromCache(namespacedName)
-	return nil
+	_ = accPoller.inventory.DeleteAllVmsFromCache(accPoller.accountNamespacedName)
+	_ = accPoller.inventory.DeleteVpcsFromCache(accPoller.accountNamespacedName)
 }
 
 // getAccountPoller returns the account poller matching the nameSpacedName
@@ -285,111 +193,6 @@ func (a *AccountManager) getAccountPoller(name *types.NamespacedName) (*accountP
 		return nil, false
 	}
 	return accPoller, true
-}
-
-// getAccountConfig returns the account configuration.
-func (a *AccountManager) getAccountConfig(name *types.NamespacedName) *accountConfig {
-	a.mutex.RLock()
-	defer a.mutex.RUnlock()
-	config, ok := a.accountConfigMap[*name]
-	if !ok {
-		return nil
-	}
-	return config
-}
-
-// addAccountConfig creates the account configuration or returns the existing configuration.
-func (a *AccountManager) addAccountConfig(name *types.NamespacedName, provider runtimev1alpha1.CloudProvider) *accountConfig {
-	config := a.getAccountConfig(name)
-	if config != nil {
-		return config
-	}
-	// Create a new account config.
-	config = &accountConfig{
-		providerType:     provider,
-		initialized:      false,
-		credentialsValid: false,
-		retry:            false,
-		// Init maps.
-		selectorMap: make(map[types.NamespacedName]*crdv1alpha1.CloudEntitySelector),
-	}
-	a.Log.V(1).Info("Adding account config", "account", name)
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-	a.accountConfigMap[*name] = config
-	return config
-}
-
-// removeAccountConfig removes the account configuration.
-func (a *AccountManager) removeAccountConfig(namespacedName *types.NamespacedName) {
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-	a.Log.V(1).Info("Removing account config", "account", namespacedName)
-	delete(a.accountConfigMap, *namespacedName)
-}
-
-// getSelectorFromAccountConfig gets the selector configuration of the specified account and selector.
-func (a *AccountManager) getSelectorFromAccountConfig(accountNamespacedName,
-	selectorNamespacedName *types.NamespacedName) *crdv1alpha1.CloudEntitySelector {
-	acctConfig := a.getAccountConfig(accountNamespacedName)
-	if acctConfig == nil {
-		a.Log.Error(fmt.Errorf("failed to get account config"), "", "account", accountNamespacedName)
-		return nil
-	}
-	return acctConfig.selectorMap[*selectorNamespacedName]
-}
-
-// addSelectorToAccountConfig add the current selector configuration to the specified account.
-func (a *AccountManager) addSelectorToAccountConfig(accountNamespacedName, selectorNamespacedName *types.NamespacedName,
-	selector *crdv1alpha1.CloudEntitySelector) error {
-	acctConfig := a.getAccountConfig(accountNamespacedName)
-	if acctConfig == nil {
-		return fmt.Errorf("failed to get account config for account %v", accountNamespacedName)
-	}
-	a.Log.V(1).Info("Adding selector config", "account", accountNamespacedName,
-		"selector", selectorNamespacedName)
-	acctConfig.selectorMap[*selectorNamespacedName] = selector.DeepCopy()
-	return nil
-}
-
-// removeSelectorFromAccountConfig removes the current selector configuration for the specified account.
-func (a *AccountManager) removeSelectorFromAccountConfig(accountNamespacedName, selectorNamespacedName *types.NamespacedName) {
-	acctConfig := a.getAccountConfig(accountNamespacedName)
-	if acctConfig == nil {
-		a.Log.Error(fmt.Errorf("failed to get account config"), "", "account", accountNamespacedName)
-		return
-	}
-	a.Log.V(1).Info("Removing selector config", "account", accountNamespacedName,
-		"selector", selectorNamespacedName)
-	delete(acctConfig.selectorMap, *selectorNamespacedName)
-}
-
-func (a *AccountManager) getAccountProviderType(namespacedName *types.NamespacedName) (runtimev1alpha1.CloudProvider, bool) {
-	acctConfig := a.getAccountConfig(namespacedName)
-	if acctConfig != nil {
-		return acctConfig.providerType, true
-	}
-	return "", false
-}
-
-// handleAddProviderAccountError performs the cleanup on account add/update.
-// i.e. Removes poller, inventory and returns if the error can be retried or not.
-func (a *AccountManager) handleAddProviderAccountError(namespacedName *types.NamespacedName, config *accountConfig,
-	err error) bool {
-	// Account poller is removed upon any error in the plug-in.
-	_ = a.removeAccountPoller(namespacedName)
-	_ = a.Inventory.DeleteVpcsFromCache(namespacedName)
-	_ = a.Inventory.DeleteAllVmsFromCache(namespacedName)
-	// TODO: require lock to write into account config structure.
-	config.initialized = false
-	if strings.Contains(err.Error(), util.ErrorMsgSecretReference) {
-		config.credentialsValid = false
-		config.retry = false
-	} else {
-		config.credentialsValid = true
-		config.retry = true
-	}
-	return config.retry
 }
 
 // WaitForPollDone restarts account poller and waits till inventory poll is done.

--- a/pkg/cloudprovider/plugins/internal/cloud_common.go
+++ b/pkg/cloudprovider/plugins/internal/cloud_common.go
@@ -124,6 +124,8 @@ func (c *cloudCommon) AddCloudAccount(client client.Client, account *crdv1alpha1
 }
 
 func (c *cloudCommon) RemoveCloudAccount(namespacedName *types.NamespacedName) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	delete(c.accountConfigs, *namespacedName)
 }
 

--- a/pkg/controllers/cloudentityselector/controller.go
+++ b/pkg/controllers/cloudentityselector/controller.go
@@ -150,9 +150,9 @@ func (r *CloudEntitySelectorReconciler) processCreateOrUpdate(selector *crdv1alp
 		Name:      selector.Spec.AccountName,
 	}
 	r.selectorToAccountMap[*selectorNamespacedName] = *accountNamespacedName
-	retry, err := r.AccManager.AddResourceFiltersToAccount(accountNamespacedName, selectorNamespacedName,
-		selector, false)
-	if err != nil && retry {
+	retryCes, err := r.AccManager.AddResourceFiltersToAccount(accountNamespacedName, selectorNamespacedName,
+		selector)
+	if err != nil && retryCes {
 		return err
 	}
 	r.updateStatus(selectorNamespacedName, err)

--- a/pkg/controllers/cloudentityselector/controller_test.go
+++ b/pkg/controllers/cloudentityselector/controller_test.go
@@ -106,7 +106,7 @@ var _ = Describe("CloudEntitySelector Controller", func() {
 
 		It("CES Add and Delete workflow", func() {
 			mockAccManager.EXPECT().AddResourceFiltersToAccount(&testAccountNamespacedName, &testSelectorNamespacedName,
-				selector, false).Return(true, nil).Times(1)
+				selector).Return(true, nil).Times(1)
 			mockAccManager.EXPECT().RemoveResourceFiltersFromAccount(&testAccountNamespacedName,
 				&testSelectorNamespacedName).Return(nil).Times(1)
 			err := reconciler.processCreateOrUpdate(selector, &testSelectorNamespacedName)
@@ -134,7 +134,7 @@ var _ = Describe("CloudEntitySelector Controller", func() {
 			}
 
 			mockAccManager.EXPECT().AddResourceFiltersToAccount(&testAccountNamespacedName, &testSelectorDifferentNamespace,
-				selector, false).Return(true, nil).Times(1)
+				selector).Return(true, nil).Times(1)
 			mockAccManager.EXPECT().RemoveResourceFiltersFromAccount(&testAccountNamespacedName,
 				&testSelectorDifferentNamespace).Return(nil).Times(1)
 			err := reconciler.processCreateOrUpdate(selector, &testSelectorDifferentNamespace)
@@ -144,13 +144,13 @@ var _ = Describe("CloudEntitySelector Controller", func() {
 		})
 		It("CES Add failure without retry", func() {
 			mockAccManager.EXPECT().AddResourceFiltersToAccount(&testAccountNamespacedName, &testSelectorNamespacedName,
-				selector, false).Return(false, fmt.Errorf("dummy")).Times(1)
+				selector).Return(false, fmt.Errorf("dummy")).Times(1)
 			err := reconciler.processCreateOrUpdate(selector, &testSelectorNamespacedName)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("CES Add failure with retry", func() {
 			mockAccManager.EXPECT().AddResourceFiltersToAccount(&testAccountNamespacedName, &testSelectorNamespacedName,
-				selector, false).Return(true, fmt.Errorf("dummy")).Times(1)
+				selector).Return(true, fmt.Errorf("dummy")).Times(1)
 			err := reconciler.processCreateOrUpdate(selector, &testSelectorNamespacedName)
 			Expect(err).Should(HaveOccurred())
 		})

--- a/pkg/controllers/cloudprovideraccount/controller.go
+++ b/pkg/controllers/cloudprovideraccount/controller.go
@@ -233,7 +233,7 @@ func (r *CloudProviderAccountReconciler) getCpaBySecret(s *types.NamespacedName)
 
 // processSecretUpdateEvent updates all dependent accounts for a given Secret Namespace.
 func (r *CloudProviderAccountReconciler) processSecretUpdateEvent(secretNamespacedName *types.NamespacedName,
-	eventType watch.EventType) {
+	_ watch.EventType) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -244,13 +244,6 @@ func (r *CloudProviderAccountReconciler) processSecretUpdateEvent(secretNamespac
 
 	for _, cpa := range cpaItems {
 		accountNamespacedName := &types.NamespacedName{Namespace: cpa.Namespace, Name: cpa.Name}
-		if eventType == watch.Added {
-			// Add event is ignored, if account credentials are already valid.
-			ok, err := r.AccManager.IsAccountCredentialsValid(accountNamespacedName)
-			if err != nil || ok {
-				continue
-			}
-		}
 		r.Log.WithName("Secret").Info("Updating account", "account", *accountNamespacedName)
 		if err := r.processCreateOrUpdate(accountNamespacedName, cpa); err != nil {
 			r.Log.WithName("Secret").Error(err, "error updating account", "account", *accountNamespacedName)

--- a/pkg/testing/accountmanager/mock.go
+++ b/pkg/testing/accountmanager/mock.go
@@ -67,33 +67,18 @@ func (mr *MockInterfaceMockRecorder) AddAccount(arg0, arg1, arg2 interface{}) *g
 }
 
 // AddResourceFiltersToAccount mocks base method.
-func (m *MockInterface) AddResourceFiltersToAccount(arg0, arg1 *types.NamespacedName, arg2 *v1alpha1.CloudEntitySelector, arg3 bool) (bool, error) {
+func (m *MockInterface) AddResourceFiltersToAccount(arg0, arg1 *types.NamespacedName, arg2 *v1alpha1.CloudEntitySelector) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddResourceFiltersToAccount", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddResourceFiltersToAccount", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddResourceFiltersToAccount indicates an expected call of AddResourceFiltersToAccount.
-func (mr *MockInterfaceMockRecorder) AddResourceFiltersToAccount(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) AddResourceFiltersToAccount(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddResourceFiltersToAccount", reflect.TypeOf((*MockInterface)(nil).AddResourceFiltersToAccount), arg0, arg1, arg2, arg3)
-}
-
-// IsAccountCredentialsValid mocks base method.
-func (m *MockInterface) IsAccountCredentialsValid(arg0 *types.NamespacedName) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsAccountCredentialsValid", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsAccountCredentialsValid indicates an expected call of IsAccountCredentialsValid.
-func (mr *MockInterfaceMockRecorder) IsAccountCredentialsValid(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAccountCredentialsValid", reflect.TypeOf((*MockInterface)(nil).IsAccountCredentialsValid), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddResourceFiltersToAccount", reflect.TypeOf((*MockInterface)(nil).AddResourceFiltersToAccount), arg0, arg1, arg2)
 }
 
 // RemoveAccount mocks base method.


### PR DESCRIPTION
Account manager was maintaining hold of state wrt to account. Removed account config and moved the cloud interface to poller to minimize state in account manager.

TODO: Accpoller should be replaced with AccController.