### PR TITLE
Fix issue with ANP having no from field

### DIFF
--- a/pkg/cloudprovider/plugins/azure/azure_nsg_rules.go
+++ b/pkg/cloudprovider/plugins/azure/azure_nsg_rules.go
@@ -427,7 +427,10 @@ func findSecurityRule(ruleList []*armnetwork.SecurityRule, rule *armnetwork.Secu
 func normalizeAzureSecurityRule(rule *armnetwork.SecurityRule) *armnetwork.SecurityRule {
 	property := *rule.Properties
 	normalizedProtocolNum := azureProtoNameToNumMap[strings.ToLower(string(*rule.Properties.Protocol))]
-	normalizedProtocol := protoNumAzureNameMap[normalizedProtocolNum]
+	normalizedProtocol, ok := protoNumAzureNameMap[normalizedProtocolNum]
+	if !ok {
+		normalizedProtocol = "*"
+	}
 
 	property.Protocol = &normalizedProtocol
 	property.Priority = nil

--- a/pkg/controllers/networkpolicy/networkpolicy.go
+++ b/pkg/controllers/networkpolicy/networkpolicy.go
@@ -462,12 +462,14 @@ func (s *securityGroupImpl) deleteImpl(c cloudSecurityGroup, membershipOnly bool
 		// and then delete it. In most cases, the detachment should go through, but we
 		// may not be able to delete AtGroup. So delete the rules from the indexers,
 		// so that when AtGroup is re-added, rules can be realized again.
-		s.deleteSgRulesFromIndexer(r)
-		// Send rule realization even if appliedToGroup is getting deleted.
-		if !membershipOnly && len(nps) != 0 {
-			for _, obj := range nps {
-				np := obj.(*networkPolicy)
-				r.sendRuleRealizationStatus(&np.NetworkPolicy, err)
+		if !membershipOnly {
+			s.deleteSgRulesFromIndexer(r)
+			// Send rule realization even if appliedToGroup is getting deleted.
+			if len(nps) != 0 {
+				for _, obj := range nps {
+					np := obj.(*networkPolicy)
+					r.sendRuleRealizationStatus(&np.NetworkPolicy, err)
+				}
 			}
 		}
 		r.cloudResponse <- &securityGroupStatus{sg: c, op: securityGroupOperationDelete, err: err}


### PR DESCRIPTION
## Description
Handled 2 bugfix

## Changes
- In case of no 'from' field in ANP, the normalization of cloudrule was not matching anp rule. Reason, the protocol field wasn't set to "*". It was set to "", due to which cloudrule was not removed.
- Secondly, when addressgroup id and applied id are same, and if addressgroup is getting removed, it was clearing rules from cloudruleindexer for appliedTo group. Added AT check if prevent that from happening