### PR TITLE
Add Liveness and Readiness Probe for Nephe

### DIFF
--- a/build/charts/nephe/templates/controller/deployment.yaml
+++ b/build/charts/nephe/templates/controller/deployment.yaml
@@ -37,6 +37,18 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           limits:
             cpu: 1000m

--- a/cmd/nephe-controller/config.go
+++ b/cmd/nephe-controller/config.go
@@ -18,6 +18,7 @@ const (
 	electionID                = "nephe-controller-election.cloud.antrea.io"
 	defaultLeaderElectionFlag = false
 	defaultMetricsAddress     = ":8080"
+	defaultProbeAddress       = ":8081"
 	defaultDebugLogFlag       = false
 	defaultCertDir            = "/var/run/nephe/nephe-controller-tls"
 )

--- a/config/manager/nephe-controller.yaml
+++ b/config/manager/nephe-controller.yaml
@@ -60,6 +60,18 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           limits:
             cpu: 1000m

--- a/config/nephe.yml
+++ b/config/nephe.yml
@@ -530,11 +530,23 @@ spec:
               fieldPath: metadata.namespace
         image: antrea/nephe:latest
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
         name: nephe-controller
         ports:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           limits:
             cpu: 1000m


### PR DESCRIPTION
## Description
Enable liveness and readiness probe for nephe controller pod

## Changes
Nephe will expose another server listening on port 8081 to handle liveness and readiness probe. Port number is tweak-able via command line arguments. 