### PR TITLE
Support ANP with ICMP Rule

### DIFF
--- a/pkg/cloudprovider/cloudresource/cloudresource.go
+++ b/pkg/cloudprovider/cloudresource/cloudresource.go
@@ -36,6 +36,12 @@ var (
 	CloudSecurityGroupVisibility bool
 )
 
+var (
+	IcmpProtocol = 1
+	TcpProtocol  = 6
+	UdpProtocol  = 17
+)
+
 // CloudResourceType specifies the type of cloud resource.
 type CloudResourceType string
 
@@ -122,7 +128,7 @@ type Rule interface {
 
 // IngressRule specifies one ingress rule of cloud SecurityGroup.
 type IngressRule struct {
-	FromPort           *int
+	FromPort           *int32
 	FromSrcIP          []*net.IPNet
 	FromSecurityGroups []*CloudResourceID
 	Protocol           *int
@@ -130,13 +136,15 @@ type IngressRule struct {
 	Priority           *float64
 	Action             *antreacrdv1beta1.RuleAction
 	RuleName           string
+	IcmpType           *int32
+	IcmpCode           *int32
 }
 
 func (i *IngressRule) isRule() {}
 
 // EgressRule specifies one egress rule of cloud SecurityGroup.
 type EgressRule struct {
-	ToPort           *int
+	ToPort           *int32
 	ToDstIP          []*net.IPNet
 	ToSecurityGroups []*CloudResourceID
 	Protocol         *int
@@ -144,6 +152,8 @@ type EgressRule struct {
 	Priority         *float64
 	Action           *antreacrdv1beta1.RuleAction
 	RuleName         string
+	IcmpType         *int32
+	IcmpCode         *int32
 }
 
 func (e *EgressRule) isRule() {}

--- a/pkg/cloudprovider/plugins/aws/aws_security_test.go
+++ b/pkg/cloudprovider/plugins/aws/aws_security_test.go
@@ -274,7 +274,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			}
 			addRule := []*cloudresource.CloudRule{{
 				Rule: &cloudresource.IngressRule{
-					FromPort: aws.Int(22),
+					FromPort: aws.Int32(22),
 					FromSrcIP: []*net.IPNet{{
 						IP:   net.ParseIP("2600:1f16:c77:a001:fb97:21b2:a8dc:dc60"),
 						Mask: net.CIDRMask(128, 128)},
@@ -319,7 +319,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			}
 			addRule := []*cloudresource.CloudRule{{
 				Rule: &cloudresource.IngressRule{
-					FromPort:           aws.Int(22),
+					FromPort:           aws.Int32(22),
 					FromSrcIP:          []*net.IPNet{},
 					FromSecurityGroups: []*cloudresource.CloudResourceID{&webSgIdentifier.CloudResourceID},
 					Protocol:           aws.Int(6),
@@ -355,7 +355,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			}
 			addRule := []*cloudresource.CloudRule{{
 				Rule: &cloudresource.EgressRule{
-					ToPort:           aws.Int(22),
+					ToPort:           aws.Int32(22),
 					ToDstIP:          []*net.IPNet{},
 					ToSecurityGroups: []*cloudresource.CloudResourceID{&webSgIdentifier.CloudResourceID},
 					Protocol:         aws.Int(6),
@@ -396,7 +396,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			}
 			addRule := []*cloudresource.CloudRule{{
 				Rule: &cloudresource.EgressRule{
-					ToPort:           aws.Int(22),
+					ToPort:           aws.Int32(22),
 					ToDstIP:          []*net.IPNet{},
 					ToSecurityGroups: []*cloudresource.CloudResourceID{&webSgIdentifier.CloudResourceID},
 					Protocol:         aws.Int(6),
@@ -441,7 +441,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			addRule := []*cloudresource.CloudRule{
 				{
 					Rule: &cloudresource.IngressRule{
-						FromPort: aws.Int(22),
+						FromPort: aws.Int32(22),
 						FromSrcIP: []*net.IPNet{{
 							IP:   net.ParseIP("2600:1f16:c77:a001:fb97:21b2:a8dc:dc60"),
 							Mask: net.CIDRMask(128, 128)},
@@ -450,7 +450,7 @@ var _ = Describe("AWS Cloud Security", func() {
 					}, NpNamespacedName: testAnpNamespacedName.String(),
 				}, {
 					Rule: &cloudresource.IngressRule{
-						FromPort: aws.Int(22),
+						FromPort: aws.Int32(22),
 						FromSrcIP: []*net.IPNet{{
 							IP:   net.ParseIP("2600:1f16:c77:a001:fb97:21b2:a8dc:dc61"),
 							Mask: net.CIDRMask(128, 128)},
@@ -459,13 +459,13 @@ var _ = Describe("AWS Cloud Security", func() {
 					}, NpNamespacedName: testAnpNamespacedName.String(),
 				}, {
 					Rule: &cloudresource.IngressRule{
-						FromPort:           aws.Int(22),
+						FromPort:           aws.Int32(22),
 						FromSecurityGroups: []*cloudresource.CloudResourceID{&webSgIdentifier1.CloudResourceID},
 						Protocol:           aws.Int(6),
 					}, NpNamespacedName: testAnpNamespacedName.String(),
 				}, {
 					Rule: &cloudresource.IngressRule{
-						FromPort:           aws.Int(22),
+						FromPort:           aws.Int32(22),
 						FromSecurityGroups: []*cloudresource.CloudResourceID{&webSgIdentifier2.CloudResourceID},
 						Protocol:           aws.Int(6),
 					}, NpNamespacedName: testAnpNamespacedName.String(),
@@ -543,7 +543,7 @@ var _ = Describe("AWS Cloud Security", func() {
 			addRule := []*cloudresource.CloudRule{
 				{
 					Rule: &cloudresource.EgressRule{
-						ToPort: aws.Int(22),
+						ToPort: aws.Int32(22),
 						ToDstIP: []*net.IPNet{{
 							IP:   net.ParseIP("2600:1f16:c77:a001:fb97:21b2:a8dc:dc60"),
 							Mask: net.CIDRMask(128, 128)},
@@ -552,7 +552,7 @@ var _ = Describe("AWS Cloud Security", func() {
 					}, NpNamespacedName: testAnpNamespacedName.String(),
 				}, {
 					Rule: &cloudresource.EgressRule{
-						ToPort: aws.Int(22),
+						ToPort: aws.Int32(22),
 						ToDstIP: []*net.IPNet{{
 							IP:   net.ParseIP("2600:1f16:c77:a001:fb97:21b2:a8dc:dc61"),
 							Mask: net.CIDRMask(128, 128)},
@@ -561,13 +561,13 @@ var _ = Describe("AWS Cloud Security", func() {
 					}, NpNamespacedName: testAnpNamespacedName.String(),
 				}, {
 					Rule: &cloudresource.EgressRule{
-						ToPort:           aws.Int(22),
+						ToPort:           aws.Int32(22),
 						ToSecurityGroups: []*cloudresource.CloudResourceID{&webSgIdentifier1.CloudResourceID},
 						Protocol:         aws.Int(6),
 					}, NpNamespacedName: testAnpNamespacedName.String(),
 				}, {
 					Rule: &cloudresource.EgressRule{
-						ToPort:           aws.Int(22),
+						ToPort:           aws.Int32(22),
 						ToSecurityGroups: []*cloudresource.CloudResourceID{&webSgIdentifier2.CloudResourceID},
 						Protocol:         aws.Int(6),
 					}, NpNamespacedName: testAnpNamespacedName.String(),

--- a/pkg/cloudprovider/plugins/azure/azure_security_test.go
+++ b/pkg/cloudprovider/plugins/azure/azure_security_test.go
@@ -64,8 +64,8 @@ var _ = Describe("Azure Cloud Security", func() {
 		testDestinationPortRange          = "*"
 		testPrivateIP                     = "0.0.0.0"
 		testProtocol                      = 6
-		testFromPort                      = 22
-		testToPort                        = 23
+		testFromPort                      = int32(22)
+		testToPort                        = int32(23)
 		testCidrStr                       = "192.168.1.1/24"
 
 		testVnet01   = "testVnet01"
@@ -553,7 +553,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							SourceAddressPrefixes:                []*string{to.StringPtr("2600:1f16:c77:a001:fb97:21b2:a8dc:dc60/128")},
 							Priority:                             &testPriority,
 							SourcePortRange:                      &testSourcePortRange,
-							DestinationPortRange:                 to.StringPtr(strconv.Itoa(testFromPort)),
+							DestinationPortRange:                 to.StringPtr(strconv.Itoa(int(testFromPort))),
 							Direction:                            &testDirection,
 							Description:                          &desc,
 						},
@@ -567,7 +567,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							SourceAddressPrefixes:                []*string{to.StringPtr("2600:1f16:c77:a001:fb97:21b2:a8dc:dc61/128")},
 							Priority:                             to.Int32Ptr(testPriority + 1),
 							SourcePortRange:                      &testSourcePortRange,
-							DestinationPortRange:                 to.StringPtr(strconv.Itoa(testFromPort)),
+							DestinationPortRange:                 to.StringPtr(strconv.Itoa(int(testFromPort))),
 							Direction:                            &testDirection,
 							Description:                          &desc,
 						},
@@ -581,7 +581,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							DestinationApplicationSecurityGroups: []*network.ApplicationSecurityGroup{{ID: &testATAsgID}},
 							Priority:                             to.Int32Ptr(testPriority + 2),
 							SourcePortRange:                      &testSourcePortRange,
-							DestinationPortRange:                 to.StringPtr(strconv.Itoa(testFromPort)),
+							DestinationPortRange:                 to.StringPtr(strconv.Itoa(int(testFromPort))),
 							Direction:                            &testDirection,
 							Description:                          &desc,
 						},
@@ -674,7 +674,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							SourceApplicationSecurityGroups: []*network.ApplicationSecurityGroup{{ID: &testATAsgID}},
 							DestinationAddressPrefixes:      []*string{to.StringPtr("2600:1f16:c77:a001:fb97:21b2:a8dc:dc60/128")},
 							Priority:                        &testPriority,
-							DestinationPortRange:            to.StringPtr(strconv.Itoa(testToPort)),
+							DestinationPortRange:            to.StringPtr(strconv.Itoa(int(testToPort))),
 							SourcePortRange:                 &testSourcePortRange,
 							Direction:                       &outbound,
 							Description:                     &desc,
@@ -688,7 +688,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							SourceApplicationSecurityGroups: []*network.ApplicationSecurityGroup{{ID: &testATAsgID}},
 							DestinationAddressPrefixes:      []*string{to.StringPtr("2600:1f16:c77:a001:fb97:21b2:a8dc:dc61/128")},
 							Priority:                        to.Int32Ptr(testPriority + 1),
-							DestinationPortRange:            to.StringPtr(strconv.Itoa(testToPort)),
+							DestinationPortRange:            to.StringPtr(strconv.Itoa(int(testToPort))),
 							SourcePortRange:                 &testSourcePortRange,
 							Direction:                       &outbound,
 							Description:                     &desc,
@@ -702,7 +702,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							DestinationApplicationSecurityGroups: []*network.ApplicationSecurityGroup{{ID: to.StringPtr(testAGAsgID + "1")}},
 							SourceApplicationSecurityGroups:      []*network.ApplicationSecurityGroup{{ID: &testATAsgID}},
 							Priority:                             to.Int32Ptr(testPriority + 2),
-							DestinationPortRange:                 to.StringPtr(strconv.Itoa(testToPort)),
+							DestinationPortRange:                 to.StringPtr(strconv.Itoa(int(testToPort))),
 							SourcePortRange:                      &testSourcePortRange,
 							Direction:                            &outbound,
 							Description:                          &desc,
@@ -776,7 +776,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							SourceAddressPrefixes:                []*string{to.StringPtr("1.1.1.0/24")},
 							Priority:                             &testPriority,
 							SourcePortRange:                      &testSourcePortRange,
-							DestinationPortRange:                 to.StringPtr(strconv.Itoa(testFromPort)),
+							DestinationPortRange:                 to.StringPtr(strconv.Itoa(int(testFromPort))),
 							Direction:                            &testDirection,
 							Description:                          &desc,
 						},
@@ -854,7 +854,7 @@ var _ = Describe("Azure Cloud Security", func() {
 							SourceAddressPrefixes:                []*string{to.StringPtr("1.1.1.0/24")},
 							Priority:                             &testPriority,
 							SourcePortRange:                      &testSourcePortRange,
-							DestinationPortRange:                 to.StringPtr(strconv.Itoa(testFromPort)),
+							DestinationPortRange:                 to.StringPtr(strconv.Itoa(int(testFromPort))),
 							Direction:                            &outbound,
 							Description:                          &desc,
 						},

--- a/pkg/controllers/networkpolicy/controller.go
+++ b/pkg/controllers/networkpolicy/controller.go
@@ -133,13 +133,13 @@ func (r *NetworkPolicyReconciler) isNetworkPolicySupported(anp *antreanetworking
 	// Check for support actions.
 	for _, rule := range anp.Rules {
 		if rule.Action != nil && !(*rule.Action == antreacrdv1beta1.RuleActionAllow || *rule.Action == antreacrdv1beta1.RuleActionDrop) {
-			return fmt.Errorf("unsupported action: %v, supportted actions: %v, %v", *rule.Action,
+			return fmt.Errorf("unsupported action: %v, supported actions: %v, %v", *rule.Action,
 				antreacrdv1beta1.RuleActionAllow, antreacrdv1beta1.RuleActionDrop)
 		}
 		// check for supported protocol.
 		for _, s := range rule.Services {
 			if _, ok := AntreaProtocolMap[*s.Protocol]; !ok {
-				return fmt.Errorf("unsupported protocol: %v, supportted protocols: %v", *s.Protocol, reflect.ValueOf(AntreaProtocolMap).MapKeys())
+				return fmt.Errorf("unsupported protocol: %v, supported protocols: %v", *s.Protocol, reflect.ValueOf(AntreaProtocolMap).MapKeys())
 			}
 		}
 	}

--- a/pkg/controllers/networkpolicy/sync.go
+++ b/pkg/controllers/networkpolicy/sync.go
@@ -329,7 +329,7 @@ func countIngressRuleItems(iRule *cloudresource.IngressRule, items map[string]in
 	if iRule.Protocol != nil {
 		proto = *iRule.Protocol
 	}
-	port := 0
+	var port int32
 	if iRule.FromPort != nil {
 		port = *iRule.FromPort
 	}
@@ -351,7 +351,7 @@ func countEgressRuleItems(eRule *cloudresource.EgressRule, items map[string]int,
 	if eRule.Protocol != nil {
 		proto = *eRule.Protocol
 	}
-	port := 0
+	var port int32
 	if eRule.ToPort != nil {
 		port = *eRule.ToPort
 	}

--- a/test/templates/vm_anp.go
+++ b/test/templates/vm_anp.go
@@ -26,11 +26,12 @@ type NamespaceParameters struct {
 }
 
 type ToFromParameters struct {
-	Entity    *EntitySelectorParameters
-	Namespace *NamespaceParameters
-	IPBlock   string
-	Ports     []*PortParameters
-	DenyAll   bool
+	Entity       *EntitySelectorParameters
+	Namespace    *NamespaceParameters
+	IPBlock      string
+	Ports        []*PortParameters
+	ICMPProtocol string
+	DenyAll      bool
 }
 
 type PortParameters struct {
@@ -127,6 +128,10 @@ spec:
       port: {{$port.Port}}
 {{ end }}
 {{- end }}{{/* .From.Ports */}}
+{{- if .From.ICMPProtocol }}
+    protocols:
+       - icmp: {}
+{{- end }}{{/* .From.ICMPProtocol */}}
 {{- if  .RuleAppliedToGroup }}
     appliedTo:
     - group: {{ .RuleAppliedToGroup.Name }}
@@ -174,6 +179,10 @@ spec:
       port: {{$port.Port}}
 {{ end }}
 {{- end }}{{/* .To.Ports */}}
+{{- if .To.ICMPProtocol }}
+    protocols:
+       - icmp: {}
+{{- end }}{{/* .To.ICMPProtocol */}}
 {{ end }} {{/* .To */}}
 `
 const CloudAntreaGroup = `

--- a/test/upgrade/networkpolicy_e2e_test.go
+++ b/test/upgrade/networkpolicy_e2e_test.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	controlplanev1beta2 "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	runtimev1alpha1 "antrea.io/nephe/apis/runtime/v1alpha1"
 	"antrea.io/nephe/pkg/labels"
 	"antrea.io/nephe/test/utils"
@@ -164,11 +165,11 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy upgrade test", focusAws, focu
 		vmKind := reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()
 		anpSetupParams.AppliedTo = utils.ConfigANPApplyTo(vmKind, "", "", "", "")
 		anpSetupParams.From = utils.ConfigANPToFrom("", "", "", "", "",
-			"0.0.0.0/0", "", allowedPorts, false)
+			"0.0.0.0/0", "", controlplanev1beta2.ProtocolTCP, allowedPorts, false)
 		if denyEgress {
-			anpSetupParams.To = utils.ConfigANPToFrom("", "", "", "", "", "", "", nil, denyEgress)
+			anpSetupParams.To = utils.ConfigANPToFrom("", "", "", "", "", "", "", controlplanev1beta2.ProtocolTCP, nil, denyEgress)
 		} else {
-			anpSetupParams.To = utils.ConfigANPToFrom("", "", "", "", "", "0.0.0.0/0", "", nil, false)
+			anpSetupParams.To = utils.ConfigANPToFrom("", "", "", "", "", "0.0.0.0/0", "", controlplanev1beta2.ProtocolTCP, nil, false)
 
 		}
 		err := utils.ConfigureK8s(kubeCtl, anpSetupParams, k8stemplates.CloudAntreaNetworkPolicy, false)
@@ -252,7 +253,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy upgrade test", focusAws, focu
 		dstNsName := namespace.Name
 
 		appliedIdx := len(ids) - 1
-		anpParams.From = utils.ConfigANPToFrom(kind, "", "", "", "", "", dstNsName, []string{apachePort}, false)
+		anpParams.From = utils.ConfigANPToFrom(kind, "", "", "", "", "", dstNsName, controlplanev1beta2.ProtocolTCP, []string{apachePort}, false)
 
 		By(fmt.Sprintf("Applied NetworkPolicy to %v by kind label selector", kind))
 		applied := make([]bool, len(ids))
@@ -318,7 +319,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy upgrade test", focusAws, focu
 			srcVM := cloudVPC.GetVMs()[0]
 			srcIP := cloudVPC.GetVMPrivateIPs()[0]
 			dstNsName := namespace.Name
-			anpParams.From = utils.ConfigANPToFrom(kind, "", "", "", "", "", dstNsName, []string{apachePort}, false)
+			anpParams.From = utils.ConfigANPToFrom(kind, "", "", "", "", "", dstNsName, controlplanev1beta2.ProtocolTCP, []string{apachePort}, false)
 
 			By(fmt.Sprintf("Applied NetworkPolicy to %v by kind label selector", kind))
 			applied := make([]bool, len(ids))

--- a/test/utils/helpers.go
+++ b/test/utils/helpers.go
@@ -408,6 +408,16 @@ func ExecuteCurlCmds(vpc CloudVPC, kubctl *KubeCtl,
 	return ExecuteCmds(vpc, kubctl, srcIDs, ns, cmds, oks, retries)
 }
 
+// ExecutePingCmds executes ping on resource srcIDs in parallel, and returns error if oks mismatch.
+func ExecutePingCmds(vpc CloudVPC, kubctl *KubeCtl,
+	srcIDs []string, ns string, destIPs []string, oks []bool, retries int) error {
+	cmds := make([][]string, 0, len(destIPs))
+	for _, ip := range destIPs {
+		cmds = append(cmds, []string{"ping", "-c", "1", "-w", "1", ip})
+	}
+	return ExecuteCmds(vpc, kubctl, srcIDs, ns, cmds, oks, retries)
+}
+
 // CheckRestart returns error if nephe controller has restarted.
 func CheckRestart(kubctl *KubeCtl) error {
 	controllers := []string{"nephe-controller"}

--- a/test/utils/networkpolicy_helper.go
+++ b/test/utils/networkpolicy_helper.go
@@ -17,8 +17,7 @@ package utils
 import (
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
-
+	cpv1beta2 "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	"antrea.io/nephe/pkg/labels"
 	k8stemplates "antrea.io/nephe/test/templates"
 )
@@ -43,7 +42,7 @@ func ConfigANPApplyTo(kind, instanceName, vpc, tagKey, tagVal string) *k8stempla
 }
 
 // ConfigANPToFrom helper function to configure to and from fields in Antrea NetworkPolicy.
-func ConfigANPToFrom(kind, instanceName, vpc, tagKey, tagVal, ipBlock, nsName string, ports []string,
+func ConfigANPToFrom(kind, instanceName, vpc, tagKey, tagVal, ipBlock, nsName string, protocol cpv1beta2.Protocol, ports []string,
 	denyAll bool) *k8stemplates.ToFromParameters {
 	ret := &k8stemplates.ToFromParameters{
 		DenyAll: denyAll,
@@ -67,8 +66,12 @@ func ConfigANPToFrom(kind, instanceName, vpc, tagKey, tagVal, ipBlock, nsName st
 		}
 	}
 
-	for _, p := range ports {
-		ret.Ports = append(ret.Ports, &k8stemplates.PortParameters{Protocol: string(v1.ProtocolTCP), Port: p})
+	if protocol == cpv1beta2.ProtocolTCP {
+		for _, p := range ports {
+			ret.Ports = append(ret.Ports, &k8stemplates.PortParameters{Protocol: string(protocol), Port: p})
+		}
+	} else if protocol == cpv1beta2.ProtocolICMP {
+		ret.ICMPProtocol = string(cpv1beta2.ProtocolICMP)
 	}
 	return ret
 }


### PR DESCRIPTION
With this PR, Nephe will support icmp protocol in Antrea NetworkPolicy. Its enabled for both AWS and Azure Cloud. Both ICMP-ALL and ICMP-Custom are supported. With ICMP-Custom, user can specify ICMP-Type and ICMP-Code for more granular control.