### PR TITLE
Expose ANP priority in test templates for Agented VMs

### DIFF
--- a/hack/terraform/azure/variables.tf
+++ b/hack/terraform/azure/variables.tf
@@ -93,12 +93,12 @@ variable "azure_vm_os_types_agented" {
       init      = "init_script_ubuntu.sh"
     },
     {
-      name      = "rhel-host3"
-      offer     = "RHEL-SAP-HA"
-      publisher = "RedHat"
-      sku       = "8_4"
-      init      = "init_script_rhel.sh"
-    }
+      name      = "ubuntu-host3"
+      offer     = "0001-com-ubuntu-server-focal"
+      publisher = "Canonical"
+      sku       = "20_04-lts-gen2"
+      init      = "init_script_ubuntu.sh"
+    },
   ]
 }
 

--- a/test/integration/networkpolicy_e2e_test.go
+++ b/test/integration/networkpolicy_e2e_test.go
@@ -155,6 +155,7 @@ var _ = Describe(fmt.Sprintf("%s,%s: NetworkPolicy On Cloud Resources", focusAws
 			defaultANPParameters = k8stemplates.DefaultANPParameters{
 				Namespace: staticVMNS.Name,
 				Name:      "deny-8080",
+				Priority:  defaultAnpPriority,
 				Entity: &k8stemplates.EntitySelectorParameters{
 					Kind: labels.ExternalEntityLabelKeyKind + ": " + strings.ToLower(reflect.TypeOf(runtimev1alpha1.VirtualMachine{}).Name()),
 				},

--- a/test/templates/default_anp.go
+++ b/test/templates/default_anp.go
@@ -28,7 +28,7 @@ metadata:
   name: {{.Name}}
   namespace: {{.Namespace}}
 spec:
-  priority: 2
+  priority: {{.Priority}}
   appliedTo:
     - externalEntitySelector:
         matchLabels:


### PR DESCRIPTION
Use ubuntu Vms for Azure agented tests
On Azure RHEL VM, when ExternalNode is added and deleted
repeatedly, antrea-agent goes into a weired state where
ExternalNode add event is ignored, as agent things there
is no change in the ExternalNode interface.

Tracking issue on antrea:

[#5192](https://github.com/antrea-io/antrea/issues/5192)
[#5111](https://github.com/antrea-io/antrea/issues/5111)

Signed-off-by: Anand Kumar <kumaranand@vmware.com>