### PR TITLE
Support deny action for Azure cloud

### DIFF
--- a/pkg/cloudprovider/plugins/aws/aws_converters.go
+++ b/pkg/cloudprovider/plugins/aws/aws_converters.go
@@ -147,7 +147,7 @@ func convertIngressToIpPermission(rules []*cloudresource.CloudRule, cloudSGNameT
 		if rule == nil {
 			continue
 		}
-		description, err := utils.GenerateCloudDescription(obj.NpNamespacedName)
+		description, err := utils.GenerateCloudDescription(obj.NpNamespacedName, rule.Priority)
 		if err != nil {
 			return nil, fmt.Errorf("unable to generate rule description, err: %v", err)
 		}
@@ -176,7 +176,7 @@ func convertEgressToIpPermission(rules []*cloudresource.CloudRule, cloudSGNameTo
 		if rule == nil {
 			continue
 		}
-		description, err := utils.GenerateCloudDescription(obj.NpNamespacedName)
+		description, err := utils.GenerateCloudDescription(obj.NpNamespacedName, rule.Priority)
 		if err != nil {
 			return nil, fmt.Errorf("unable to generate rule description, err: %v", err)
 		}

--- a/pkg/cloudprovider/plugins/aws/aws_security_test.go
+++ b/pkg/cloudprovider/plugins/aws/aws_security_test.go
@@ -474,7 +474,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			output1 := constructEc2DescribeSecurityGroupsOutput(&webSgIdentifier1.CloudResourceID, true, false)
 			output2 := constructEc2DescribeSecurityGroupsOutput(&webSgIdentifier2.CloudResourceID, true, false)
 			outputAt := constructEc2DescribeSecurityGroupsOutput(&webSgIdentifier1.CloudResourceID, false, false)
-			desc, _ := utils.GenerateCloudDescription(testAnpNamespacedName.String())
+			desc, _ := utils.GenerateCloudDescription(testAnpNamespacedName.String(), nil)
 			outputAt.SecurityGroups[0].IpPermissions = []*ec2.IpPermission{
 				{
 					FromPort:   aws.Int64(22),
@@ -576,7 +576,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			output1 := constructEc2DescribeSecurityGroupsOutput(&webSgIdentifier1.CloudResourceID, true, false)
 			output2 := constructEc2DescribeSecurityGroupsOutput(&webSgIdentifier2.CloudResourceID, true, false)
 			outputAt := constructEc2DescribeSecurityGroupsOutput(&webSgIdentifier1.CloudResourceID, false, false)
-			desc, _ := utils.GenerateCloudDescription(testAnpNamespacedName.String())
+			desc, _ := utils.GenerateCloudDescription(testAnpNamespacedName.String(), nil)
 			outputAt.SecurityGroups[0].IpPermissionsEgress = []*ec2.IpPermission{
 				{
 					FromPort:   aws.Int64(22),

--- a/pkg/cloudprovider/plugins/azure/azure_security.go
+++ b/pkg/cloudprovider/plugins/azure/azure_security.go
@@ -378,7 +378,6 @@ func (computeCfg *computeServiceConfig) buildEffectiveNSGSecurityRulesToApply(ap
 
 	allIngressRules := updateSecurityRuleNameAndPriority(currentNsgIngressRules, addIngressRules)
 	allEgressRules := updateSecurityRuleNameAndPriority(currentNsgEgressRules, addEgressRules)
-	allIngressRules, allEgressRules = addDefaultDenyRule(allIngressRules, allEgressRules)
 
 	return append(allIngressRules, allEgressRules...), nil
 }
@@ -469,8 +468,6 @@ func (computeCfg *computeServiceConfig) buildEffectivePeerNSGSecurityRulesToAppl
 
 	allIngressRules := updateSecurityRuleNameAndPriority(currentNsgIngressRules, addIngressRules)
 	allEgressRules := updateSecurityRuleNameAndPriority(currentNsgEgressRules, addEgressRules)
-	allIngressRules, allEgressRules = addDefaultDenyRule(allIngressRules, allEgressRules)
-
 	return append(allIngressRules, allEgressRules...), nil
 }
 

--- a/pkg/cloudprovider/securitygroup/securitygroup.go
+++ b/pkg/cloudprovider/securitygroup/securitygroup.go
@@ -131,6 +131,12 @@ type CloudSecurityGroupInterface interface {
 	// This API ensures cloud plug-in stays stateless.
 	// - Correct SGs accidentally changed by customers via cloud API/console directly.
 	GetSecurityGroupSyncChan() <-chan cloudresource.SynchronizationContent
+
+	// CloudProviderSupportsRulePriority Returns true is Cloud Provider supports priority in the rule.
+	CloudProviderSupportsRulePriority(provider string) bool
+
+	// CloudProviderSupportsRuleAction Returns true is Cloud Provider supports action in the rule.
+	CloudProviderSupportsRuleAction(provider string) bool
 }
 
 type CloudSecurityGroupImpl struct{}
@@ -292,4 +298,12 @@ func (sg *CloudSecurityGroupImpl) GetSecurityGroupSyncChan() <-chan cloudresourc
 	}()
 
 	return retCh
+}
+
+func (sg *CloudSecurityGroupImpl) CloudProviderSupportsRulePriority(provider string) bool {
+	return provider == string(runtimev1alpha1.AzureCloudProvider)
+}
+
+func (sg *CloudSecurityGroupImpl) CloudProviderSupportsRuleAction(provider string) bool {
+	return provider == string(runtimev1alpha1.AzureCloudProvider)
 }

--- a/pkg/controllers/networkpolicy/controller_test.go
+++ b/pkg/controllers/networkpolicy/controller_test.go
@@ -344,6 +344,10 @@ var _ = Describe("NetworkPolicy", func() {
 		sgConfig.appSgMemberTimes = 1
 		sgConfig.appSgRuleTimes = 1
 		sgConfig.sgDeleteTimes = 1
+
+		// mock
+		mockCloudSecurityAPI.EXPECT().CloudProviderSupportsRulePriority(mock.Any()).Return(false).AnyTimes()
+		mockCloudSecurityAPI.EXPECT().CloudProviderSupportsRuleAction(mock.Any()).Return(false).AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -945,9 +949,9 @@ var _ = Describe("NetworkPolicy", func() {
 		deleteAndVerifyNP(true)
 	})
 
-	It("Verify unsupported networkPolicy drop action", func() {
+	It("Verify unsupported networkPolicy reject action", func() {
 		anpTemp := anp
-		ruleAction := antreacrdv1beta1.RuleActionDrop
+		ruleAction := antreacrdv1beta1.RuleActionReject
 		anpTemp.Rules[0].Action = &ruleAction
 		event := watch.Event{Type: watch.Added, Object: anpTemp}
 		err := reconciler.processNetworkPolicy(event)

--- a/pkg/testing/cloudsecurity/mock.go
+++ b/pkg/testing/cloudsecurity/mock.go
@@ -49,6 +49,34 @@ func (m *MockCloudSecurityGroupInterface) EXPECT() *MockCloudSecurityGroupInterf
 	return m.recorder
 }
 
+// CloudProviderSupportsRuleAction mocks base method.
+func (m *MockCloudSecurityGroupInterface) CloudProviderSupportsRuleAction(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloudProviderSupportsRuleAction", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CloudProviderSupportsRuleAction indicates an expected call of CloudProviderSupportsRuleAction.
+func (mr *MockCloudSecurityGroupInterfaceMockRecorder) CloudProviderSupportsRuleAction(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudProviderSupportsRuleAction", reflect.TypeOf((*MockCloudSecurityGroupInterface)(nil).CloudProviderSupportsRuleAction), arg0)
+}
+
+// CloudProviderSupportsRulePriority mocks base method.
+func (m *MockCloudSecurityGroupInterface) CloudProviderSupportsRulePriority(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloudProviderSupportsRulePriority", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CloudProviderSupportsRulePriority indicates an expected call of CloudProviderSupportsRulePriority.
+func (mr *MockCloudSecurityGroupInterfaceMockRecorder) CloudProviderSupportsRulePriority(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudProviderSupportsRulePriority", reflect.TypeOf((*MockCloudSecurityGroupInterface)(nil).CloudProviderSupportsRulePriority), arg0)
+}
+
 // CreateSecurityGroup mocks base method.
 func (m *MockCloudSecurityGroupInterface) CreateSecurityGroup(arg0 *cloudresource.CloudResource, arg1 bool) <-chan error {
 	m.ctrl.T.Helper()

--- a/test/templates/default_anp.go
+++ b/test/templates/default_anp.go
@@ -16,14 +16,16 @@ package templates
 
 type DefaultANPParameters struct {
 	Namespace string
+	Name      string
+	Priority  int
 	Entity    *EntitySelectorParameters
 }
 
-const DefaultANPSetup = `
+const DefaultANPAgentedSetup = `
 apiVersion: crd.antrea.io/v1alpha1
 kind: NetworkPolicy
 metadata:
-  name: deny-8080
+  name: {{.Name}}
   namespace: {{.Namespace}}
 spec:
   priority: 2
@@ -44,6 +46,30 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+`
+const DefaultANPSetup = `
+apiVersion: crd.antrea.io/v1alpha1
+kind: NetworkPolicy
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  tier: application
+  priority: {{.Priority}}
+  appliedTo:
+    - externalEntitySelector:
+        matchLabels:
+          {{.Entity.Kind}}
+  ingress:
+    - action: Drop
+      from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+  egress:
+    - action: Drop
       to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/test/templates/vm_anp.go
+++ b/test/templates/vm_anp.go
@@ -46,6 +46,7 @@ type ANPParameters struct {
 	AppliedTo          *EntitySelectorParameters
 	RuleAppliedToGroup *GroupParameters
 	AppliedToGroup     *GroupParameters
+	Priority           int
 }
 
 type GroupParameters struct {
@@ -61,7 +62,8 @@ metadata:
   name: {{.Name}}
   namespace: {{.Namespace}}
 spec:
-  priority: 1
+  tier: application
+  priority: {{.Priority}}
 {{- if  .AppliedToGroup }}
   appliedTo:
   - group : {{ .AppliedToGroup.Name }}


### PR DESCRIPTION
With this PR, Nephe will support Deny action for Azure cloud. If an ANP is configured with Drop action, it will be translated to Deny action for Azure.
Nephe will also support ANP tier and priority and re-arrange the rules based on priority. Lower the priority, higher the precedence.

Changes
- Introduce priroity and action in CloudRule
- Translate ANP tier, priority, and rule priority to CloudRule priority
- Cloud Rule will store rule priority in the rule description field which will be used to insert new rule at its correct location/priority
- Update sync logic to ignore action/priority for aws cloud
- Update logic to detect ANP modify, in case of tier or priority changes
- Update unit tests
- Add integration test for validating priority re-ordering