### PR TITLE
Support Rule Name in Azure Cloud NSG Rule

### DIFF
--- a/pkg/cloudprovider/cloudresource/cloudresource.go
+++ b/pkg/cloudprovider/cloudresource/cloudresource.go
@@ -129,6 +129,7 @@ type IngressRule struct {
 	AppliedToGroup     map[string]struct{}
 	Priority           *float64
 	Action             *antreacrdv1beta1.RuleAction
+	RuleName           string
 }
 
 func (i *IngressRule) isRule() {}
@@ -142,6 +143,7 @@ type EgressRule struct {
 	AppliedToGroup   map[string]struct{}
 	Priority         *float64
 	Action           *antreacrdv1beta1.RuleAction
+	RuleName         string
 }
 
 func (e *EgressRule) isRule() {}

--- a/pkg/cloudprovider/securitygroup/securitygroup.go
+++ b/pkg/cloudprovider/securitygroup/securitygroup.go
@@ -134,9 +134,10 @@ type CloudSecurityGroupInterface interface {
 
 	// CloudProviderSupportsRulePriority Returns true is Cloud Provider supports priority in the rule.
 	CloudProviderSupportsRulePriority(provider string) bool
-
 	// CloudProviderSupportsRuleAction Returns true is Cloud Provider supports action in the rule.
 	CloudProviderSupportsRuleAction(provider string) bool
+	// CloudProviderSupportsRuleName Returns true is Cloud Provider supports name in the rule.
+	CloudProviderSupportsRuleName(provider string) bool
 }
 
 type CloudSecurityGroupImpl struct{}
@@ -305,5 +306,9 @@ func (sg *CloudSecurityGroupImpl) CloudProviderSupportsRulePriority(provider str
 }
 
 func (sg *CloudSecurityGroupImpl) CloudProviderSupportsRuleAction(provider string) bool {
+	return provider == string(runtimev1alpha1.AzureCloudProvider)
+}
+
+func (sg *CloudSecurityGroupImpl) CloudProviderSupportsRuleName(provider string) bool {
 	return provider == string(runtimev1alpha1.AzureCloudProvider)
 }

--- a/pkg/controllers/networkpolicy/controller_test.go
+++ b/pkg/controllers/networkpolicy/controller_test.go
@@ -348,6 +348,7 @@ var _ = Describe("NetworkPolicy", func() {
 		// mock
 		mockCloudSecurityAPI.EXPECT().CloudProviderSupportsRulePriority(mock.Any()).Return(false).AnyTimes()
 		mockCloudSecurityAPI.EXPECT().CloudProviderSupportsRuleAction(mock.Any()).Return(false).AnyTimes()
+		mockCloudSecurityAPI.EXPECT().CloudProviderSupportsRuleName(mock.Any()).Return(false).AnyTimes()
 	})
 
 	AfterEach(func() {

--- a/pkg/testing/cloudsecurity/mock.go
+++ b/pkg/testing/cloudsecurity/mock.go
@@ -63,6 +63,20 @@ func (mr *MockCloudSecurityGroupInterfaceMockRecorder) CloudProviderSupportsRule
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudProviderSupportsRuleAction", reflect.TypeOf((*MockCloudSecurityGroupInterface)(nil).CloudProviderSupportsRuleAction), arg0)
 }
 
+// CloudProviderSupportsRuleName mocks base method.
+func (m *MockCloudSecurityGroupInterface) CloudProviderSupportsRuleName(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloudProviderSupportsRuleName", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CloudProviderSupportsRuleName indicates an expected call of CloudProviderSupportsRuleName.
+func (mr *MockCloudSecurityGroupInterfaceMockRecorder) CloudProviderSupportsRuleName(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudProviderSupportsRuleName", reflect.TypeOf((*MockCloudSecurityGroupInterface)(nil).CloudProviderSupportsRuleName), arg0)
+}
+
 // CloudProviderSupportsRulePriority mocks base method.
 func (m *MockCloudSecurityGroupInterface) CloudProviderSupportsRulePriority(arg0 string) bool {
 	m.ctrl.T.Helper()

--- a/test/upgrade/networkpolicy_e2e_test.go
+++ b/test/upgrade/networkpolicy_e2e_test.go
@@ -45,6 +45,9 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy upgrade test", focusAws, focu
 		anpSetupParams       k8stemplates.ANPParameters
 		defaultANPParameters k8stemplates.DefaultANPParameters
 		defaultDenyANP       bool
+
+		anpPriority        = 10
+		defaultAnpPriority = 20
 	)
 
 	BeforeEach(func() {
@@ -149,12 +152,14 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy upgrade test", focusAws, focu
 		anpParams = k8stemplates.ANPParameters{
 			Name:      "test-cloud-anp",
 			Namespace: namespace.Name,
+			Priority:  anpPriority,
 		}
 
 		// Setup policies for all VMs
 		anpSetupParams = k8stemplates.ANPParameters{
 			Name:      "test-cloud-setup-anp",
 			Namespace: namespace.Name,
+			Priority:  anpPriority,
 		}
 		vmKind := reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()
 		anpSetupParams.AppliedTo = utils.ConfigANPApplyTo(vmKind, "", "", "", "")
@@ -233,6 +238,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy upgrade test", focusAws, focu
 			defaultANPParameters = k8stemplates.DefaultANPParameters{
 				Namespace: namespace.Name,
 				Name:      "deny-all",
+				Priority:  defaultAnpPriority,
 				Entity: &k8stemplates.EntitySelectorParameters{
 					Kind: labels.ExternalEntityLabelKeyKind + ": " + strings.ToLower(reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()),
 				},
@@ -330,6 +336,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy upgrade test", focusAws, focu
 				defaultANPParameters = k8stemplates.DefaultANPParameters{
 					Namespace: namespace.Name,
 					Name:      "deny-all",
+					Priority:  defaultAnpPriority,
 					Entity: &k8stemplates.EntitySelectorParameters{
 						Kind: labels.ExternalEntityLabelKeyKind + ": " + strings.ToLower(reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()),
 					},


### PR DESCRIPTION
Azure NSG rules will have a rule name constructed as the rule name within ANP + '-' + ANP name + RuleNumber. This will provide visibility as to which ANP/Rule maps to what cloud rule.