### PR TITLE
Avoid waiting for inventory sync in np controller

### DIFF
--- a/pkg/cloudprovider/plugins/aws/aws_ec2.go
+++ b/pkg/cloudprovider/plugins/aws/aws_ec2.go
@@ -17,11 +17,9 @@ package aws
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/cenkalti/backoff/v4"
 	"github.com/mohae/deepcopy"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -83,21 +81,6 @@ func (p *awsServiceSdkConfigProvider) compute() (awsEC2Wrapper, error) {
 	}
 
 	return awsEC2, nil
-}
-
-func (ec2Cfg *ec2ServiceConfig) waitForInventoryInit(duration time.Duration) error {
-	operation := func() error {
-		done := ec2Cfg.inventoryStats.IsInventoryInitialized()
-		if !done {
-			return fmt.Errorf("inventory for account %v not initialized (waited %v duration)", ec2Cfg.accountNamespacedName, duration)
-		}
-		return nil
-	}
-
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = duration
-
-	return backoff.Retry(operation, b)
 }
 
 // getCachedInstances returns instances from the cache applicable for the given selector.

--- a/pkg/cloudprovider/plugins/aws/aws_security_impl.go
+++ b/pkg/cloudprovider/plugins/aws/aws_security_impl.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"antrea.io/nephe/pkg/cloudprovider/cloudresource"
-	"antrea.io/nephe/pkg/cloudprovider/plugins/internal"
 	"antrea.io/nephe/pkg/cloudprovider/utils"
 )
 
@@ -244,19 +243,12 @@ func (c *awsCloud) GetEnforcedSecurity() []cloudresource.SynchronizationContent 
 
 			accCfg, err := c.cloudCommon.GetCloudAccountByName(name)
 			if err != nil {
-				awsPluginLogger().Info("Enforced-security-cloud-view GET for account skipped", "err", err)
 				return
 			}
 
 			accCfg.LockMutex()
 			defer accCfg.UnlockMutex()
-
-			ec2Service := accCfg.GetServiceConfig().(*ec2ServiceConfig)
-			if err := ec2Service.waitForInventoryInit(internal.InventoryInitWaitDuration); err != nil {
-				awsPluginLogger().Error(err, "Enforced-security-cloud-view GET for account skipped", "account", accCfg.GetNamespacedName())
-				return
-			}
-			sendCh <- ec2Service.getNepheControllerManagedSecurityGroupsCloudView()
+			sendCh <- accCfg.GetServiceConfig().(*ec2ServiceConfig).getNepheControllerManagedSecurityGroupsCloudView()
 		}(accNamespacedNameCopy, ch)
 	}
 

--- a/pkg/cloudprovider/plugins/azure/azure_compute.go
+++ b/pkg/cloudprovider/plugins/azure/azure_compute.go
@@ -18,10 +18,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
-	"github.com/cenkalti/backoff/v4"
 	"github.com/mohae/deepcopy"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -100,22 +98,6 @@ func newComputeServiceConfig(account types.NamespacedName, service azureServiceC
 	vmSnapshot := make(map[types.NamespacedName][]*virtualMachineTable)
 	config.resourcesCache.UpdateSnapshot(&computeResourcesCacheSnapshot{vmSnapshot, nil, nil, nil})
 	return config, nil
-}
-
-func (computeCfg *computeServiceConfig) waitForInventoryInit(duration time.Duration) error {
-	operation := func() error {
-		done := computeCfg.inventoryStats.IsInventoryInitialized()
-		if !done {
-			return fmt.Errorf("inventory for account %v not initialized (waited %v duration)",
-				computeCfg.accountNamespacedName, duration)
-		}
-		return nil
-	}
-
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = duration
-
-	return backoff.Retry(operation, b)
 }
 
 // getCachedVirtualMachines returns virtualMachines specific to a selector from the cache for the subscription.

--- a/pkg/cloudprovider/plugins/azure/azure_security_impl.go
+++ b/pkg/cloudprovider/plugins/azure/azure_security_impl.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"antrea.io/nephe/pkg/cloudprovider/cloudresource"
-	"antrea.io/nephe/pkg/cloudprovider/plugins/internal"
 )
 
 // CreateSecurityGroup invokes cloud api and creates the cloud security group based on securityGroupIdentifier.
@@ -228,20 +227,12 @@ func (c *azureCloud) GetEnforcedSecurity() []cloudresource.SynchronizationConten
 
 			accCfg, err := c.cloudCommon.GetCloudAccountByName(name)
 			if err != nil {
-				azurePluginLogger().Info("Enforced-security-cloud-view GET for account skipped", "err",
-					err)
 				return
 			}
 
 			accCfg.LockMutex()
 			defer accCfg.UnlockMutex()
-
-			computeService := accCfg.GetServiceConfig().(*computeServiceConfig)
-			if err := computeService.waitForInventoryInit(internal.InventoryInitWaitDuration); err != nil {
-				azurePluginLogger().Error(err, "enforced-security-cloud-view GET for account skipped", "account", accCfg.GetNamespacedName())
-				return
-			}
-			sendCh <- computeService.getNepheControllerManagedSecurityGroupsCloudView()
+			sendCh <- accCfg.GetServiceConfig().(*computeServiceConfig).getNepheControllerManagedSecurityGroupsCloudView()
 		}(accNamespacedNameCopy, ch)
 	}
 


### PR DESCRIPTION
All the controllers starts in sequence now. For example, NP controller will run only when CPA and CES controllers are synced. This implies inventory will be available. Hence removing the check.